### PR TITLE
Feature/022 homepage components

### DIFF
--- a/src/pages/home/ui/components/HomeNavbar.tsx
+++ b/src/pages/home/ui/components/HomeNavbar.tsx
@@ -19,7 +19,7 @@ export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
           <span></span>
         </div>
       </button>
-      <Link to="/home" className="hp-nav-logo">me<span className="hi">Fit</span></Link>
+      <Link to="/" className="hp-nav-logo">me<span className="hi">Fit</span></Link>
       <Link to="/home" className="hp-nav-link active">홈</Link>
       <Link to="/resume" className="hp-nav-link">이력서</Link>
       <Link to="/jd" className="hp-nav-link">채용공고</Link>

--- a/src/pages/landing/ui/PricingSection.tsx
+++ b/src/pages/landing/ui/PricingSection.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 const FREE_ITEMS = [
   { ok: true, text: "월 5회 면접" },
   { ok: true, text: "기본 AI 리뷰 리포트" },
@@ -75,9 +77,12 @@ export function PricingSection() {
                 </li>
               ))}
             </ul>
-            <button className="w-full py-[14px] rounded-lg border-none font-inter text-[15px] font-bold cursor-pointer transition-opacity duration-200 hover:opacity-85 bg-white text-[#0A0A0A] md:py-4 md:rounded-lg md:text-[16px]">
+            <Link 
+              to="/subscription" 
+              className="w-full py-[14px] rounded-lg border-none font-inter text-[15px] font-bold cursor-pointer transition-opacity duration-200 hover:opacity-85 bg-white text-[#0A0A0A] md:py-4 md:rounded-lg md:text-[16px] flex items-center justify-center no-underline"
+            >
               Pro 업그레이드
-            </button>
+            </Link>
             <div className="text-center text-[12px] text-white/45 mt-2.5 md:text-[13px] md:mt-3">언제든지 취소 가능</div>
           </div>
         </div>

