### PR TITLE
[032] 인증 라우트 보호 및 백엔드 프로필 API 연동

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,14 +1,16 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "vite_project",
       "dependencies": {
+        "@mediapipe/tasks-vision": "^0.10.34",
+        "lucide-react": "^1.7.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1",
-        "zustand": "^5.0.12"
+        "sonner": "^2.0.7",
+        "zustand": "^5.0.12",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -35,9 +37,9 @@
         "ts-jest": "^29.4.6",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
-      }
-    }
+        "vite": "^7.3.1",
+      },
+    },
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -267,6 +269,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@mediapipe/tasks-vision": ["@mediapipe/tasks-vision@0.10.34", "", {}, "sha512-KFGyhDsjJ+9WUMcMfjTOpcEp3LJNS3KwC7BfvKrCYELn/7G/5kmwnU7z6Spps+iWQoTGL8xW8i68r65OTa3DwA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
@@ -864,6 +868,8 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
+
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -1001,6 +1007,8 @@
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -1270,6 +1278,6 @@
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
-    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="]
+    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
     ]
   },
   "dependencies": {
+    "@mediapipe/tasks-vision": "^0.10.34",
+    "lucide-react": "^1.7.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1",
+    "sonner": "^2.0.7",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -56,8 +56,6 @@ function App() {
         <Route path="/resume/upload" element={<ProtectedRoute><ResumeUploadPage /></ProtectedRoute>} />
         <Route path="/interview/setup" element={<ProtectedRoute><InterviewSetupPage /></ProtectedRoute>} />
         <Route path="/interview/precheck" element={<ProtectedRoute><InterviewPreCheckPage /></ProtectedRoute>} />
-        <Route path="/interview/session/:interviewSessionUuid" element={<ProtectedRoute><InterviewSessionPage /></ProtectedRoute>} />
-        <Route path="/interview/session/:interviewSessionUuid/report" element={<ProtectedRoute><InterviewReportPage /></ProtectedRoute>} />
         <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
         <Route path="/streak" element={<ProtectedRoute><StreakPage /></ProtectedRoute>} />
         <Route path="/subscription" element={<ProtectedRoute><SubscriptionPage /></ProtectedRoute>} />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,12 +1,15 @@
 import { useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Toaster } from "sonner";
 import { useAuthStore } from "@/features/auth";
+import { ProtectedRoute } from "./ProtectedRoute";
+
 import { LandingPage } from "@/pages/landing";
-import { InterviewPreCheckPage } from "@/pages/interview-precheck";
 import { SignUpPage } from "@/pages/sign-up";
 import { LoginPage } from "@/pages/login";
 import { VerifyEmailPage } from "@/pages/verify-email";
 import { OnboardingPage } from "@/pages/onboarding";
+import { HomePage } from "@/pages/home";
 import { JdAddPage } from "@/pages/jd-add";
 import { JdAnalyzingPage } from "@/pages/jd-analyzing";
 import { JdDetailPage } from "@/pages/jd-detail";
@@ -15,8 +18,8 @@ import { JdListPage } from "@/pages/jd-list";
 import { ResumeInputPage } from "@/pages/resume-input";
 import { ResumeUploadPage } from "@/pages/resume-upload";
 import { ResumeListPage } from "@/pages/resume-list";
-import { HomePage } from "@/pages/home";
 import { InterviewSetupPage } from "@/pages/interview-setup";
+import { InterviewPreCheckPage } from "@/pages/interview-precheck";
 import { SettingsPage } from "@/pages/settings";
 import { StreakPage } from "@/pages/streak";
 import { SubscriptionPage } from "@/pages/subscription";
@@ -30,26 +33,34 @@ function App() {
 
   return (
     <BrowserRouter>
+      {/* 전역 토스트 컨테이너 */}
+      <Toaster position="bottom-right" richColors />
+
       <Routes>
+        {/* ── 공개 라우트 (로그인 불필요) ── */}
         <Route path="/" element={<LandingPage />} />
-        <Route path="/home" element={<HomePage />} />
-        <Route path="/sign-up" element={<SignUpPage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/sign-up" element={<SignUpPage />} />
         <Route path="/verify-email" element={<VerifyEmailPage />} />
         <Route path="/onboarding" element={<OnboardingPage />} />
-        <Route path="/jd/add" element={<JdAddPage />} />
-        <Route path="/jd/analyzing" element={<JdAnalyzingPage />} />
-        <Route path="/jd/detail/:id" element={<JdDetailPage />} />
-        <Route path="/jd/edit/:id" element={<JdEditPage />} />
-        <Route path="/jd" element={<JdListPage />} />
-        <Route path="/resume" element={<ResumeListPage />} />
-        <Route path="/resume/input" element={<ResumeInputPage />} />
-        <Route path="/resume/upload" element={<ResumeUploadPage />} />
-        <Route path="/interview/setup" element={<InterviewSetupPage />} />
-        <Route path="/interview/precheck" element={<InterviewPreCheckPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
-        <Route path="/streak" element={<StreakPage />} />
-        <Route path="/subscription" element={<SubscriptionPage />} />
+
+        {/* ── 보호 라우트 (로그인 필요) ── */}
+        <Route path="/home" element={<ProtectedRoute><HomePage /></ProtectedRoute>} />
+        <Route path="/jd/add" element={<ProtectedRoute><JdAddPage /></ProtectedRoute>} />
+        <Route path="/jd/analyzing" element={<ProtectedRoute><JdAnalyzingPage /></ProtectedRoute>} />
+        <Route path="/jd/detail/:id" element={<ProtectedRoute><JdDetailPage /></ProtectedRoute>} />
+        <Route path="/jd/edit/:id" element={<ProtectedRoute><JdEditPage /></ProtectedRoute>} />
+        <Route path="/jd" element={<ProtectedRoute><JdListPage /></ProtectedRoute>} />
+        <Route path="/resume" element={<ProtectedRoute><ResumeListPage /></ProtectedRoute>} />
+        <Route path="/resume/input" element={<ProtectedRoute><ResumeInputPage /></ProtectedRoute>} />
+        <Route path="/resume/upload" element={<ProtectedRoute><ResumeUploadPage /></ProtectedRoute>} />
+        <Route path="/interview/setup" element={<ProtectedRoute><InterviewSetupPage /></ProtectedRoute>} />
+        <Route path="/interview/precheck" element={<ProtectedRoute><InterviewPreCheckPage /></ProtectedRoute>} />
+        <Route path="/interview/session/:interviewSessionUuid" element={<ProtectedRoute><InterviewSessionPage /></ProtectedRoute>} />
+        <Route path="/interview/session/:interviewSessionUuid/report" element={<ProtectedRoute><InterviewReportPage /></ProtectedRoute>} />
+        <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
+        <Route path="/streak" element={<ProtectedRoute><StreakPage /></ProtectedRoute>} />
+        <Route path="/subscription" element={<ProtectedRoute><SubscriptionPage /></ProtectedRoute>} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { useAuthStore } from "@/features/auth";
 import { LandingPage } from "@/pages/landing";
 import { InterviewPreCheckPage } from "@/pages/interview-precheck";
 import { SignUpPage } from "@/pages/sign-up";
@@ -20,6 +22,12 @@ import { StreakPage } from "@/pages/streak";
 import { SubscriptionPage } from "@/pages/subscription";
 
 function App() {
+  const { initAuth } = useAuthStore();
+
+  useEffect(() => {
+    initAuth();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <BrowserRouter>
       <Routes>

--- a/src/app/ProtectedRoute.tsx
+++ b/src/app/ProtectedRoute.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from "react";
+import { Navigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useAuthStore } from "@/features/auth";
+
+/**
+ * 인증이 필요한 라우트를 감싸는 가드 컴포넌트.
+ * - initAuth() 완료 전(authReady=false)에는 아무것도 렌더하지 않음
+ * - 비로그인 상태면 토스트 메시지 + 소개 페이지(/)로 리다이렉트
+ */
+export function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const { user, authReady } = useAuthStore();
+  const toastFired = useRef(false);
+
+  useEffect(() => {
+    if (authReady && !user && !toastFired.current) {
+      toastFired.current = true;
+      toast.error("로그인해주세요.", { duration: 3000 });
+    }
+  }, [authReady, user]);
+
+  // 아직 초기화 중이면 빈 화면 유지
+  if (!authReady) return null;
+
+  // 비로그인 → 소개 페이지로
+  if (!user) return <Navigate to="/" replace />;
+
+  return <>{children}</>;
+}

--- a/src/features/auth/model/store.ts
+++ b/src/features/auth/model/store.ts
@@ -8,15 +8,17 @@ import {
   getMeApi,
 } from "../api/authApi";
 import type { UserMe } from "../api/authApi";
-import { getAccessToken } from "@/shared/api/client";
+import { getAccessToken, getRefreshToken, refreshAccessToken } from "@/shared/api/client";
 
 interface LoginResult {
   success: boolean;
   isEmailConfirmed?: boolean;
+  isProfileCompleted?: boolean;
 }
 
 interface AuthState {
   user: UserMe | null;
+  authReady: boolean; // initAuth 완료 여부
   isLoading: boolean;
   isVerifying: boolean;
   isResending: boolean;
@@ -29,20 +31,20 @@ interface AuthState {
   verifyCode: (code: string) => Promise<boolean>;
   resendVerification: () => Promise<boolean>;
   fetchMe: () => Promise<void>;
+  /** 앱 초기화 시 localStorage 토큰이 있으면 사용자 정보를 복원한다. */
+  initAuth: () => Promise<void>;
   setPendingEmail: (email: string) => void;
   clearError: () => void;
-  isAuthenticated: () => boolean;
 }
 
 export const useAuthStore = create<AuthState>()((set) => ({
   user: null,
+  authReady: false,
   isLoading: false,
   isVerifying: false,
   isResending: false,
   error: null,
   pendingEmail: null,
-
-  isAuthenticated: () => !!getAccessToken(),
 
   signUp: async ({ name, email, password }) => {
     set({ isLoading: true, error: null });
@@ -62,14 +64,20 @@ export const useAuthStore = create<AuthState>()((set) => ({
       set({ isLoading: false, error: res.message });
       return { success: false };
     }
-    set({ isLoading: false, pendingEmail: email });
-    return { success: true, isEmailConfirmed: res.isEmailConfirmed };
+    // 로그인 성공 시 사용자 정보 즉시 조회 (isProfileCompleted, isEmailConfirmed 확인)
+    const me = await getMeApi();
+    set({ isLoading: false, pendingEmail: email, user: me });
+    return {
+      success: true,
+      isEmailConfirmed: me?.isEmailConfirmed ?? res.isEmailConfirmed,
+      isProfileCompleted: me?.isProfileCompleted ?? false,
+    };
   },
 
   logout: async () => {
     set({ isLoading: true });
     await signOutApi();
-    set({ user: null, isLoading: false, pendingEmail: null, error: null });
+    set({ user: null, authReady: true, isLoading: false, pendingEmail: null, error: null });
   },
 
   verifyCode: async (code) => {
@@ -97,6 +105,26 @@ export const useAuthStore = create<AuthState>()((set) => ({
   fetchMe: async () => {
     const me = await getMeApi();
     if (me) set({ user: me });
+  },
+
+  initAuth: async () => {
+    // access token도 없고 refresh token도 없으면 로그인 상태 아님
+    if (!getAccessToken() && !getRefreshToken()) {
+      set({ authReady: true });
+      return;
+    }
+
+    // access token이 없지만 refresh token이 있으면 먼저 갱신 시도
+    if (!getAccessToken() && getRefreshToken()) {
+      const refreshed = await refreshAccessToken();
+      if (!refreshed) {
+        set({ authReady: true });
+        return;
+      }
+    }
+
+    const me = await getMeApi();
+    set({ user: me ?? null, authReady: true });
   },
 
   setPendingEmail: (email) => set({ pendingEmail: email }),

--- a/src/features/onboarding/api/onboardingApi.ts
+++ b/src/features/onboarding/api/onboardingApi.ts
@@ -1,89 +1,34 @@
-// Mock Onboarding API
+import { profileApi } from "@/shared/api/profileApi";
+import type { JobCategory, Job } from "@/shared/api/profileApi";
+
+export type { JobCategory, Job };
 
 export interface OnboardingPayload {
-  desiredJob: string;
-  jobTitles: string[];
-  jobStatus: string;
+  jobCategoryId: number;
+  jobIds: number[];
+  jobStatus: string; // 백엔드 미지원, 프론트에서만 보관
 }
 
-interface OnboardingResponse {
-  success: boolean;
-  message: string;
+export async function fetchJobCategoriesApi(): Promise<JobCategory[]> {
+  const res = await profileApi.getJobCategories();
+  return res.results;
 }
 
-export interface JobTitleOption {
-  id: string;
-  label: string;
+export async function fetchJobsByCategoryApi(jobCategoryId: number): Promise<Job[]> {
+  const res = await profileApi.getJobsByCategory(jobCategoryId);
+  return res.results;
 }
 
-const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-// 직군별 직업 리스트 mock 데이터
-const JOB_TITLES_BY_CATEGORY: Record<string, JobTitleOption[]> = {
-  it: [
-    { id: "frontend", label: "프론트엔드 개발자" },
-    { id: "backend", label: "백엔드 개발자" },
-    { id: "fullstack", label: "풀스택 개발자" },
-    { id: "mobile", label: "모바일 개발자" },
-    { id: "devops", label: "DevOps 엔지니어" },
-    { id: "data-engineer", label: "데이터 엔지니어" },
-    { id: "ml-engineer", label: "ML 엔지니어" },
-    { id: "security", label: "보안 엔지니어" },
-    { id: "qa", label: "QA 엔지니어" },
-    { id: "pm", label: "IT PM" },
-  ],
-  marketing: [
-    { id: "digital-marketer", label: "디지털 마케터" },
-    { id: "content-marketer", label: "콘텐츠 마케터" },
-    { id: "brand-manager", label: "브랜드 매니저" },
-    { id: "performance-marketer", label: "퍼포먼스 마케터" },
-    { id: "growth-hacker", label: "그로스 해커" },
-    { id: "seo-specialist", label: "SEO 전문가" },
-  ],
-  finance: [
-    { id: "accountant", label: "회계사" },
-    { id: "financial-analyst", label: "재무 분석가" },
-    { id: "auditor", label: "감사" },
-    { id: "tax-specialist", label: "세무사" },
-    { id: "investment-banker", label: "투자은행가" },
-    { id: "risk-manager", label: "리스크 매니저" },
-  ],
-  sales: [
-    { id: "account-manager", label: "어카운트 매니저" },
-    { id: "sales-manager", label: "영업 관리자" },
-    { id: "biz-dev", label: "사업개발 매니저" },
-    { id: "cs-manager", label: "CS 매니저" },
-    { id: "retail-manager", label: "리테일 매니저" },
-  ],
-  hr: [
-    { id: "recruiter", label: "리크루터" },
-    { id: "hr-manager", label: "HR 매니저" },
-    { id: "compensation-specialist", label: "보상/복리후생 담당자" },
-    { id: "training-manager", label: "교육/연수 담당자" },
-    { id: "hrbp", label: "HRBP" },
-  ],
-};
-
-/** 선택된 직군에 해당하는 직업 리스트를 반환하는 mock API */
-export async function fetchJobTitlesApi(
-  categoryId: string
-): Promise<JobTitleOption[]> {
-  await delay(400);
-  return JOB_TITLES_BY_CATEGORY[categoryId] ?? [];
-}
-
-export async function submitProfileApi(
+export async function submitOnboardingProfileApi(
   payload: OnboardingPayload
-): Promise<OnboardingResponse> {
-  await delay(1000);
-  if (!payload.desiredJob) {
-    return { success: false, message: "희망 직군을 선택해주세요." };
+): Promise<{ success: boolean; message: string }> {
+  try {
+    await profileApi.saveMyProfile({
+      jobCategoryId: payload.jobCategoryId,
+      jobIds: payload.jobIds,
+    });
+    return { success: true, message: "프로필이 저장되었습니다." };
+  } catch {
+    return { success: false, message: "프로필 저장에 실패했습니다." };
   }
-  if (payload.jobTitles.length === 0) {
-    return { success: false, message: "희망 직업을 1개 이상 선택해주세요." };
-  }
-  if (!payload.jobStatus) {
-    return { success: false, message: "현재 직업 상태를 선택해주세요." };
-  }
-  return { success: true, message: "프로필이 저장되었습니다." };
 }

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,2 +1,1 @@
-export { useOnboardingStore, JOB_CATEGORIES, JOB_STATUS_OPTIONS } from "./model/store";
-export type { JobTitleOption } from "./api/onboardingApi";
+export { useOnboardingStore, JOB_STATUS_OPTIONS } from "./model/store";

--- a/src/features/onboarding/model/store.ts
+++ b/src/features/onboarding/model/store.ts
@@ -1,17 +1,11 @@
 import { create } from "zustand";
 import {
-  submitProfileApi,
-  fetchJobTitlesApi,
-  type JobTitleOption,
+  fetchJobCategoriesApi,
+  fetchJobsByCategoryApi,
+  submitOnboardingProfileApi,
+  type JobCategory,
+  type Job,
 } from "../api/onboardingApi";
-
-export const JOB_CATEGORIES = [
-  { id: "it", label: "IT/개발", emoji: "💻" },
-  { id: "marketing", label: "마케팅", emoji: "📣" },
-  { id: "finance", label: "금융/회계", emoji: "🏦" },
-  { id: "sales", label: "영업/서비스", emoji: "👋" },
-  { id: "hr", label: "인사/HR", emoji: "🏢" },
-] as const;
 
 export const JOB_STATUS_OPTIONS = [
   { value: "", label: "선택해 주세요" },
@@ -25,65 +19,93 @@ export const JOB_STATUS_OPTIONS = [
 ] as const;
 
 interface OnboardingState {
-  selectedJob: string;
-  jobTitles: string[];
-  jobTitleOptions: JobTitleOption[];
-  jobTitlesLoading: boolean;
+  jobCategories: JobCategory[];
+  jobCategoriesLoading: boolean;
+
+  selectedJobCategoryId: number | null;
+  availableJobs: Job[];
+  availableJobsLoading: boolean;
+  selectedJobIds: number[];
+
   jobStatus: string;
   isLoading: boolean;
   error: string | null;
 
-  selectJob: (jobId: string) => Promise<void>;
-  toggleJobTitle: (title: string) => void;
+  loadJobCategories: () => Promise<void>;
+  selectJobCategory: (jobCategoryId: number) => Promise<void>;
+  toggleJobId: (jobId: number) => void;
   setJobStatus: (status: string) => void;
   submitProfile: () => Promise<boolean>;
   clearError: () => void;
 }
 
 export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
-  selectedJob: "",
-  jobTitles: [],
-  jobTitleOptions: [],
-  jobTitlesLoading: false,
+  jobCategories: [],
+  jobCategoriesLoading: false,
+
+  selectedJobCategoryId: null,
+  availableJobs: [],
+  availableJobsLoading: false,
+  selectedJobIds: [],
+
   jobStatus: "",
   isLoading: false,
   error: null,
 
-  selectJob: async (jobId: string) => {
-    const current = get().selectedJob;
-    if (current === jobId) return;
-
-    set({
-      selectedJob: jobId,
-      jobTitles: [],
-      jobTitleOptions: [],
-      jobTitlesLoading: true,
-    });
-
-    const options = await fetchJobTitlesApi(jobId);
-    // 비동기 완료 후 여전히 같은 직군이 선택되어 있는지 확인
-    if (get().selectedJob === jobId) {
-      set({ jobTitleOptions: options, jobTitlesLoading: false });
+  loadJobCategories: async () => {
+    if (get().jobCategories.length > 0) return;
+    set({ jobCategoriesLoading: true });
+    try {
+      const categories = await fetchJobCategoriesApi();
+      set({ jobCategories: categories, jobCategoriesLoading: false });
+    } catch {
+      set({ jobCategoriesLoading: false });
     }
   },
 
-  toggleJobTitle: (title: string) =>
-    set((state) => {
-      if (state.jobTitles.includes(title)) {
-        return { jobTitles: state.jobTitles.filter((t) => t !== title) };
+  selectJobCategory: async (jobCategoryId: number) => {
+    if (get().selectedJobCategoryId === jobCategoryId) return;
+    set({
+      selectedJobCategoryId: jobCategoryId,
+      selectedJobIds: [],
+      availableJobs: [],
+      availableJobsLoading: true,
+    });
+    try {
+      const jobs = await fetchJobsByCategoryApi(jobCategoryId);
+      if (get().selectedJobCategoryId === jobCategoryId) {
+        set({ availableJobs: jobs, availableJobsLoading: false });
       }
-      if (state.jobTitles.length >= 3) return state;
-      return { jobTitles: [...state.jobTitles, title] };
+    } catch {
+      set({ availableJobsLoading: false });
+    }
+  },
+
+  toggleJobId: (jobId: number) =>
+    set((state) => {
+      if (state.selectedJobIds.includes(jobId)) {
+        return { selectedJobIds: state.selectedJobIds.filter((id) => id !== jobId) };
+      }
+      if (state.selectedJobIds.length >= 3) return state;
+      return { selectedJobIds: [...state.selectedJobIds, jobId] };
     }),
 
   setJobStatus: (status) => set({ jobStatus: status }),
 
   submitProfile: async () => {
-    const { selectedJob, jobTitles, jobStatus } = get();
+    const { selectedJobCategoryId, selectedJobIds, jobStatus } = get();
+    if (!selectedJobCategoryId) {
+      set({ error: "희망 직군을 선택해주세요." });
+      return false;
+    }
+    if (selectedJobIds.length === 0) {
+      set({ error: "희망 직업을 1개 이상 선택해주세요." });
+      return false;
+    }
     set({ isLoading: true, error: null });
-    const res = await submitProfileApi({
-      desiredJob: selectedJob,
-      jobTitles,
+    const res = await submitOnboardingProfileApi({
+      jobCategoryId: selectedJobCategoryId,
+      jobIds: selectedJobIds,
       jobStatus,
     });
     if (!res.success) {

--- a/src/features/settings/api/settingsApi.ts
+++ b/src/features/settings/api/settingsApi.ts
@@ -1,16 +1,20 @@
-// Settings API - Connected to backend
-
 import { apiRequest } from "@/shared/api/client";
+import { profileApi } from "@/shared/api/profileApi";
+import { getMeApi } from "@/features/auth/api/authApi";
+import type { JobCategory, Job } from "@/shared/api/profileApi";
 
-const USE_MOCK = false;
+export type { JobCategory, Job };
 
 /* ── Types ── */
 export interface SettingsProfile {
   name: string;
   email: string;
-  jobCategory: string;
-  jobTitle: string;
   avatarInitial: string;
+  // 프로필 API 연동 필드
+  jobCategoryId: number | null;
+  jobCategory: JobCategory | null;
+  jobIds: number[];
+  jobs: Job[];
 }
 
 export interface SettingsNotifications {
@@ -47,60 +51,75 @@ export interface ApiResult {
   message: string;
 }
 
-/* ── Mock Data ── */
-const MOCK_SETTINGS: SettingsData = {
-  profile: {
-    name: "김지원",
-    email: "jiwon@example.com",
-    jobCategory: "IT/개발",
-    jobTitle: "대학생",
-    avatarInitial: "김",
-  },
-  notifications: {
-    streakReminder: true,
-    streakExpire: true,
-    streakReward: true,
-    reportReady: true,
-    serviceNotice: false,
-    marketing: false,
-  },
-  subscription: {
-    plan: "free",
-    resumeUsed: 1,
-    resumeMax: 3,
-    nextBillingDate: null,
-  },
-  consents: {
-    termsAgreedAt: "2025.01.15",
-    privacyAgreedAt: "2025.01.15",
-    aiDataAgreed: false,
-  },
+/* ── Fallback Mock (비프로필 영역 — 아직 API 미구현) ── */
+const MOCK_NOTIFICATIONS: SettingsNotifications = {
+  streakReminder: true,
+  streakExpire: true,
+  streakReward: true,
+  reportReady: true,
+  serviceNotice: false,
+  marketing: false,
 };
 
-/* ── Fetch Settings ── */
+const MOCK_SUBSCRIPTION: SettingsSubscription = {
+  plan: "free",
+  resumeUsed: 1,
+  resumeMax: 3,
+  nextBillingDate: null,
+};
+
+const MOCK_CONSENTS: SettingsConsents = {
+  termsAgreedAt: "2025.01.15",
+  privacyAgreedAt: "2025.01.15",
+  aiDataAgreed: false,
+};
+
+/* ── Fetch Settings ──
+   - 사용자 기본정보: GET /api/v1/users/me/
+   - 프로필 (직군/직업): GET /api/v1/profiles/me/
+   - 나머지는 미구현 → mock fallback
+*/
 export async function fetchSettingsApi(): Promise<{ success: boolean; data?: SettingsData; error?: string }> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 350));
-    return { success: true, data: MOCK_SETTINGS };
-  }
   try {
-    const data = await apiRequest<SettingsData>("/api/v1/users/settings/", { method: "GET", auth: true });
-    return { success: true, data };
+    const [me, userProfile] = await Promise.allSettled([
+      getMeApi(),
+      profileApi.getMyProfile(),
+    ]);
+
+    const meData = me.status === "fulfilled" ? me.value : null;
+    const profileData = userProfile.status === "fulfilled" ? userProfile.value : null;
+
+    const profile: SettingsProfile = {
+      name: meData?.name ?? "",
+      email: meData?.email ?? "",
+      avatarInitial: meData?.name ? meData.name[0] : "?",
+      jobCategoryId: profileData?.jobCategory?.id ?? null,
+      jobCategory: profileData?.jobCategory ?? null,
+      jobIds: profileData?.jobs?.map((j) => j.id) ?? [],
+      jobs: profileData?.jobs ?? [],
+    };
+
+    return {
+      success: true,
+      data: {
+        profile,
+        notifications: MOCK_NOTIFICATIONS,
+        subscription: MOCK_SUBSCRIPTION,
+        consents: MOCK_CONSENTS,
+      },
+    };
   } catch {
-    return { success: true, data: MOCK_SETTINGS };
+    return { success: false, error: "설정을 불러오지 못했습니다." };
   }
 }
 
-/* ── Update Profile ── */
-export async function updateProfileApi(payload: Partial<SettingsProfile>): Promise<ApiResult> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 700));
-    return { success: true, message: "프로필이 저장되었습니다." };
-  }
+/* ── Update Profile ── POST /api/v1/profiles/me/ ── */
+export async function updateProfileApi(payload: {
+  jobCategoryId: number;
+  jobIds: number[];
+}): Promise<ApiResult> {
   try {
-    await apiRequest("/api/v1/users/profile/", {
-      method: "PUT", auth: true, body: JSON.stringify(payload),
-    });
+    await profileApi.saveMyProfile({ jobCategoryId: payload.jobCategoryId, jobIds: payload.jobIds });
     return { success: true, message: "프로필이 저장되었습니다." };
   } catch {
     return { success: false, message: "저장에 실패했습니다." };
@@ -112,10 +131,6 @@ export async function changePasswordApi(payload: {
   currentPassword: string;
   newPassword: string;
 }): Promise<ApiResult> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 800));
-    return { success: true, message: "비밀번호가 변경되었습니다." };
-  }
   try {
     await apiRequest("/api/v1/users/change-password/", {
       method: "POST", auth: true,
@@ -132,10 +147,6 @@ export async function changePasswordApi(payload: {
 
 /* ── Update Notifications ── */
 export async function updateNotificationsApi(payload: SettingsNotifications): Promise<ApiResult> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 600));
-    return { success: true, message: "알림 설정이 저장되었습니다." };
-  }
   try {
     await apiRequest("/api/v1/users/notifications/", {
       method: "PUT", auth: true, body: JSON.stringify(payload),
@@ -148,10 +159,6 @@ export async function updateNotificationsApi(payload: SettingsNotifications): Pr
 
 /* ── Update Consents ── */
 export async function updateConsentsApi(payload: { aiDataAgreed: boolean }): Promise<ApiResult> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 600));
-    return { success: true, message: "동의 설정이 저장되었습니다." };
-  }
   try {
     await apiRequest("/api/v1/users/consents/", {
       method: "PUT", auth: true, body: JSON.stringify({ ai_data_agreed: payload.aiDataAgreed }),
@@ -164,10 +171,6 @@ export async function updateConsentsApi(payload: { aiDataAgreed: boolean }): Pro
 
 /* ── Delete Interview Data ── */
 export async function deleteInterviewDataApi(): Promise<ApiResult> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 900));
-    return { success: true, message: "면접 데이터가 삭제되었습니다." };
-  }
   try {
     await apiRequest("/api/v1/users/interview-data/", { method: "DELETE", auth: true });
     return { success: true, message: "면접 데이터가 삭제되었습니다." };
@@ -178,10 +181,6 @@ export async function deleteInterviewDataApi(): Promise<ApiResult> {
 
 /* ── Delete Account ── */
 export async function deleteAccountApi(): Promise<ApiResult> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 1000));
-    return { success: true, message: "계정이 탈퇴 처리되었습니다." };
-  }
   try {
     await apiRequest("/api/v1/users/", { method: "DELETE", auth: true });
     return { success: true, message: "계정이 탈퇴 처리되었습니다." };

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -143,15 +143,14 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setProfileDraftField: (field, value) => {
     set((s) => {
       const next = { ...s.profileDraft, [field]: value } as ProfileDraft;
-      // 직군 변경 시 직업 선택 초기화
       if (field === "jobCategoryId") {
         next.jobIds = [];
-        if (value !== null) {
-          get().loadJobsByCategory(value as number);
-        }
       }
       return { profileDraft: next };
     });
+    if (field === "jobCategoryId" && value !== null) {
+      get().loadJobsByCategory(value as number);
+    }
   },
 
   toggleJobId: (jobId) => {

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -8,9 +8,16 @@ import {
   deleteInterviewDataApi,
   deleteAccountApi,
 } from "../api/settingsApi";
-import type { SettingsData, SettingsProfile, SettingsNotifications } from "../api/settingsApi";
+import type { SettingsData, SettingsProfile, SettingsNotifications, JobCategory, Job } from "../api/settingsApi";
+import { profileApi } from "@/shared/api/profileApi";
 
 export type SettingsPanel = "profile" | "password" | "notifications" | "subscription" | "consent";
+
+interface ProfileDraft {
+  name: string;
+  jobCategoryId: number | null;
+  jobIds: number[];
+}
 
 interface SettingsState {
   data: SettingsData | null;
@@ -21,8 +28,14 @@ interface SettingsState {
   activePanel: SettingsPanel;
   consentBadge: boolean;
 
+  /* 직군/직업 목록 */
+  jobCategories: JobCategory[];
+  jobCategoriesLoading: boolean;
+  availableJobs: Job[];
+  availableJobsLoading: boolean;
+
   /* Draft state for editing */
-  profileDraft: Partial<SettingsProfile>;
+  profileDraft: ProfileDraft;
   notificationsDraft: Partial<SettingsNotifications>;
   passwordDraft: { currentPassword: string; newPassword: string; confirmPassword: string };
   aiDataDraft: boolean | null;
@@ -31,7 +44,10 @@ interface SettingsState {
   fetchSettings: () => Promise<void>;
   setActivePanel: (panel: SettingsPanel) => void;
 
-  setProfileDraft: (field: keyof SettingsProfile, value: string) => void;
+  loadJobCategories: () => Promise<void>;
+  loadJobsByCategory: (jobCategoryId: number) => Promise<void>;
+  setProfileDraftField: <K extends keyof ProfileDraft>(field: K, value: ProfileDraft[K]) => void;
+  toggleJobId: (jobId: number) => void;
   saveProfile: () => Promise<void>;
   resetProfileDraft: () => void;
 
@@ -52,6 +68,8 @@ interface SettingsState {
   clearMessage: () => void;
 }
 
+const EMPTY_PROFILE_DRAFT: ProfileDraft = { name: "", jobCategoryId: null, jobIds: [] };
+
 export const useSettingsStore = create<SettingsState>()((set, get) => ({
   data: null,
   loading: false,
@@ -61,7 +79,12 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   activePanel: "profile",
   consentBadge: true,
 
-  profileDraft: {},
+  jobCategories: [],
+  jobCategoriesLoading: false,
+  availableJobs: [],
+  availableJobsLoading: false,
+
+  profileDraft: EMPTY_PROFILE_DRAFT,
   notificationsDraft: {},
   passwordDraft: { currentPassword: "", newPassword: "", confirmPassword: "" },
   aiDataDraft: null,
@@ -70,13 +93,22 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     set({ loading: true, error: null });
     const res = await fetchSettingsApi();
     if (res.success && res.data) {
+      const profile = res.data.profile;
       set({
         data: res.data,
         loading: false,
-        profileDraft: { ...res.data.profile },
+        profileDraft: {
+          name: profile.name,
+          jobCategoryId: profile.jobCategoryId,
+          jobIds: profile.jobIds,
+        },
         notificationsDraft: { ...res.data.notifications },
         aiDataDraft: res.data.consents.aiDataAgreed,
       });
+      // 프로필에 직군이 있으면 해당 직군의 직업 목록을 미리 로드
+      if (profile.jobCategoryId) {
+        get().loadJobsByCategory(profile.jobCategoryId);
+      }
     } else {
       set({ error: res.error ?? "설정을 불러오지 못했습니다.", loading: false });
     }
@@ -87,28 +119,81 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (panel === "consent") set({ consentBadge: false });
   },
 
-  setProfileDraft: (field, value) => {
+  loadJobCategories: async () => {
+    if (get().jobCategories.length > 0) return;
+    set({ jobCategoriesLoading: true });
+    try {
+      const res = await profileApi.getJobCategories();
+      set({ jobCategories: res.results, jobCategoriesLoading: false });
+    } catch {
+      set({ jobCategoriesLoading: false });
+    }
+  },
+
+  loadJobsByCategory: async (jobCategoryId) => {
+    set({ availableJobsLoading: true, availableJobs: [] });
+    try {
+      const res = await profileApi.getJobsByCategory(jobCategoryId);
+      set({ availableJobs: res.results, availableJobsLoading: false });
+    } catch {
+      set({ availableJobsLoading: false });
+    }
+  },
+
+  setProfileDraftField: (field, value) => {
     set((s) => {
-      const newDraft = { ...s.profileDraft, [field]: value };
-      // 직군 변경 시 직업도 초기화
-      if (field === "jobCategory") {
-        newDraft.jobTitle = "";
+      const next = { ...s.profileDraft, [field]: value } as ProfileDraft;
+      // 직군 변경 시 직업 선택 초기화
+      if (field === "jobCategoryId") {
+        next.jobIds = [];
+        if (value !== null) {
+          get().loadJobsByCategory(value as number);
+        }
       }
-      return { profileDraft: newDraft };
+      return { profileDraft: next };
+    });
+  },
+
+  toggleJobId: (jobId) => {
+    set((s) => {
+      const ids = s.profileDraft.jobIds;
+      const next = ids.includes(jobId) ? ids.filter((id) => id !== jobId) : [...ids, jobId];
+      return { profileDraft: { ...s.profileDraft, jobIds: next } };
     });
   },
 
   saveProfile: async () => {
+    const { profileDraft } = get();
+    if (!profileDraft.jobCategoryId) {
+      set({ error: "직군을 선택해주세요." });
+      return;
+    }
     set({ saving: true, error: null, saveMessage: null });
-    const res = await updateProfileApi(get().profileDraft);
+    const res = await updateProfileApi({
+      jobCategoryId: profileDraft.jobCategoryId,
+      jobIds: profileDraft.jobIds,
+    });
     if (res.success) {
-      set((s) => ({
-        saving: false,
-        saveMessage: res.message,
-        data: s.data
-          ? { ...s.data, profile: { ...s.data.profile, ...s.profileDraft } as SettingsProfile }
-          : s.data,
-      }));
+      // 로컬 data 업데이트
+      set((s) => {
+        if (!s.data) return { saving: false, saveMessage: res.message };
+        const selectedCategory = s.jobCategories.find((c) => c.id === profileDraft.jobCategoryId) ?? null;
+        const selectedJobs = s.availableJobs.filter((j) => profileDraft.jobIds.includes(j.id));
+        return {
+          saving: false,
+          saveMessage: res.message,
+          data: {
+            ...s.data,
+            profile: {
+              ...s.data.profile,
+              jobCategoryId: profileDraft.jobCategoryId,
+              jobCategory: selectedCategory,
+              jobIds: profileDraft.jobIds,
+              jobs: selectedJobs,
+            } as SettingsProfile,
+          },
+        };
+      });
     } else {
       set({ saving: false, error: res.message });
     }
@@ -116,7 +201,16 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   resetProfileDraft: () => {
     const data = get().data;
-    if (data) set({ profileDraft: { ...data.profile }, saveMessage: null });
+    if (data) {
+      set({
+        profileDraft: {
+          name: data.profile.name,
+          jobCategoryId: data.profile.jobCategoryId,
+          jobIds: data.profile.jobIds,
+        },
+        saveMessage: null,
+      });
+    }
   },
 
   setPasswordDraft: (field, value) => {
@@ -147,10 +241,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   toggleNotification: (key) => {
     set((s) => ({
-      notificationsDraft: {
-        ...s.notificationsDraft,
-        [key]: !s.notificationsDraft[key],
-      },
+      notificationsDraft: { ...s.notificationsDraft, [key]: !s.notificationsDraft[key] },
     }));
   },
 
@@ -185,9 +276,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       set((s) => ({
         saving: false,
         saveMessage: res.message,
-        data: s.data
-          ? { ...s.data, consents: { ...s.data.consents, aiDataAgreed } }
-          : s.data,
+        data: s.data ? { ...s.data, consents: { ...s.data.consents, aiDataAgreed } } : s.data,
       }));
     } else {
       set({ saving: false, error: res.message });

--- a/src/pages/landing/ui/LandingPage.tsx
+++ b/src/pages/landing/ui/LandingPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { Navbar } from "@/widgets/landing-navbar";
 import { HeroSection } from "./HeroSection";
 import { StatsSection } from "./StatsSection";
@@ -9,8 +11,24 @@ import { PricingSection } from "./PricingSection";
 import { WhySection } from "./WhySection";
 import { CtaSection } from "./CtaSection";
 import { FooterSection } from "./FooterSection";
+import { useAuthStore } from "@/features/auth";
 
 export function LandingPage() {
+  const navigate = useNavigate();
+  const { user, authReady } = useAuthStore();
+
+  useEffect(() => {
+    if (!authReady || !user) return;
+    // 이미 로그인된 사용자를 적절한 화면으로 리다이렉트
+    if (!user.isEmailConfirmed) {
+      navigate("/verify-email", { replace: true });
+    } else if (!user.isProfileCompleted) {
+      navigate("/onboarding", { replace: true });
+    } else {
+      navigate("/home", { replace: true });
+    }
+  }, [authReady, user, navigate]);
+
   return (
     <>
       <Navbar />

--- a/src/pages/login/ui/LoginPage.tsx
+++ b/src/pages/login/ui/LoginPage.tsx
@@ -31,8 +31,10 @@ export function LoginPage() {
     if (result.success) {
       if (result.isEmailConfirmed === false) {
         navigate("/verify-email");
-      } else {
+      } else if (result.isProfileCompleted === false) {
         navigate("/onboarding");
+      } else {
+        navigate("/home");
       }
     }
   };

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -1,25 +1,24 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "@/features/auth";
-import {
-  useOnboardingStore,
-  JOB_CATEGORIES,
-  JOB_STATUS_OPTIONS,
-} from "@/features/onboarding";
+import { useOnboardingStore, JOB_STATUS_OPTIONS } from "@/features/onboarding";
 
 export function OnboardingPage() {
   const navigate = useNavigate();
   const { pendingEmail } = useAuthStore();
   const {
-    selectedJob,
-    jobTitles,
-    jobTitleOptions,
-    jobTitlesLoading,
+    jobCategories,
+    jobCategoriesLoading,
+    selectedJobCategoryId,
+    availableJobs,
+    availableJobsLoading,
+    selectedJobIds,
     jobStatus,
     isLoading,
     error,
-    selectJob,
-    toggleJobTitle,
+    loadJobCategories,
+    selectJobCategory,
+    toggleJobId,
     setJobStatus,
     submitProfile,
     clearError,
@@ -33,11 +32,19 @@ export function OnboardingPage() {
   const acRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const filtered = jobTitleOptions.filter(
-    (o) =>
-      o.label.toLowerCase().includes(acFilter.toLowerCase()) &&
-      !jobTitles.includes(o.label)
+  useEffect(() => {
+    loadJobCategories();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const filteredJobs = availableJobs.filter(
+    (j) =>
+      j.name.toLowerCase().includes(acFilter.toLowerCase()) &&
+      !selectedJobIds.includes(j.id)
   );
+
+  // 선택된 직업 이름 조회 헬퍼
+  const getJobName = (jobId: number) =>
+    availableJobs.find((j) => j.id === jobId)?.name ?? String(jobId);
 
   // 외부 클릭 시 닫기
   useEffect(() => {
@@ -50,30 +57,23 @@ export function OnboardingPage() {
     return () => document.removeEventListener("mousedown", handler);
   }, []);
 
-  const handleSelectTitle = useCallback(
-    (label: string) => {
-      toggleJobTitle(label);
+  const handleSelectJob = useCallback(
+    (jobId: number) => {
+      toggleJobId(jobId);
       setAcFilter("");
       setAcOpen(false);
     },
-    [toggleJobTitle]
-  );
-
-  const handleRemoveTitle = useCallback(
-    (label: string) => {
-      toggleJobTitle(label);
-    },
-    [toggleJobTitle]
+    [toggleJobId]
   );
 
   const filledCount =
-    (selectedJob ? 1 : 0) + (jobTitles.length > 0 ? 1 : 0);
+    (selectedJobCategoryId !== null ? 1 : 0) + (selectedJobIds.length > 0 ? 1 : 0);
   const progress = Math.round((filledCount / 2) * 100);
 
   const handleSubmit = async () => {
     clearError();
     const ok = await submitProfile();
-    if (ok) navigate("/interview");
+    if (ok) navigate("/home");
   };
 
   return (
@@ -125,8 +125,8 @@ export function OnboardingPage() {
           {/* Steps - 모바일에서는 숨김 */}
           <div className="hidden md:flex md:flex-col md:gap-2 w-full">
             {[
-              { done: true, num: null, name: "이메일로 계정 생성", sub: "완료" },
-              { done: true, num: null, name: "이메일 인증 완료", sub: "완료" },
+              { done: true, name: "이메일로 계정 생성", sub: "완료" },
+              { done: true, name: "이메일 인증 완료", sub: "완료" },
             ].map((step, i) => (
               <div key={i} className="flex flex-row items-center gap-[14px] text-left px-5 py-[14px] rounded-lg opacity-60">
                 <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#059669] shrink-0">
@@ -168,44 +168,48 @@ export function OnboardingPage() {
               />
             </div>
 
-            {/* Job categories — 단일 선택 */}
+            {/* 직군 선택 */}
             <label className="block text-[14px] font-bold text-[#0A0A0A] mb-2">희망 직군</label>
-            <div className="flex flex-wrap gap-2 mb-6">
-              {JOB_CATEGORIES.map((cat) => (
-                <button
-                  key={cat.id}
-                  type="button"
-                  className={`inline-flex items-center gap-[6px] px-4 py-[9px] font-inter text-[13px] font-semibold rounded-lg cursor-pointer transition-all duration-200 whitespace-nowrap border ${
-                    selectedJob === cat.id
-                      ? "bg-[#E6F7FA] border-[#0991B2] text-[#0991B2]"
-                      : "bg-white border-[#E5E7EB] text-[#374151] hover:border-[#0991B2] hover:text-[#0991B2]"
-                  }`}
-                  onClick={() => selectJob(cat.id)}
-                  aria-pressed={selectedJob === cat.id}
-                >
-                  <span className="text-[14px]">{cat.emoji}</span>
-                  {cat.label}
-                </button>
-              ))}
-            </div>
+            {jobCategoriesLoading ? (
+              <p className="text-[13px] text-[#9CA3AF] mb-6">직군 목록 불러오는 중...</p>
+            ) : (
+              <div className="flex flex-wrap gap-2 mb-6">
+                {jobCategories.map((cat) => (
+                  <button
+                    key={cat.id}
+                    type="button"
+                    className={`inline-flex items-center gap-[6px] px-4 py-[9px] font-inter text-[13px] font-semibold rounded-lg cursor-pointer transition-all duration-200 whitespace-nowrap border ${
+                      selectedJobCategoryId === cat.id
+                        ? "bg-[#E6F7FA] border-[#0991B2] text-[#0991B2]"
+                        : "bg-white border-[#E5E7EB] text-[#374151] hover:border-[#0991B2] hover:text-[#0991B2]"
+                    }`}
+                    onClick={() => selectJobCategory(cat.id)}
+                    aria-pressed={selectedJobCategoryId === cat.id}
+                  >
+                    <span className="text-[14px]">{cat.emoji}</span>
+                    {cat.name}
+                  </button>
+                ))}
+              </div>
+            )}
 
             {/* 희망 직업 — 자동완성 (1~3개) */}
             <label className="block text-[14px] font-bold text-[#0A0A0A] mb-2">
               희망 직업
-              <span className="text-[12px] font-semibold text-[#9CA3AF]"> ({jobTitles.length}/3)</span>
+              <span className="text-[12px] font-semibold text-[#9CA3AF]"> ({selectedJobIds.length}/3)</span>
             </label>
 
             {/* 선택된 직업 태그 */}
-            {jobTitles.length > 0 && (
+            {selectedJobIds.length > 0 && (
               <div className="flex flex-wrap gap-[6px] mb-2">
-                {jobTitles.map((t) => (
-                  <span key={t} className="inline-flex items-center gap-1 px-3 py-[6px] text-[13px] font-semibold text-[#0991B2] bg-[#E6F7FA] border border-[#0991B2] rounded-lg">
-                    {t}
+                {selectedJobIds.map((id) => (
+                  <span key={id} className="inline-flex items-center gap-1 px-3 py-[6px] text-[13px] font-semibold text-[#0991B2] bg-[#E6F7FA] border border-[#0991B2] rounded-lg">
+                    {getJobName(id)}
                     <button
                       type="button"
                       className="inline-flex items-center justify-center w-4 h-4 p-0 text-[14px] leading-none text-[#0991B2] bg-none border-none cursor-pointer rounded-full transition-[background] duration-150 hover:bg-[rgba(9,145,178,0.15)]"
-                      onClick={() => handleRemoveTitle(t)}
-                      aria-label={`${t} 제거`}
+                      onClick={() => toggleJobId(id)}
+                      aria-label={`${getJobName(id)} 제거`}
                     >
                       ×
                     </button>
@@ -220,44 +224,44 @@ export function OnboardingPage() {
                 type="text"
                 className="w-full py-[14px] px-4 font-inter text-[15px] text-[#0A0A0A] bg-white border border-[#E5E7EB] rounded-lg outline-none transition-[border-color] duration-200 placeholder-[#D1D5DB] focus:border-[#0991B2] disabled:bg-[#F3F4F6] disabled:cursor-not-allowed"
                 placeholder={
-                  !selectedJob
+                  selectedJobCategoryId === null
                     ? "먼저 희망 직군을 선택해주세요"
-                    : jobTitlesLoading
+                    : availableJobsLoading
                       ? "직업 목록 불러오는 중..."
-                      : jobTitles.length >= 3
+                      : selectedJobIds.length >= 3
                         ? "최대 3개까지 선택 가능합니다"
                         : "직업을 검색하세요"
                 }
                 value={acFilter}
-                disabled={!selectedJob || jobTitlesLoading || jobTitles.length >= 3}
+                disabled={selectedJobCategoryId === null || availableJobsLoading || selectedJobIds.length >= 3}
                 onChange={(e) => {
                   setAcFilter(e.target.value);
                   setAcOpen(true);
                 }}
                 onFocus={() => {
-                  if (selectedJob && !jobTitlesLoading && jobTitles.length < 3) setAcOpen(true);
+                  if (selectedJobCategoryId !== null && !availableJobsLoading && selectedJobIds.length < 3) setAcOpen(true);
                 }}
                 aria-label="희망 직업"
                 autoComplete="off"
               />
-              {acOpen && filtered.length > 0 && (
+              {acOpen && filteredJobs.length > 0 && (
                 <ul className="absolute top-full left-0 right-0 mt-1 py-[6px] bg-white border border-[#E5E7EB] rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.08)] list-none max-h-[200px] overflow-y-auto z-10" role="listbox">
-                  {filtered.map((opt) => (
+                  {filteredJobs.map((job) => (
                     <li
-                      key={opt.id}
-                      className="px-4 py-[10px] text-[14px] text-[#374151] cursor-pointer transition-[background] duration-150 hover:bg-[#E6F7FA] hover:text-[#0991B2] aria-selected:bg-[#E6F7FA] aria-selected:text-[#0991B2] aria-selected:font-semibold"
+                      key={job.id}
+                      className="px-4 py-[10px] text-[14px] text-[#374151] cursor-pointer transition-[background] duration-150 hover:bg-[#E6F7FA] hover:text-[#0991B2]"
                       role="option"
-                      aria-selected={jobTitles.includes(opt.label)}
-                      onClick={() => handleSelectTitle(opt.label)}
+                      aria-selected={selectedJobIds.includes(job.id)}
+                      onClick={() => handleSelectJob(job.id)}
                     >
-                      {opt.label}
+                      {job.name}
                     </li>
                   ))}
                 </ul>
               )}
             </div>
 
-            {/* Job status */}
+            {/* 현재 직업 상태 */}
             <label className="block text-[14px] font-bold text-[#0A0A0A] mb-2">현재 직업 상태</label>
             <div className="relative mb-6">
               <select

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -73,7 +73,10 @@ export function OnboardingPage() {
   const handleSubmit = async () => {
     clearError();
     const ok = await submitProfile();
-    if (ok) navigate("/home");
+    if (ok) {
+      await useAuthStore.getState().fetchMe();
+      navigate("/home");
+    }
   };
 
   return (

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -30,8 +30,10 @@ export function SettingsPage() {
   const {
     data, loading, saving, error, saveMessage, activePanel, consentBadge,
     profileDraft, notificationsDraft, passwordDraft, aiDataDraft,
+    jobCategories, jobCategoriesLoading, availableJobs, availableJobsLoading,
     fetchSettings, setActivePanel,
-    setProfileDraft, saveProfile, resetProfileDraft,
+    loadJobCategories,
+    setProfileDraftField, toggleJobId, saveProfile, resetProfileDraft,
     setPasswordDraft, savePassword, resetPasswordDraft,
     toggleNotification, saveNotifications, resetNotificationsDraft,
     setAiDataDraft, saveConsents,
@@ -44,7 +46,8 @@ export function SettingsPage() {
 
   useEffect(() => {
     fetchSettings();
-  }, [fetchSettings]);
+    loadJobCategories();
+  }, [fetchSettings, loadJobCategories]);
 
   useEffect(() => {
     if (saveMessage) {
@@ -192,7 +195,7 @@ export function SettingsPage() {
                           type="text"
                           className={inputClass}
                           value={profileDraft.name ?? ""}
-                          onChange={(e) => setProfileDraft("name", e.target.value)}
+                          onChange={(e) => setProfileDraftField("name", e.target.value)}
                           placeholder="이름을 입력하세요"
                         />
                       </div>
@@ -201,33 +204,66 @@ export function SettingsPage() {
                         <input type="email" className={inputClass} value={data.profile.email} readOnly />
                         <p className="text-[11px] text-[#6B7280] leading-[1.45]">이메일 주소는 변경할 수 없습니다. 고객센터로 문의해주세요.</p>
                       </div>
-                      <div className="grid grid-cols-2 gap-3 max-[640px]:grid-cols-1">
+                      <div className="flex flex-col gap-4">
+                        {/* 직군 선택 */}
                         <div className="flex flex-col gap-[5px]">
                           <label className="font-inter text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px] flex items-center gap-1">
                             희망 직군 <span className="text-[#EF4444] text-[10px]">*</span>
                           </label>
-                          <select
-                            className={selectClass}
-                            value={profileDraft.jobCategory ?? ""}
-                            onChange={(e) => setProfileDraft("jobCategory", e.target.value)}
-                          >
-                            {["IT/개발","마케팅/광고","금융/회계","의료/간호","교육","영업","디자인","기획/전략","HR/인사","기타"].map((v) => (
-                              <option key={v}>{v}</option>
-                            ))}
-                          </select>
+                          {jobCategoriesLoading ? (
+                            <div className="text-[12px] text-[#9CA3AF] py-2">직군 목록 불러오는 중...</div>
+                          ) : (
+                            <select
+                              className={selectClass}
+                              value={profileDraft.jobCategoryId ?? ""}
+                              onChange={(e) => {
+                                const id = e.target.value ? Number(e.target.value) : null;
+                                setProfileDraftField("jobCategoryId", id);
+                              }}
+                            >
+                              <option value="">직군을 선택하세요</option>
+                              {jobCategories.map((cat) => (
+                                <option key={cat.id} value={cat.id}>
+                                  {cat.emoji} {cat.name}
+                                </option>
+                              ))}
+                            </select>
+                          )}
                           <p className="text-[11px] text-[#6B7280] leading-[1.45]">면접 질문 생성에 반영됩니다</p>
                         </div>
-                        <div className="flex flex-col gap-[5px]">
-                          <label className="font-inter text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px]">현재 직업 / 직책</label>
-                          <input
-                            type="text"
-                            className={inputClass}
-                            value={profileDraft.jobTitle ?? ""}
-                            onChange={(e) => setProfileDraft("jobTitle", e.target.value)}
-                            placeholder="직업 또는 직책"
-                          />
-                          <p className="text-[11px] text-[#6B7280] leading-[1.45]">면접 맥락 설정에 활용됩니다</p>
-                        </div>
+
+                        {/* 직업 다중 선택 */}
+                        {profileDraft.jobCategoryId && (
+                          <div className="flex flex-col gap-[5px]">
+                            <label className="font-inter text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px]">
+                              직업 선택 <span className="text-[11px] font-normal text-[#6B7280]">(복수 선택 가능)</span>
+                            </label>
+                            {availableJobsLoading ? (
+                              <div className="text-[12px] text-[#9CA3AF]">직업 목록 불러오는 중...</div>
+                            ) : (
+                              <div className="grid grid-cols-2 gap-2 max-[640px]:grid-cols-1">
+                                {availableJobs.map((job) => {
+                                  const isSelected = profileDraft.jobIds.includes(job.id);
+                                  return (
+                                    <button
+                                      key={job.id}
+                                      type="button"
+                                      onClick={() => toggleJobId(job.id)}
+                                      className={`text-left text-[12px] font-semibold px-3 py-2 rounded-lg border-[1.5px] transition-all ${
+                                        isSelected
+                                          ? "border-[#0991B2] bg-[#E6F7FA] text-[#0991B2]"
+                                          : "border-[#E5E7EB] bg-[#F9FAFB] text-[#374151] hover:border-[#0991B2]"
+                                      }`}
+                                    >
+                                      {isSelected ? "✓ " : ""}{job.name}
+                                    </button>
+                                  );
+                                })}
+                              </div>
+                            )}
+                            <p className="text-[11px] text-[#6B7280] leading-[1.45]">면접 맥락 설정에 활용됩니다</p>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -38,21 +38,26 @@ export async function apiRequest<T>(
 }
 
 /* ── Path validation ── */
-function validateApiPath(path: string): string {
+function validateApiPath(path: string): { pathname: string; search: string } {
+  // Parse relative path using a dummy base to extract pathname vs query string
+  const parsed = new URL(path, "http://dummy");
+  const pathname = parsed.pathname;
+  const search = parsed.search;
+
   // Only allow paths starting with /api/
-  if (!path.startsWith("/api/")) {
+  if (!pathname.startsWith("/api/")) {
     throw new Error(`Invalid API path: ${path}. Must start with /api/`);
   }
 
-  // Sanitize path: remove any potentially dangerous characters
-  const safePath = path.replace(/[^/a-zA-Z0-9._~:-]/g, "");
-  
+  // Sanitize pathname only (query string is handled by URL parser)
+  const safePath = pathname.replace(/[^/a-zA-Z0-9._~:-]/g, "");
+
   // Prevent path traversal attacks
   if (safePath.includes("..") || safePath.includes("//")) {
     throw new Error(`Invalid API path: path traversal detected`);
   }
 
-  return safePath;
+  return { pathname: safePath, search };
 }
 
 async function _request<T>(
@@ -73,11 +78,12 @@ async function _request<T>(
   }
 
   // Validate and sanitize the path
-  const safePath = validateApiPath(path);
+  const { pathname, search } = validateApiPath(path);
 
   // Construct URL using only trusted base URL and validated path
   const endpoint = new URL(BASE_URL);
-  endpoint.pathname = safePath;
+  endpoint.pathname = pathname;
+  endpoint.search = search;
 
   const res = await fetch(endpoint.toString(), { ...fetchOptions, headers });
 
@@ -111,15 +117,33 @@ async function _request<T>(
 }
 
 /* ── Token refresh helper ── */
-export async function refreshAccessToken(): Promise<boolean> {
+
+// 동시에 여러 요청이 401을 받아도 refresh는 한 번만 실행되도록 뮤텍스
+let _refreshPromise: Promise<boolean> | null = null;
+
+export function refreshAccessToken(): Promise<boolean> {
+  if (_refreshPromise) return _refreshPromise;
+  _refreshPromise = _doRefresh().finally(() => {
+    _refreshPromise = null;
+  });
+  return _refreshPromise;
+}
+
+async function _doRefresh(): Promise<boolean> {
   const refresh = getRefreshToken();
   if (!refresh) return false;
   try {
-    const res = await apiRequest<{ access: string }>(
-      "/api/v1/users/tokens/refresh/",
-      { method: "POST", body: JSON.stringify({ refresh }) }
-    );
-    setTokens(res.access, refresh);
+    const res = await fetch(new URL("/api/v1/users/tokens/refresh/", BASE_URL).toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh }),
+    });
+    if (!res.ok) {
+      clearTokens();
+      return false;
+    }
+    const data = await res.json() as { access: string; refresh?: string };
+    setTokens(data.access, data.refresh ?? refresh);
     return true;
   } catch {
     clearTokens();

--- a/src/shared/api/profileApi.ts
+++ b/src/shared/api/profileApi.ts
@@ -1,0 +1,52 @@
+import { apiRequest } from "./client";
+
+export interface JobCategory {
+  id: number;
+  emoji: string;
+  name: string;
+}
+
+export interface Job {
+  id: number;
+  name: string;
+}
+
+export interface UserProfile {
+  id: number;
+  user: number;
+  jobCategory: JobCategory;
+  jobs: Job[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SaveProfileParams {
+  jobCategoryId: number;
+  jobIds: number[];
+}
+
+export interface PaginatedJobCategories {
+  count: number;
+  totalPagesCount: number;
+  results: JobCategory[];
+}
+
+export const profileApi = {
+  getJobCategories: () =>
+    apiRequest<PaginatedJobCategories>("/api/v1/job-categories/?per_page=100"),
+
+  getJobsByCategory: (jobCategoryId: number) =>
+    apiRequest<{ count: number; results: Job[] }>(
+      `/api/v1/job-categories/${jobCategoryId}/jobs/?per_page=100`
+    ),
+
+  getMyProfile: () =>
+    apiRequest<UserProfile>("/api/v1/profiles/me/", { auth: true }),
+
+  saveMyProfile: (params: SaveProfileParams) =>
+    apiRequest<UserProfile>("/api/v1/profiles/me/", {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify({ jobCategoryId: params.jobCategoryId, jobIds: params.jobIds }),
+    }),
+};

--- a/src/widgets/landing-navbar/MobileNav.tsx
+++ b/src/widgets/landing-navbar/MobileNav.tsx
@@ -1,11 +1,11 @@
 import { Link } from "react-router-dom";
 import { useNavbarStore } from "./store";
 import { MobileDrawer } from "./MobileDrawer";
-import { useSessionStore } from "@/entities/session";
+import { useAuthStore } from "@/features/auth";
 
 export function MobileNav() {
   const { isMobileDrawerOpen, toggleDrawer, closeDrawer } = useNavbarStore();
-  const isAuthenticated = useSessionStore((s) => s.isAuthenticated);
+  const isAuthenticated = useAuthStore((s) => s.user !== null);
 
   return (
     <>

--- a/src/widgets/landing-navbar/NavPill.tsx
+++ b/src/widgets/landing-navbar/NavPill.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { useSessionStore } from "@/entities/session";
+import { useAuthStore } from "@/features/auth";
 
 const NAV_LINKS = [
   { label: "서비스 소개", href: "#hero" },
@@ -11,7 +11,8 @@ const NAV_LINKS = [
 
 export function NavPill() {
   const [scrolled, setScrolled] = useState(false);
-  const isAuthenticated = useSessionStore((s) => s.isAuthenticated);
+  const user = useAuthStore((s) => s.user);
+  const isAuthenticated = user !== null;
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -103,7 +104,7 @@ export function NavPill() {
         <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
           {isAuthenticated ? (
             <button
-              onClick={() => navigate("/dashboard")}
+              onClick={() => navigate("/home")}
               style={{
                 fontFamily: "'Inter', sans-serif",
                 fontSize: 14,


### PR DESCRIPTION
## 관련 이슈
Closes #32

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- ProtectedRoute 컴포넌트를 추가하여 인증이 필요한 라우트를 보호하고, 비로그인 시 토스트 메시지와 함께 랜딩 페이지로 리다이렉트 처리
- 앱 초기화 시 initAuth()를 통해 localStorage 토큰 기반 인증 상태를 복원하고, refresh token 동시 요청 방지를 위한 뮤텍스 적용
- 랜딩 페이지에서 로그인 상태에 따라 이메일 인증/온보딩/홈으로 자동 리다이렉트 처리
- 로그인 성공 후 isProfileCompleted 여부에 따라 온보딩 또는 홈으로 라우팅 분기
- 온보딩/설정 페이지의 직군·직업 데이터를 mock에서 실제 백엔드 API(/api/v1/job-categories/, /api/v1/profiles/me/)로 전환
- 랜딩 네비바의 세션 스토어를 useAuthStore로 교체
- profileApi 공유 모듈 신규 추가 (src/shared/api/profileApi.ts)
- apiRequest의 경로 파싱 개선으로 쿼리스트링 파라미터 지원

## 변경 유형
해당하는 항목에 체크해주세요.

- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 비로그인 상태에서 /home, /jd, /settings 등 보호 라우트 접근 시 토스트 메시지 노출 후 랜딩 페이지로 리다이렉트되는지 확인
2. 로그인 후 프로필 미완료 사용자가 /onboarding으로, 완료 사용자가 /home으로 이동하는지 확인
3. 온보딩 페이지에서 백엔드 직군/직업 목록이 정상 로드되고, 프로필 저장이 성공하는지 확인
4. 설정 페이지에서 직군/직업 변경 및 저장이 정상 동작하는지 확인
5. 브라우저 새로고침 시 토큰 기반 인증 상태가 복원되는지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

## 추가 정보
- sonner 패키지를 추가하여 전역 토스트 알림을 지원합니다 (<Toaster /> in App.tsx)
- lucide-react, @mediapipe/tasks-vision 의존성이 추가되었습니다
- refreshAccessToken에 뮤텍스 패턴을 적용하여 동시 401 응답 시 중복 refresh 요청을 방지합니다
- useSessionStore → useAuthStore 마이그레이션으로 인증 상태 관리가 단일 스토어로 통합되었습니다
- 알림/구독/동의 설정은 아직 백엔드 API 미구현 상태로 mock fallback을 유지합니다