### PR TITLE
refactor: HomePage를 여러 컴포넌트로 분리

### DIFF
--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import { useHomeStore } from "@/features/home";
+import {
+  HomeNavbar,
+  HomeSidebar,
+  HomeHeader,
+  QuickStartHero,
+  StatsGrid,
+  RecentSessions,
+  StreakCalendar,
+  JobStatus,
+  LoadingSkeleton,
+} from "./components";
 import "./HomePage.css";
 
 export function HomePage() {
@@ -21,238 +31,36 @@ export function HomePage() {
   return (
     <>
       <div className="hp-wrap">
-        {/* NAV */}
-        <nav className="hp-nav">
-          <button 
-            className={`hp-menu-btn${menuOpen ? " open" : ""}`}
-            onClick={() => setMenuOpen(!menuOpen)}
-            aria-label="메뉴"
-          >
-            <div className="hp-menu-icon">
-              <span></span>
-              <span></span>
-              <span></span>
-            </div>
-          </button>
-          <Link to="/home" className="hp-nav-logo">me<span className="hi">Fit</span></Link>
-          <Link to="/home" className="hp-nav-link active">홈</Link>
-          <Link to="/resume" className="hp-nav-link">이력서</Link>
-          <Link to="/jd" className="hp-nav-link">채용공고</Link>
-          <Link to="/interview/setup" className="hp-btn-primary">면접 시작 →</Link>
-        </nav>
+        <HomeNavbar menuOpen={menuOpen} onMenuToggle={() => setMenuOpen(!menuOpen)} />
 
-        {/* Sidebar Overlay */}
         <div 
           className={`hp-sidebar-overlay${menuOpen ? " open" : ""}`}
           onClick={() => setMenuOpen(false)}
         />
 
         <div className="hp-shell">
-          {/* SIDEBAR */}
-          <aside className={`hp-sidebar${menuOpen ? " open" : ""}`}>
-            <div className="hp-sb-sep">메인</div>
-            <Link to="/home" className="hp-sb-item active">
-              <span className="hp-sb-icon">🏠</span>홈
-            </Link>
-            <Link to="/interview/setup" className="hp-sb-item">
-              <span className="hp-sb-icon">🎥</span>면접 시작
-            </Link>
-            <div className="hp-sb-sep">관리</div>
-            <Link to="/resume" className="hp-sb-item">
-              <span className="hp-sb-icon">📄</span>이력서
-            </Link>
-            <Link to="/jd" className="hp-sb-item">
-              <span className="hp-sb-icon">🏢</span>채용공고
-              <span className="hp-sb-badge">3</span>
-            </Link>
-            <div className="hp-sb-sep">분석</div>
-            <Link to="#" className="hp-sb-item">
-              <span className="hp-sb-icon">📊</span>리뷰 리포트
-            </Link>
-            <Link to="/streak" className="hp-sb-item">
-              <span className="hp-sb-icon">🔥</span>스트릭
-            </Link>
-            <div className="hp-sb-sep">설정</div>
-            <Link to="/subscription" className="hp-sb-item">
-              <span className="hp-sb-icon">💳</span>요금제
-            </Link>
-            <Link to="/settings" className="hp-sb-item">
-              <span className="hp-sb-icon">⚙️</span>계정 설정
-            </Link>
-            <div className="hp-sb-streak-card">
-              <div className="hp-ssc-label">스트릭</div>
-              <div className="hp-ssc-num">{data?.currentStreak ?? 0}</div>
-              <div className="hp-ssc-unit">연속 일수</div>
-            </div>
-          </aside>
+          <HomeSidebar menuOpen={menuOpen} currentStreak={data?.currentStreak ?? 0} />
 
-          {/* MAIN */}
           <main className="hp-main">
             {loading && !data ? (
-              <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-                <div className="hp-skeleton" style={{ height: 80 }} />
-                <div className="hp-skeleton" style={{ height: 160 }} />
-                <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 12 }}>
-                  {[0, 1, 2, 3].map((i) => (
-                    <div key={i} className="hp-skeleton" style={{ height: 110 }} />
-                  ))}
-                </div>
-              </div>
+              <LoadingSkeleton />
             ) : data ? (
               <>
-                {/* Header */}
-                <div className="hp-header">
-                  <div className="hp-eyebrow">{data.user.greeting}</div>
-                  <h1 className="hp-title">
-                    안녕하세요, {data.user.name} 님.<br />오늘도 핏을 맞춰볼까요?
-                  </h1>
-                  <p className="hp-sub">
-                    마지막 면접으로부터 {data.user.lastInterviewDaysAgo}일이 지났어요. 스트릭을 이어가세요!
-                  </p>
-                </div>
+                <HomeHeader
+                  greeting={data.user.greeting}
+                  userName={data.user.name}
+                  lastInterviewDaysAgo={data.user.lastInterviewDaysAgo}
+                />
 
-                {/* Quick Start Hero */}
-                <Link
-                  to="/interview/setup"
-                  className={`hp-qs-hero hp-rv${revealed ? " hp-rv-in" : ""}`}
-                  style={{ transitionDelay: "0ms" }}
-                >
-                  <div>
-                    <div className="hp-qsh-tag">
-                      <span className="dot" />빠른 시작
-                    </div>
-                    <div className="hp-qsh-title">AI 면접 바로 시작하기</div>
-                    <div className="hp-qsh-sub">이전 설정을 불러와 바로 준비를 이어갈 수 있어요.</div>
-                    <div className="hp-qsh-btns">
-                      <span className="hp-qsh-btn-w">이어서 준비하기 →</span>
-                      <span className="hp-qsh-btn-g">새 면접 설정</span>
-                    </div>
-                  </div>
-                  <div className="hp-qs-visual">
-                    <div className="hp-qsv-icon">🎙️</div>
-                    <div className="hp-qsv-text">AI 면접관 대기 중</div>
-                  </div>
-                </Link>
+                <QuickStartHero revealed={revealed} />
 
-                {/* Stats */}
-                <div className="hp-stats-grid">
-                  {data.stats.map((stat, i) => (
-                    <div
-                      key={i}
-                      className={`hp-stat-card hp-rv${revealed ? " hp-rv-in" : ""}`}
-                      style={{ transitionDelay: `${55 + i * 55}ms` }}
-                    >
-                      <span className="hp-stat-icon">{stat.icon}</span>
-                      <div className="hp-stat-num">
-                        {stat.value}
-                        {stat.unit && (
-                          <small style={{ fontSize: 14, opacity: 0.5 }}>{stat.unit}</small>
-                        )}
-                      </div>
-                      <div className="hp-stat-label">{stat.label}</div>
-                      <span
-                        className={`hp-stat-delta ${
-                          stat.deltaType === "up"
-                            ? "hp-delta-up"
-                            : stat.deltaType === "down"
-                            ? "hp-delta-dn"
-                            : "hp-delta-neutral"
-                        }`}
-                      >
-                        {stat.delta}
-                      </span>
-                    </div>
-                  ))}
-                </div>
+                <StatsGrid stats={data.stats} revealed={revealed} />
 
-                {/* Recent Sessions */}
-                <div className={`hp-sec-head hp-rv${revealed ? " hp-rv-in" : ""}`} style={{ transitionDelay: "275ms" }}>
-                  <div className="hp-sec-title">최근 면접 기록</div>
-                  <a className="hp-sec-link" href="#">전체 보기 →</a>
-                </div>
-                <div className="hp-session-list">
-                  {data.recentSessions.map((session, i) => (
-                    <a
-                      key={session.id}
-                      className={`hp-session-item hp-rv${revealed ? " hp-rv-in" : ""}`}
-                      style={{ transitionDelay: `${330 + i * 55}ms` }}
-                      href="#"
-                    >
-                      <div className="hp-si-icon">{session.icon}</div>
-                      <div className="hp-si-body">
-                        <div className="hp-si-company">
-                          {session.company}
-                          <span
-                            className={`hp-badge${session.badgeType === "neutral" ? " hp-badge-neutral" : ""}`}
-                            style={{ fontSize: 10 }}
-                          >
-                            {session.badgeLabel}
-                          </span>
-                        </div>
-                        <div className="hp-si-meta">
-                          {session.role} · {session.round} · {session.date}
-                        </div>
-                      </div>
-                      <div className="hp-si-score">
-                        <div className="hp-si-num">{session.score}</div>
-                        <div className="hp-si-num-label">종합 점수</div>
-                      </div>
-                    </a>
-                  ))}
-                </div>
+                <RecentSessions sessions={data.recentSessions} revealed={revealed} />
 
-                {/* Bottom Row */}
                 <div className="hp-bottom">
-                  {/* Streak Calendar */}
-                  <div
-                    className={`hp-card-white hp-rv${revealed ? " hp-rv-in" : ""}`}
-                    style={{ padding: 20, transitionDelay: "495ms" }}
-                  >
-                    <div className="hp-sec-head" style={{ marginBottom: 12 }}>
-                      <div className="hp-sec-title" style={{ fontSize: 13 }}>🔥 이번 달 스트릭</div>
-                      <span className="hp-badge" style={{ fontSize: 10 }}>3월</span>
-                    </div>
-                    <div className="hp-streak-cal">
-                      {data.streakData.map((v, i) => (
-                        <div key={i} className={`hp-sc-day hp-sc-${v}`} />
-                      ))}
-                    </div>
-                    <div className="hp-sc-days-label" style={{ marginTop: 6 }}>
-                      {["월", "화", "수", "목", "금", "토", "일"].map((d) => (
-                        <span key={d} className="hp-sc-dl">{d}</span>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Job Status */}
-                  <div
-                    className={`hp-card-white hp-rv${revealed ? " hp-rv-in" : ""}`}
-                    style={{ padding: 20, transitionDelay: "550ms" }}
-                  >
-                    <div className="hp-sec-head" style={{ marginBottom: 12 }}>
-                      <div className="hp-sec-title" style={{ fontSize: 13 }}>📋 지원 현황</div>
-                      <Link to="/jd" className="hp-sec-link">관리 →</Link>
-                    </div>
-                    {data.jobs.map((job) => (
-                      <div key={job.id} className="hp-job-item">
-                        <div className={`hp-job-dot hp-jd-${job.dotColor}`} />
-                        <div className="hp-job-body">
-                          <div className="hp-job-name">{job.company} — {job.role}</div>
-                          <div className="hp-job-sub">{job.stage}</div>
-                        </div>
-                        <div className="hp-job-dday">D-{job.dday}</div>
-                      </div>
-                    ))}
-                    <div style={{ marginTop: 14 }}>
-                      <Link
-                        to="/interview/setup"
-                        className="hp-btn-primary"
-                        style={{ width: "100%", justifyContent: "center" }}
-                      >
-                        면접 시작하기 →
-                      </Link>
-                    </div>
-                  </div>
+                  <StreakCalendar streakData={data.streakData} revealed={revealed} />
+                  <JobStatus jobs={data.jobs} revealed={revealed} />
                 </div>
               </>
             ) : null}

--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -39,7 +39,11 @@ export function HomePage() {
         />
 
         <div className="hp-shell">
-          <HomeSidebar menuOpen={menuOpen} currentStreak={data?.currentStreak ?? 0} />
+          <HomeSidebar 
+            menuOpen={menuOpen} 
+            currentStreak={data?.currentStreak ?? 0}
+            jdCount={data?.jobs.length ?? 0}
+          />
 
           <main className="hp-main">
             {loading && !data ? (

--- a/src/pages/home/ui/components/HomeHeader.tsx
+++ b/src/pages/home/ui/components/HomeHeader.tsx
@@ -1,0 +1,19 @@
+interface HomeHeaderProps {
+  greeting: string;
+  userName: string;
+  lastInterviewDaysAgo: number;
+}
+
+export function HomeHeader({ greeting, userName, lastInterviewDaysAgo }: HomeHeaderProps) {
+  return (
+    <div className="hp-header">
+      <div className="hp-eyebrow">{greeting}</div>
+      <h1 className="hp-title">
+        안녕하세요, {userName} 님.<br />오늘도 핏을 맞춰볼까요?
+      </h1>
+      <p className="hp-sub">
+        마지막 면접으로부터 {lastInterviewDaysAgo}일이 지났어요. 스트릭을 이어가세요!
+      </p>
+    </div>
+  );
+}

--- a/src/pages/home/ui/components/HomeNavbar.tsx
+++ b/src/pages/home/ui/components/HomeNavbar.tsx
@@ -1,0 +1,29 @@
+import { Link } from "react-router-dom";
+
+interface HomeNavbarProps {
+  menuOpen: boolean;
+  onMenuToggle: () => void;
+}
+
+export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
+  return (
+    <nav className="hp-nav">
+      <button 
+        className={`hp-menu-btn${menuOpen ? " open" : ""}`}
+        onClick={onMenuToggle}
+        aria-label="메뉴"
+      >
+        <div className="hp-menu-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </button>
+      <Link to="/home" className="hp-nav-logo">me<span className="hi">Fit</span></Link>
+      <Link to="/home" className="hp-nav-link active">홈</Link>
+      <Link to="/resume" className="hp-nav-link">이력서</Link>
+      <Link to="/jd" className="hp-nav-link">채용공고</Link>
+      <Link to="/interview/setup" className="hp-btn-primary">면접 시작 →</Link>
+    </nav>
+  );
+}

--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -3,9 +3,10 @@ import { Link } from "react-router-dom";
 interface HomeSidebarProps {
   menuOpen: boolean;
   currentStreak: number;
+  jdCount?: number;
 }
 
-export function HomeSidebar({ menuOpen, currentStreak }: HomeSidebarProps) {
+export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0 }: HomeSidebarProps) {
   return (
     <aside className={`hp-sidebar${menuOpen ? " open" : ""}`}>
       <div className="hp-sb-sep">메인</div>
@@ -21,7 +22,7 @@ export function HomeSidebar({ menuOpen, currentStreak }: HomeSidebarProps) {
       </Link>
       <Link to="/jd" className="hp-sb-item">
         <span className="hp-sb-icon">🏢</span>채용공고
-        <span className="hp-sb-badge">3</span>
+        {jdCount > 0 && <span className="hp-sb-badge">{jdCount}</span>}
       </Link>
       <div className="hp-sb-sep">분석</div>
       <Link to="#" className="hp-sb-item">

--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -1,0 +1,47 @@
+import { Link } from "react-router-dom";
+
+interface HomeSidebarProps {
+  menuOpen: boolean;
+  currentStreak: number;
+}
+
+export function HomeSidebar({ menuOpen, currentStreak }: HomeSidebarProps) {
+  return (
+    <aside className={`hp-sidebar${menuOpen ? " open" : ""}`}>
+      <div className="hp-sb-sep">메인</div>
+      <Link to="/home" className="hp-sb-item active">
+        <span className="hp-sb-icon">🏠</span>홈
+      </Link>
+      <Link to="/interview/setup" className="hp-sb-item">
+        <span className="hp-sb-icon">🎥</span>면접 시작
+      </Link>
+      <div className="hp-sb-sep">관리</div>
+      <Link to="/resume" className="hp-sb-item">
+        <span className="hp-sb-icon">📄</span>이력서
+      </Link>
+      <Link to="/jd" className="hp-sb-item">
+        <span className="hp-sb-icon">🏢</span>채용공고
+        <span className="hp-sb-badge">3</span>
+      </Link>
+      <div className="hp-sb-sep">분석</div>
+      <Link to="#" className="hp-sb-item">
+        <span className="hp-sb-icon">📊</span>리뷰 리포트
+      </Link>
+      <Link to="/streak" className="hp-sb-item">
+        <span className="hp-sb-icon">🔥</span>스트릭
+      </Link>
+      <div className="hp-sb-sep">설정</div>
+      <Link to="/subscription" className="hp-sb-item">
+        <span className="hp-sb-icon">💳</span>요금제
+      </Link>
+      <Link to="/settings" className="hp-sb-item">
+        <span className="hp-sb-icon">⚙️</span>계정 설정
+      </Link>
+      <div className="hp-sb-streak-card">
+        <div className="hp-ssc-label">스트릭</div>
+        <div className="hp-ssc-num">{currentStreak}</div>
+        <div className="hp-ssc-unit">연속 일수</div>
+      </div>
+    </aside>
+  );
+}

--- a/src/pages/home/ui/components/JobStatus.tsx
+++ b/src/pages/home/ui/components/JobStatus.tsx
@@ -1,0 +1,40 @@
+import { Link } from "react-router-dom";
+import type { HomeJob } from "@/features/home/api/homeApi";
+
+interface JobStatusProps {
+  jobs: HomeJob[];
+  revealed: boolean;
+}
+
+export function JobStatus({ jobs, revealed }: JobStatusProps) {
+  return (
+    <div
+      className={`hp-card-white hp-rv${revealed ? " hp-rv-in" : ""}`}
+      style={{ padding: 20, transitionDelay: "550ms" }}
+    >
+      <div className="hp-sec-head" style={{ marginBottom: 12 }}>
+        <div className="hp-sec-title" style={{ fontSize: 13 }}>📋 지원 현황</div>
+        <Link to="/jd" className="hp-sec-link">관리 →</Link>
+      </div>
+      {jobs.map((job) => (
+        <div key={job.id} className="hp-job-item">
+          <div className={`hp-job-dot hp-jd-${job.dotColor}`} />
+          <div className="hp-job-body">
+            <div className="hp-job-name">{job.company} — {job.role}</div>
+            <div className="hp-job-sub">{job.stage}</div>
+          </div>
+          <div className="hp-job-dday">D-{job.dday}</div>
+        </div>
+      ))}
+      <div style={{ marginTop: 14 }}>
+        <Link
+          to="/interview/setup"
+          className="hp-btn-primary"
+          style={{ width: "100%", justifyContent: "center" }}
+        >
+          면접 시작하기 →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/home/ui/components/LoadingSkeleton.tsx
+++ b/src/pages/home/ui/components/LoadingSkeleton.tsx
@@ -1,0 +1,13 @@
+export function LoadingSkeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <div className="hp-skeleton" style={{ height: 80 }} />
+      <div className="hp-skeleton" style={{ height: 160 }} />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 12 }}>
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="hp-skeleton" style={{ height: 110 }} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/home/ui/components/QuickStartHero.tsx
+++ b/src/pages/home/ui/components/QuickStartHero.tsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router-dom";
+
+interface QuickStartHeroProps {
+  revealed: boolean;
+}
+
+export function QuickStartHero({ revealed }: QuickStartHeroProps) {
+  return (
+    <Link
+      to="/interview/setup"
+      className={`hp-qs-hero hp-rv${revealed ? " hp-rv-in" : ""}`}
+      style={{ transitionDelay: "0ms" }}
+    >
+      <div>
+        <div className="hp-qsh-tag">
+          <span className="dot" />빠른 시작
+        </div>
+        <div className="hp-qsh-title">AI 면접 바로 시작하기</div>
+        <div className="hp-qsh-sub">이전 설정을 불러와 바로 준비를 이어갈 수 있어요.</div>
+        <div className="hp-qsh-btns">
+          <span className="hp-qsh-btn-w">이어서 준비하기 →</span>
+          <span className="hp-qsh-btn-g">새 면접 설정</span>
+        </div>
+      </div>
+      <div className="hp-qs-visual">
+        <div className="hp-qsv-icon">🎙️</div>
+        <div className="hp-qsv-text">AI 면접관 대기 중</div>
+      </div>
+    </Link>
+  );
+}

--- a/src/pages/home/ui/components/README.md
+++ b/src/pages/home/ui/components/README.md
@@ -1,0 +1,46 @@
+# Home Page Components
+
+이 디렉토리는 HomePage를 구성하는 개별 컴포넌트들을 포함합니다.
+
+## 컴포넌트 구조
+
+### Layout Components
+- **HomeNavbar** - 상단 네비게이션 바
+- **HomeSidebar** - 좌측 사이드바 메뉴
+- **LoadingSkeleton** - 로딩 상태 스켈레톤 UI
+
+### Content Components
+- **HomeHeader** - 페이지 헤더 (인사말, 사용자 이름)
+- **QuickStartHero** - 빠른 시작 CTA 섹션
+- **StatsGrid** - 통계 카드 그리드 (면접 횟수, 평균 점수 등)
+- **RecentSessions** - 최근 면접 기록 목록
+- **StreakCalendar** - 스트릭 달력
+- **JobStatus** - 지원 현황 카드
+
+## 사용 예시
+
+```tsx
+import {
+  HomeNavbar,
+  HomeSidebar,
+  HomeHeader,
+  QuickStartHero,
+  StatsGrid,
+  RecentSessions,
+  StreakCalendar,
+  JobStatus,
+  LoadingSkeleton,
+} from "./components";
+
+// HomePage.tsx에서 사용
+<HomeNavbar menuOpen={menuOpen} onMenuToggle={handleToggle} />
+<HomeSidebar menuOpen={menuOpen} currentStreak={12} />
+<StatsGrid stats={data.stats} revealed={true} />
+```
+
+## 타입 정의
+
+모든 컴포넌트는 `@/features/home/api/homeApi`에서 타입을 가져옵니다:
+- `HomeStat` - 통계 데이터
+- `HomeSession` - 면접 세션 데이터
+- `HomeJob` - 채용 공고 데이터

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import type { HomeSession } from "@/features/home/api/homeApi";
 
 interface RecentSessionsProps {
@@ -10,15 +11,15 @@ export function RecentSessions({ sessions, revealed }: RecentSessionsProps) {
     <>
       <div className={`hp-sec-head hp-rv${revealed ? " hp-rv-in" : ""}`} style={{ transitionDelay: "275ms" }}>
         <div className="hp-sec-title">최근 면접 기록</div>
-        <a className="hp-sec-link" href="#">전체 보기 →</a>
+        <Link to="/interview/history" className="hp-sec-link">전체 보기 →</Link>
       </div>
       <div className="hp-session-list">
         {sessions.map((session, i) => (
-          <a
+          <Link
             key={session.id}
+            to={`/interview/review/${session.id}`}
             className={`hp-session-item hp-rv${revealed ? " hp-rv-in" : ""}`}
             style={{ transitionDelay: `${330 + i * 55}ms` }}
-            href="#"
           >
             <div className="hp-si-icon">{session.icon}</div>
             <div className="hp-si-body">
@@ -39,7 +40,7 @@ export function RecentSessions({ sessions, revealed }: RecentSessionsProps) {
               <div className="hp-si-num">{session.score}</div>
               <div className="hp-si-num-label">종합 점수</div>
             </div>
-          </a>
+          </Link>
         ))}
       </div>
     </>

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -1,0 +1,47 @@
+import type { HomeSession } from "@/features/home/api/homeApi";
+
+interface RecentSessionsProps {
+  sessions: HomeSession[];
+  revealed: boolean;
+}
+
+export function RecentSessions({ sessions, revealed }: RecentSessionsProps) {
+  return (
+    <>
+      <div className={`hp-sec-head hp-rv${revealed ? " hp-rv-in" : ""}`} style={{ transitionDelay: "275ms" }}>
+        <div className="hp-sec-title">최근 면접 기록</div>
+        <a className="hp-sec-link" href="#">전체 보기 →</a>
+      </div>
+      <div className="hp-session-list">
+        {sessions.map((session, i) => (
+          <a
+            key={session.id}
+            className={`hp-session-item hp-rv${revealed ? " hp-rv-in" : ""}`}
+            style={{ transitionDelay: `${330 + i * 55}ms` }}
+            href="#"
+          >
+            <div className="hp-si-icon">{session.icon}</div>
+            <div className="hp-si-body">
+              <div className="hp-si-company">
+                {session.company}
+                <span
+                  className={`hp-badge${session.badgeType === "neutral" ? " hp-badge-neutral" : ""}`}
+                  style={{ fontSize: 10 }}
+                >
+                  {session.badgeLabel}
+                </span>
+              </div>
+              <div className="hp-si-meta">
+                {session.role} · {session.round} · {session.date}
+              </div>
+            </div>
+            <div className="hp-si-score">
+              <div className="hp-si-num">{session.score}</div>
+              <div className="hp-si-num-label">종합 점수</div>
+            </div>
+          </a>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/pages/home/ui/components/StatsGrid.tsx
+++ b/src/pages/home/ui/components/StatsGrid.tsx
@@ -1,0 +1,40 @@
+import type { HomeStat } from "@/features/home/api/homeApi";
+
+interface StatsGridProps {
+  stats: HomeStat[];
+  revealed: boolean;
+}
+
+export function StatsGrid({ stats, revealed }: StatsGridProps) {
+  return (
+    <div className="hp-stats-grid">
+      {stats.map((stat, i) => (
+        <div
+          key={i}
+          className={`hp-stat-card hp-rv${revealed ? " hp-rv-in" : ""}`}
+          style={{ transitionDelay: `${55 + i * 55}ms` }}
+        >
+          <span className="hp-stat-icon">{stat.icon}</span>
+          <div className="hp-stat-num">
+            {stat.value}
+            {stat.unit && (
+              <small style={{ fontSize: 14, opacity: 0.5 }}>{stat.unit}</small>
+            )}
+          </div>
+          <div className="hp-stat-label">{stat.label}</div>
+          <span
+            className={`hp-stat-delta ${
+              stat.deltaType === "up"
+                ? "hp-delta-up"
+                : stat.deltaType === "down"
+                ? "hp-delta-dn"
+                : "hp-delta-neutral"
+            }`}
+          >
+            {stat.delta}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/home/ui/components/StreakCalendar.tsx
+++ b/src/pages/home/ui/components/StreakCalendar.tsx
@@ -4,6 +4,8 @@ interface StreakCalendarProps {
 }
 
 export function StreakCalendar({ streakData, revealed }: StreakCalendarProps) {
+  const currentMonth = new Date().toLocaleDateString('ko-KR', { month: 'long' });
+  
   return (
     <div
       className={`hp-card-white hp-rv${revealed ? " hp-rv-in" : ""}`}
@@ -11,7 +13,7 @@ export function StreakCalendar({ streakData, revealed }: StreakCalendarProps) {
     >
       <div className="hp-sec-head" style={{ marginBottom: 12 }}>
         <div className="hp-sec-title" style={{ fontSize: 13 }}>🔥 이번 달 스트릭</div>
-        <span className="hp-badge" style={{ fontSize: 10 }}>3월</span>
+        <span className="hp-badge" style={{ fontSize: 10 }}>{currentMonth}</span>
       </div>
       <div className="hp-streak-cal">
         {streakData.map((v, i) => (

--- a/src/pages/home/ui/components/StreakCalendar.tsx
+++ b/src/pages/home/ui/components/StreakCalendar.tsx
@@ -1,0 +1,28 @@
+interface StreakCalendarProps {
+  streakData: number[];
+  revealed: boolean;
+}
+
+export function StreakCalendar({ streakData, revealed }: StreakCalendarProps) {
+  return (
+    <div
+      className={`hp-card-white hp-rv${revealed ? " hp-rv-in" : ""}`}
+      style={{ padding: 20, transitionDelay: "495ms" }}
+    >
+      <div className="hp-sec-head" style={{ marginBottom: 12 }}>
+        <div className="hp-sec-title" style={{ fontSize: 13 }}>🔥 이번 달 스트릭</div>
+        <span className="hp-badge" style={{ fontSize: 10 }}>3월</span>
+      </div>
+      <div className="hp-streak-cal">
+        {streakData.map((v, i) => (
+          <div key={i} className={`hp-sc-day hp-sc-${v}`} />
+        ))}
+      </div>
+      <div className="hp-sc-days-label" style={{ marginTop: 6 }}>
+        {["월", "화", "수", "목", "금", "토", "일"].map((d) => (
+          <span key={d} className="hp-sc-dl">{d}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/home/ui/components/index.ts
+++ b/src/pages/home/ui/components/index.ts
@@ -1,0 +1,9 @@
+export { HomeNavbar } from "./HomeNavbar";
+export { HomeSidebar } from "./HomeSidebar";
+export { HomeHeader } from "./HomeHeader";
+export { QuickStartHero } from "./QuickStartHero";
+export { StatsGrid } from "./StatsGrid";
+export { RecentSessions } from "./RecentSessions";
+export { StreakCalendar } from "./StreakCalendar";
+export { JobStatus } from "./JobStatus";
+export { LoadingSkeleton } from "./LoadingSkeleton";


### PR DESCRIPTION
## 관련 이슈
Closes #22 

## 변경 사항
Home 화면의 컴포넌트 구조를 분리하여 가독성과 유지보수성을 개선했습니다.

- HomeNavbar: 상단 네비게이션 바
- HomeSidebar: 좌측 사이드바 메뉴
- HomeHeader: 페이지 헤더
- QuickStartHero: 빠른 시작 섹션
- StatsGrid: 통계 카드 그리드
- RecentSessions: 최근 면접 기록
- StreakCalendar: 스트릭 달력
- JobStatus: 지원 현황
- LoadingSkeleton: 로딩 UI

- 각 컴포넌트를 역할 단위로 분리하여 책임을 명확히 하고 재사용성을 높였습니다.

## 변경 유형
해당하는 항목에 체크해주세요.

- [ ] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. Home 화면 진입 시 각 컴포넌트가 정상적으로 렌더링되는지 확인
2. 네비게이션, 사이드바, 통계 카드 등 주요 UI 요소 정상 동작 확인
3. 기존 기능과 동일하게 사용자 흐름이 유지되는지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 반응형 디자인을 확인했습니다
- [x] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보
기능 변경 없이 UI 구조 개선 및 컴포넌트 분리를 중심으로 진행된 리팩토링입니다.  
추후 기능 확장 시 유지보수성과 확장성을 고려한 구조로 개선되었습니다.