--- a/src/pages/login/ui/LoginPage.tsx
+++ b/src/pages/login/ui/LoginPage.tsx
@@ -68,7 +68,7 @@ export function LoginPage() {
 
         {/* Form Card */}
         <section className="w-full flex justify-center">
-          <div className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-7 py-10 shadow-[var(--sc)] md:max-w-form md:px-9">
+          <div className="w-full max-w-[480px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-7 shadow-[var(--sc)] sm:px-7 sm:py-9">
             <form onSubmit={handleSubmit} noValidate>
               <div className="mb-4 md:mb-[18px]">
                 <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="li-email">이메일</label>

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -88,8 +88,8 @@ export function OnboardingPage() {
         </div>
       </header>
 
-      <main className="w-full mx-auto px-5 py-8 flex flex-col gap-8 md:px-10 md:py-12">
-        <div className="w-full max-w-[1000px] mx-auto flex flex-col gap-8 md:flex-row md:items-start md:gap-10 lg:gap-12">
+      <main className="flex-1 w-full mx-auto px-5 py-8 flex flex-col justify-center gap-8 md:px-10 md:py-12">
+        <div className="w-full max-w-[1000px] mx-auto flex flex-col gap-8 md:flex-row md:items-center md:gap-10 lg:gap-12">
         {/* ── Left ── */}
         <section className="flex flex-col items-center md:flex-1 md:items-start md:sticky md:top-8">
           <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] tracking-[0.5px] self-center md:self-start md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">
@@ -150,7 +150,7 @@ export function OnboardingPage() {
 
         {/* ── Right: Profile Card ── */}
         <section className="flex justify-center w-full md:flex-1">
-          <div className="w-full max-w-[520px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-7 shadow-[var(--sc)] sm:px-7 sm:py-9">
+          <div className="w-full max-w-[560px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-10 shadow-[var(--sc)] sm:px-7 sm:py-12">
             <h2 className="font-inter text-[22px] font-extrabold text-[#0A0A0A] mb-1.5">나를 알려주세요 👋</h2>
             <p className="text-[14px] text-[#6B7280] leading-[1.6] mb-6">
               면접 질문 맞춤화를 위해 딱 2가지만 입력하면 돼요.

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -118,7 +118,7 @@ export function OnboardingPage() {
             </div>
             <div className="flex flex-col gap-0.5 overflow-hidden">
               <span className="text-[14px] font-bold text-[#059669]">이메일 인증 완료!</span>
-              <span className="text-[13px] text-[#6B7280] truncate">{email}</span>
+              <span className="text-[13px] text-[#6B7280] truncate" title={email}>{email}</span>
             </div>
           </div>
 

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -78,7 +78,7 @@ export function OnboardingPage() {
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
-      <header className="w-full max-w-container mx-auto flex justify-between items-center px-5 pt-5 md:px-10 md:pt-7">
+      <header className="w-full max-w-container mx-auto flex justify-between items-center px-5 py-5 md:px-10 md:py-7">
         <Link to="/" className="font-inter text-[22px] font-black text-[#0A0A0A] no-underline">
           me<span style={{ color: "#0991B2" }}>Fit</span>
         </Link>
@@ -88,58 +88,59 @@ export function OnboardingPage() {
         </div>
       </header>
 
-      <main className="flex-1 w-full max-w-container mx-auto px-5 flex flex-col gap-10 justify-center items-center text-center md:flex-row md:items-center md:px-10 md:gap-[60px] md:text-left">
+      <main className="w-full mx-auto px-5 py-8 flex flex-col gap-8 md:px-10 md:py-12">
+        <div className="w-full max-w-[1000px] mx-auto flex flex-col gap-8 md:flex-row md:items-start md:gap-10 lg:gap-12">
         {/* ── Left ── */}
-        <section className="flex flex-col items-center md:flex-none md:flex-1 md:max-w-text md:items-start md:pt-4">
+        <section className="flex flex-col items-center md:flex-1 md:items-start md:sticky md:top-8">
           <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] tracking-[0.5px] self-center md:self-start md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">
             ● STEP 3 OF 3
           </div>
-          <h1 className="font-inter text-[clamp(36px,9vw,56px)] font-black leading-[1.08] text-[#0A0A0A] mb-4 tracking-[-2px] md:text-[clamp(40px,4.5vw,56px)]">
+          <h1 className="font-inter text-[clamp(32px,8vw,48px)] font-black leading-[1.1] text-[#0A0A0A] mb-3 tracking-[-2px] text-center md:text-left md:text-[clamp(36px,3.5vw,48px)]">
             이제 <span className="gradient-text">핏</span>을
             <br />
             맞춰볼
             <br />
             차례예요
           </h1>
-          <p className="text-[14px] text-[#6B7280] leading-[1.7] mb-6 md:text-[15px]">
+          <p className="text-[14px] text-[#6B7280] leading-[1.7] mb-6 text-center md:text-left md:text-[15px]">
             어떤 직군을 준비하는지 알려주면
             <br className="hidden md:block" />
             AI가 맞춤 면접 질문을 바로 생성해줄게요.
           </p>
 
           {/* Email verified card */}
-          <div className="flex items-center justify-center gap-[14px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-[22px] py-[18px] mb-7 shadow-[var(--sc)] w-full md:justify-start">
+          <div className="flex items-center justify-center gap-[14px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-[22px] py-[18px] mb-6 shadow-[var(--sc)] w-full md:justify-start">
             <div className="shrink-0">
               <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
                 <rect width="24" height="24" rx="6" fill="#059669" />
                 <polyline points="7 13 10 16 17 9" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
               </svg>
             </div>
-            <div className="flex flex-col gap-0.5">
+            <div className="flex flex-col gap-0.5 overflow-hidden">
               <span className="text-[14px] font-bold text-[#059669]">이메일 인증 완료!</span>
-              <span className="text-[13px] text-[#6B7280]">{email}</span>
+              <span className="text-[13px] text-[#6B7280] truncate">{email}</span>
             </div>
           </div>
 
-          {/* Steps */}
-          <div className="flex flex-row gap-2 w-full md:flex-col md:gap-2">
+          {/* Steps - 모바일에서는 숨김 */}
+          <div className="hidden md:flex md:flex-col md:gap-2 w-full">
             {[
               { done: true, num: null, name: "이메일로 계정 생성", sub: "완료" },
               { done: true, num: null, name: "이메일 인증 완료", sub: "완료" },
             ].map((step, i) => (
-              <div key={i} className="flex flex-col items-center text-center flex-1 px-[10px] py-3 rounded-lg opacity-60 md:flex-row md:items-center md:gap-[14px] md:text-left md:px-5 md:py-[14px]">
-                <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#059669] shrink-0 mx-auto md:mx-0">
+              <div key={i} className="flex flex-row items-center gap-[14px] text-left px-5 py-[14px] rounded-lg opacity-60">
+                <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#059669] shrink-0">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
                 </div>
-                <div className="flex flex-col gap-0.5 items-center md:items-start">
+                <div className="flex flex-col gap-0.5">
                   <span className="text-[14px] font-semibold text-[#0A0A0A]">{step.name}</span>
                   <span className="text-[12px] text-[#9CA3AF]">{step.sub}</span>
                 </div>
               </div>
             ))}
-            <div className="flex flex-col items-center text-center flex-1 px-[10px] py-3 rounded-lg bg-[#0A0A0A] transition-transform duration-200 hover:-translate-y-px md:flex-row md:items-center md:gap-[14px] md:text-left md:px-5 md:py-[14px]">
-              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#0991B2] shrink-0 mx-auto md:mx-0">3</div>
-              <div className="flex flex-col gap-0.5 items-center md:items-start">
+            <div className="flex flex-row items-center gap-[14px] text-left px-5 py-[14px] rounded-lg bg-[#0A0A0A] transition-transform duration-200 hover:-translate-y-px">
+              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#0991B2] shrink-0">3</div>
+              <div className="flex flex-col gap-0.5">
                 <span className="text-[14px] font-semibold text-white">프로필 작성 후 면접 시작</span>
                 <span className="text-[12px] text-white/50">지금 이 단계예요</span>
               </div>
@@ -148,8 +149,8 @@ export function OnboardingPage() {
         </section>
 
         {/* ── Right: Profile Card ── */}
-        <section className="flex justify-center w-full md:flex-none md:flex-1 md:max-w-form">
-          <div className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-7 py-9 shadow-[var(--sc)] md:px-9 md:py-11">
+        <section className="flex justify-center w-full md:flex-1">
+          <div className="w-full max-w-[520px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-7 shadow-[var(--sc)] sm:px-7 sm:py-9">
             <h2 className="font-inter text-[22px] font-extrabold text-[#0A0A0A] mb-1.5">나를 알려주세요 👋</h2>
             <p className="text-[14px] text-[#6B7280] leading-[1.6] mb-6">
               면접 질문 맞춤화를 위해 딱 2가지만 입력하면 돼요.
@@ -291,9 +292,10 @@ export function OnboardingPage() {
             </button>
           </div>
         </section>
+        </div>
       </main>
 
-      <footer className="w-full max-w-container mx-auto px-5 py-8 flex justify-center gap-5 md:px-10 md:py-10">
+      <footer className="w-full max-w-container mx-auto px-5 py-6 flex justify-center gap-5 md:px-10 md:py-8">
         {["개인정보처리방침", "이용약관", "쿠키"].map((item) => (
           <a key={item} href="#" className="text-[11px] text-[#9CA3AF] no-underline transition-[color] duration-200 hover:text-[#6B7280]">
             {item}

--- a/src/pages/sign-up/ui/SignUpPage.tsx
+++ b/src/pages/sign-up/ui/SignUpPage.tsx
@@ -83,29 +83,30 @@ export function SignUpPage() {
         </Link>
       </header>
 
-      <main className="flex-1 w-full max-w-container mx-auto px-5 flex flex-col gap-10 justify-center items-center text-center md:flex-row md:items-center md:px-10 md:gap-[60px] md:text-left">
+      <main className="flex-1 w-full mx-auto px-5 py-8 flex flex-col justify-center gap-8 md:px-10 md:py-12">
+        <div className="w-full max-w-[1000px] mx-auto flex flex-col gap-8 md:flex-row md:items-center md:gap-10 lg:gap-12">
         {/* Left: Hero + Steps */}
-        <section className="flex flex-col items-center md:flex-none md:flex-1 md:max-w-text md:items-start md:pt-4">
+        <section className="flex flex-col items-center md:flex-1 md:items-start">
           <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] tracking-[0.5px] md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">
             ● STEP 1 OF 3
           </div>
-          <h1 className="font-inter text-[clamp(36px,9vw,56px)] font-black leading-[1.08] text-[#0A0A0A] mb-4 tracking-[-2px] md:text-[clamp(40px,4.5vw,56px)]">
+          <h1 className="font-inter text-[clamp(32px,8vw,48px)] font-black leading-[1.1] text-[#0A0A0A] mb-3 tracking-[-2px] text-center md:text-left md:text-[clamp(36px,3.5vw,48px)]">
             핏이 맞는 나를
             <br />
             <span className="gradient-text">완성해가는</span>
             <br />
             여정
           </h1>
-          <p className="text-[14px] text-[#6B7280] leading-[1.7] mb-8 md:text-[15px]">
+          <p className="text-[14px] text-[#6B7280] leading-[1.7] mb-6 text-center md:text-left md:text-[15px]">
             이메일 하나로 시작하는 AI 면접 코치.
             <br className="hidden md:block" />
             3단계만 거치면 바로 연습할 수 있어요.
           </p>
 
-          <div className="flex flex-row gap-2 w-full md:flex-col md:gap-2">
-            <div className="flex flex-col items-center text-center flex-1 px-[10px] py-3 rounded-lg bg-[#0A0A0A] transition-transform duration-200 hover:-translate-y-px md:flex-row md:items-center md:gap-[14px] md:text-left md:px-5 md:py-[14px]">
-              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#0991B2] shrink-0 mx-auto md:mx-0">1</div>
-              <div className="flex flex-col gap-0.5 items-center md:items-start">
+          <div className="hidden md:flex md:flex-col md:gap-2 w-full">
+            <div className="flex flex-row items-center gap-[14px] text-left px-5 py-[14px] rounded-lg bg-[#0A0A0A] transition-transform duration-200 hover:-translate-y-px">
+              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#0991B2] shrink-0">1</div>
+              <div className="flex flex-col gap-0.5">
                 <span className="text-[14px] font-semibold text-white">이메일로 계정 생성</span>
                 <span className="text-[12px] text-white/50">지금 이 단계예요</span>
               </div>
@@ -114,9 +115,9 @@ export function SignUpPage() {
               { num: 2, name: "이메일 인증 완료", sub: "메일함을 확인해요" },
               { num: 3, name: "프로필 작성 후 면접 시작", sub: "직군·경력 입력" },
             ].map((step) => (
-              <div key={step.num} className="flex flex-col items-center text-center flex-1 px-[10px] py-3 rounded-lg md:flex-row md:items-center md:gap-[14px] md:text-left md:px-5 md:py-[14px]">
-                <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-[#6B7280] bg-[#E5E7EB] shrink-0 mx-auto md:mx-0">{step.num}</div>
-                <div className="flex flex-col gap-0.5 items-center md:items-start">
+              <div key={step.num} className="flex flex-row items-center gap-[14px] text-left px-5 py-[14px] rounded-lg">
+                <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-[#6B7280] bg-[#E5E7EB] shrink-0">{step.num}</div>
+                <div className="flex flex-col gap-0.5">
                   <span className="text-[14px] font-semibold text-[#0A0A0A]">{step.name}</span>
                   <span className="text-[12px] text-[#9CA3AF]">{step.sub}</span>
                 </div>
@@ -126,8 +127,8 @@ export function SignUpPage() {
         </section>
 
         {/* Right: Form Card */}
-        <section className="flex justify-center w-full md:flex-none md:flex-1 md:max-w-form">
-          <div className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-7 py-10 shadow-[var(--sc)] md:px-9">
+        <section className="flex justify-center w-full md:flex-1">
+          <div className="w-full max-w-[520px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-7 shadow-[var(--sc)] sm:px-7 sm:py-9">
             <h2 className="font-inter text-[22px] font-extrabold text-[#0A0A0A] mb-1.5">계정 만들기</h2>
             <p className="text-[14px] text-[#6B7280] mb-7">아직 핏이 맞지 않아도 괜찮아요 — 지금 시작해요.</p>
 
@@ -203,9 +204,10 @@ export function SignUpPage() {
             </p>
           </div>
         </section>
+        </div>
       </main>
 
-      <footer className="w-full max-w-container mx-auto px-5 py-8 flex justify-center gap-5 md:px-10 md:py-10">
+      <footer className="w-full max-w-container mx-auto px-5 py-6 flex justify-center gap-5 md:px-10 md:py-8">
         {["개인정보처리방침", "이용약관", "쿠키"].map((item) => (
           <a key={item} href="#" className="text-[11px] text-[#9CA3AF] no-underline transition-[color] duration-200 hover:text-[#6B7280]">
             {item}

--- a/src/pages/verify-email/ui/VerifyEmailPage.tsx
+++ b/src/pages/verify-email/ui/VerifyEmailPage.tsx
@@ -75,48 +75,49 @@ export function VerifyEmailPage() {
         </button>
       </header>
 
-      <main className="flex-1 w-full max-w-container mx-auto px-5 flex flex-col gap-10 justify-center items-center text-center md:flex-row md:items-center md:px-10 md:gap-[60px] md:text-left">
+      <main className="flex-1 w-full mx-auto px-5 py-8 flex flex-col justify-center gap-8 md:px-10 md:py-12">
+        <div className="w-full max-w-[1000px] mx-auto flex flex-col gap-8 md:flex-row md:items-center md:gap-10 lg:gap-12">
         {/* Left */}
-        <section className="flex flex-col items-center md:flex-none md:flex-1 md:max-w-text md:items-start md:pt-4">
+        <section className="flex flex-col items-center md:flex-1 md:items-start">
           <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] self-center md:self-start md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">
             ● STEP 2 OF 3
           </div>
-          <h1 className="font-inter text-[clamp(36px,9vw,56px)] font-black leading-[1.08] text-[#0A0A0A] mb-4 tracking-[-2px] md:text-[clamp(40px,4.5vw,56px)]">
+          <h1 className="font-inter text-[clamp(32px,8vw,48px)] font-black leading-[1.1] text-[#0A0A0A] mb-3 tracking-[-2px] text-center md:text-left md:text-[clamp(36px,3.5vw,48px)]">
             인증 메일을
             <br />
             <span className="gradient-text">확인</span>해주세요
           </h1>
-          <p className="text-[14px] text-[#6B7280] leading-[1.7] mb-8 md:text-[15px]">
+          <p className="text-[14px] text-[#6B7280] leading-[1.7] mb-6 text-center md:text-left md:text-[15px]">
             이메일 인증을 완료해야
             <br className="hidden md:block" />
             모든 기능을 이용할 수 있어요.
           </p>
 
-          <div className="flex flex-row gap-2 w-full md:flex-col md:gap-2">
+          <div className="hidden md:flex md:flex-col md:gap-2 w-full">
             {/* Done step */}
-            <div className="flex flex-col items-center text-center flex-1 px-[10px] py-3 rounded-lg opacity-60 md:flex-row md:items-center md:gap-[14px] md:text-left md:px-5 md:py-[14px]">
-              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#0A0A0A] shrink-0 mx-auto md:mx-0">
+            <div className="flex flex-row items-center gap-[14px] text-left px-5 py-[14px] rounded-lg opacity-60">
+              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#0A0A0A] shrink-0">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
               </div>
-              <div className="flex flex-col gap-0.5 items-center md:items-start">
+              <div className="flex flex-col gap-0.5">
                 <span className="text-[14px] font-semibold text-[#0A0A0A]">이메일로 계정 생성</span>
                 <span className="text-[12px] text-[#9CA3AF]">완료했어요</span>
               </div>
             </div>
             {/* Active step */}
-            <div className="flex flex-col items-center text-center flex-1 px-[10px] py-3 rounded-lg md:flex-row md:items-center md:gap-[14px] md:text-left md:px-5 md:py-[14px]">
-              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-[#EF4444] bg-[#FEE2E2] shrink-0 mx-auto md:mx-0">
+            <div className="flex flex-row items-center gap-[14px] text-left px-5 py-[14px] rounded-lg">
+              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-[#EF4444] bg-[#FEE2E2] shrink-0">
                 <span className="text-[18px] font-black">!</span>
               </div>
-              <div className="flex flex-col gap-0.5 items-center md:items-start">
+              <div className="flex flex-col gap-0.5">
                 <span className="text-[14px] font-bold text-[#EF4444]">이메일 인증 대기 중</span>
                 <span className="text-[12px] text-[#EF4444]">인증이 필요해요</span>
               </div>
             </div>
             {/* Pending step */}
-            <div className="flex flex-col items-center text-center flex-1 px-[10px] py-3 rounded-lg md:flex-row md:items-center md:gap-[14px] md:text-left md:px-5 md:py-[14px]">
-              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-[#6B7280] bg-[#E5E7EB] shrink-0 mx-auto md:mx-0">3</div>
-              <div className="flex flex-col gap-0.5 items-center md:items-start">
+            <div className="flex flex-row items-center gap-[14px] text-left px-5 py-[14px] rounded-lg">
+              <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-[#6B7280] bg-[#E5E7EB] shrink-0">3</div>
+              <div className="flex flex-col gap-0.5">
                 <span className="text-[14px] font-semibold text-[#0A0A0A]">프로필 작성 후 면접 시작</span>
                 <span className="text-[12px] text-[#9CA3AF]">직군·경력 입력</span>
               </div>
@@ -125,8 +126,8 @@ export function VerifyEmailPage() {
         </section>
 
         {/* Right: Card */}
-        <section className="flex justify-center w-full md:flex-none md:flex-1 md:max-w-form">
-          <div className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-7 py-10 shadow-[var(--sc)] text-center md:px-9 md:py-12">
+        <section className="flex justify-center w-full md:flex-1">
+          <div className="w-full max-w-[520px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-7 shadow-[var(--sc)] text-center sm:px-7 sm:py-9">
             {/* Lock icon */}
             <div className="inline-block relative mb-6">
               <div className="w-20 h-20 rounded-full bg-gradient-to-br from-[#E6F7FA] to-[#D1FAE5] flex items-center justify-center">
@@ -232,9 +233,10 @@ export function VerifyEmailPage() {
             </p>
           </div>
         </section>
+        </div>
       </main>
 
-      <footer className="w-full max-w-container mx-auto px-5 py-8 flex justify-center gap-5 md:px-10 md:py-10">
+      <footer className="w-full max-w-container mx-auto px-5 py-6 flex justify-center gap-5 md:px-10 md:py-8">
         {["개인정보처리방침", "이용약관", "쿠키"].map((item) => (
           <a key={item} href="#" className="text-[11px] text-[#9CA3AF] no-underline transition-[color] duration-200 hover:text-[#6B7280]">
             {item}

--- a/src/pages/verify-email/ui/VerifyEmailPage.tsx
+++ b/src/pages/verify-email/ui/VerifyEmailPage.tsx
@@ -153,9 +153,9 @@ export function VerifyEmailPage() {
             </p>
 
             {/* Email display */}
-            <div className="flex items-center justify-center gap-[10px] bg-white border border-[#E5E7EB] rounded-lg px-5 py-[14px] mb-5">
+            <div className="flex items-center justify-center gap-[10px] bg-white border border-[#E5E7EB] rounded-lg px-5 py-[14px] mb-5 overflow-hidden">
               <span className="w-2 h-2 rounded-full bg-[#F59E0B] shrink-0" />
-              <span className="font-inter text-[15px] font-bold text-[#0A0A0A]">{email}</span>
+              <span className="font-inter text-[15px] font-bold text-[#0A0A0A] truncate" title={email}>{email}</span>
             </div>
 
             {/* Code input */}


### PR DESCRIPTION
## 관련 이슈
Closes #30 
Closes #29 

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- onboarding page 레이아웃 반응형 개선
- verify-email page 레이아웃 반응형 개선 및 박스 크기 조정 
- login page 레이아웃 반응형 개선 및 박스 최대 크기 지정

## 변경 유형
해당하는 항목에 체크해주세요.

- [x] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. PC / 태블릿 / 모바일 화면에서 각 페이지(onboarding, verify-email, login) 접속
2. 화면 크기 변경 시 레이아웃이 깨지지 않고 자연스럽게 반응하는지 확인
3. verify-email, login 페이지의 박스 크기가 의도한 최대 크기로 유지되는지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다


## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->
<img width="821" height="491" alt="image" src="https://github.com/user-attachments/assets/20b93f5e-fd78-49de-b37c-e0d442505906" />

### After
<!-- 변경 후 스크린샷 -->
<img width="1658" height="974" alt="image" src="https://github.com/user-attachments/assets/a68c142d-9603-4210-8dae-792e572f9edd" />
<img width="1665" height="944" alt="image" src="https://github.com/user-attachments/assets/87a9d187-a10e-4501-9560-50cf662976fb" />

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.
