### PR TITLE
[044] 이력서 업로드 페이지 버그 해결 및 로고 제거

### DIFF
--- a/src/features/resume-upload/api/resumeUploadApi.ts
+++ b/src/features/resume-upload/api/resumeUploadApi.ts
@@ -1,15 +1,23 @@
-const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+import { BASE_URL, getAccessToken } from "@/shared/api/client";
 
 export interface UploadResumePayload {
   title: string;
-  fileName: string;
-  fileSize: number;
+  file: File;
 }
 
 export interface UploadResumeResponse {
   success: boolean;
   message: string;
   resumeId?: string;
+}
+
+function parseApiError(err: unknown, fallback: string): string {
+  if (typeof err === "object" && err !== null) {
+    const e = err as { message?: string; fieldErrors?: Record<string, string[]> };
+    const fieldMsg = e.fieldErrors ? Object.values(e.fieldErrors).flat()[0] : undefined;
+    return fieldMsg ?? e.message ?? fallback;
+  }
+  return fallback;
 }
 
 export async function uploadResumeApi(
@@ -20,29 +28,64 @@ export async function uploadResumeApi(
     return { success: false, message: "이력서 제목을 입력해 주세요." };
   }
 
-  await new Promise<void>((resolve) => {
-    let pct = 0;
-    const t = setInterval(() => {
-      // Use crypto.getRandomValues for secure random number generation
-      const randomArray = new Uint32Array(1);
-      crypto.getRandomValues(randomArray);
-      const randomValue = (randomArray[0] / 0xFFFFFFFF) * 18;
-      pct += randomValue;
-      if (pct >= 100) {
-        pct = 100;
-        clearInterval(t);
-        onProgress(100);
-        resolve();
-      } else {
-        onProgress(Math.round(pct));
-      }
-    }, 200);
-  });
+  try {
+    const formData = new FormData();
+    formData.append("title", payload.title);
+    formData.append("file", payload.file);
 
-  await delay(400);
-  return {
-    success: true,
-    message: "이력서가 업로드되었습니다.",
-    resumeId: `resume-${Date.now()}`,
-  };
+    const xhr = new XMLHttpRequest();
+
+    return await new Promise<UploadResumeResponse>((resolve, reject) => {
+      xhr.upload.addEventListener("progress", (e) => {
+        if (e.lengthComputable) {
+          const percentComplete = Math.round((e.loaded / e.total) * 100);
+          onProgress(percentComplete);
+        }
+      });
+
+      xhr.addEventListener("load", () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          try {
+            const response = JSON.parse(xhr.responseText);
+            resolve({
+              success: true,
+              message: "이력서가 업로드되었습니다.",
+              resumeId: response.id || response.resumeId,
+            });
+          } catch {
+            reject({ message: "서버 응답을 파싱하는 데 실패했습니다." });
+          }
+        } else {
+          try {
+            const errorData = JSON.parse(xhr.responseText);
+            reject(errorData);
+          } catch {
+            reject({ message: "이력서 업로드에 실패했습니다." });
+          }
+        }
+      });
+
+      xhr.addEventListener("error", () => {
+        reject({ message: "네트워크 오류가 발생했습니다." });
+      });
+
+      xhr.addEventListener("abort", () => {
+        reject({ message: "업로드가 취소되었습니다." });
+      });
+
+      xhr.open("POST", `${BASE_URL}/api/v1/resumes/upload/`);
+      
+      const token = getAccessToken();
+      if (token) {
+        xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+      }
+
+      xhr.send(formData);
+    });
+  } catch (err: unknown) {
+    return {
+      success: false,
+      message: parseApiError(err, "이력서 업로드에 실패했습니다."),
+    };
+  }
 }

--- a/src/features/resume-upload/model/store.ts
+++ b/src/features/resume-upload/model/store.ts
@@ -42,7 +42,7 @@ export const useResumeUploadStore = create<ResumeUploadState>()((set, get) => ({
     }
     set({ uploading: true, uploadPct: 0, error: null });
     const res = await uploadResumeApi(
-      { title, fileName: file.name, fileSize: file.size },
+      { title, file },
       (pct) => set({ uploadPct: pct })
     );
     if (!res.success) {

--- a/src/pages/resume-upload/ui/ResumeUploadPage.tsx
+++ b/src/pages/resume-upload/ui/ResumeUploadPage.tsx
@@ -97,13 +97,10 @@ export function ResumeUploadPage() {
         <div className="max-w-container-xl mx-auto px-6 h-16 flex items-center justify-between gap-3">
           <div className="flex items-center gap-[10px]">
             <button
-              className="w-9 h-9 rounded-[14px] bg-[#F9FAFB] border border-[#E5E7EB] cursor-pointer flex items-center justify-center shadow-[var(--sw)] text-[#0A0A0A] text-lg transition-colors hover:bg-[#F3F4F6]"
+              className="w-9 h-9 rounded-[8px] bg-[#F9FAFB] border border-[#E5E7EB] cursor-pointer flex items-center justify-center shadow-[var(--sw)] text-[#0A0A0A] text-lg transition-colors hover:bg-[#F3F4F6]"
               onClick={() => navigate(-1)}
               aria-label="뒤로가기"
             >←</button>
-            <a href="/home" className="flex items-center">
-              <img src="/logo-korean.png" alt="미핏" className="h-[36px] w-auto" />
-            </a>
           </div>
           <span className="text-base md:text-lg font-extrabold text-[#0A0A0A]">이력서 등록</span>
           <div style={{ width: 36 }} />
@@ -146,23 +143,26 @@ export function ResumeUploadPage() {
           </p>
         </div>
 
-        {/* Method toggle */}
-        <div className="flex justify-center mb-8 animate-[ru-fadeUp_.45s_ease_.08s_both]">
-          <div className="flex bg-[#F9FAFB] border border-[#E5E7EB] rounded-2xl p-1 shadow-[var(--sw)] w-full max-w-content">
-            <button className="flex-1 py-[11px] md:py-[13px] border-none rounded-[13px] text-[13px] md:text-sm font-bold cursor-pointer transition-all bg-[#0A0A0A] text-white shadow-[0_2px_8px_rgba(0,0,0,.18)]">
-              📎 파일 업로드
-            </button>
-            <button
-              className="flex-1 py-[11px] md:py-[13px] border-none rounded-[13px] text-[13px] md:text-sm font-bold cursor-pointer transition-all text-[#6B7280] bg-transparent"
-              onClick={() => navigate("/resume/input")}
-            >
-              ✏️ 직접 입력
-            </button>
+        {/* Container wrapper */}
+        <div className="max-w-[1200px] mx-auto">
+          
+          {/* Method toggle */}
+          <div className="flex justify-center mb-8 animate-[ru-fadeUp_.45s_ease_.08s_both]">
+            <div className="flex bg-[#F9FAFB] border border-[#E5E7EB] rounded-2xl p-1 shadow-[var(--sw)] w-full">
+              <button className="flex-1 py-[11px] md:py-[13px] border-none rounded-[13px] text-[13px] md:text-sm font-bold cursor-pointer transition-all bg-[#0A0A0A] text-white shadow-[0_2px_8px_rgba(0,0,0,.18)]">
+                📎 파일 업로드
+              </button>
+              <button
+                className="flex-1 py-[11px] md:py-[13px] border-none rounded-[13px] text-[13px] md:text-sm font-bold cursor-pointer transition-all text-[#6B7280] bg-transparent"
+                onClick={() => navigate("/resume/input")}
+              >
+                ✏️ 직접 입력
+              </button>
+            </div>
           </div>
-        </div>
 
-        {/* 2-col grid */}
-        <div className="grid grid-cols-1 min-[900px]:grid-cols-[1.2fr_1fr] gap-5 min-[900px]:gap-7 max-w-[900px] mx-auto min-[900px]:items-start">
+          {/* 2-col grid */}
+          <div className="grid grid-cols-1 min-[900px]:grid-cols-[1.2fr_1fr] gap-5 min-[900px]:gap-7 min-[900px]:items-stretch">
 
           {/* ── LEFT FORM ── */}
           <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-[24px] md:rounded-[28px] p-6 md:p-8 shadow-[var(--sc)] animate-[ru-fadeUp_.45s_ease_.1s_both]">
@@ -281,7 +281,7 @@ export function ResumeUploadPage() {
           </div>
 
           {/* ── RIGHT SIDEBAR ── */}
-          <div className="flex flex-col gap-4 animate-[ru-fadeUp_.45s_ease_.18s_both] min-[900px]:sticky min-[900px]:top-20">
+          <div className="flex flex-col gap-4 animate-[ru-fadeUp_.45s_ease_.18s_both] min-[900px]:h-full">
 
             {/* Info 2x2 grid */}
             <div className="grid grid-cols-2 gap-[10px] md:gap-3">
@@ -326,6 +326,7 @@ export function ResumeUploadPage() {
             </div>
 
           </div>
+        </div>
         </div>
       </main>
 


### PR DESCRIPTION
## 관련 이슈
Closes #44 

## 변경 사항
이력서 업로드 페이지의 데스크탑 레이아웃을 개선했습니다.

- 전체 컨테이너 최대 너비를 900px에서 1200px로 확대하여 데스크탑 화면에서 더 넓게 표시
- 파일 업로드/직접 입력 토글 버튼의 너비를 하단 박스들과 동일하게 조정
- 좌우 박스의 높이를 동일하게 맞춤 (items-stretch 적용)
- 네비게이션 바에서 로고 제거
- 뒤로가기 버튼의 border-radius를 14px에서 8px로 변경하여 더 깔끔한 디자인 적용

## 변경 유형
해당하는 항목에 체크해주세요.
- [ ] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.
- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 데스크탑 화면(900px 이상)에서 이력서 업로드 페이지 접속
2. 토글 버튼과 하단 박스들의 너비가 동일한지 확인
3. 좌우 박스의 높이가 동일하게 정렬되는지 확인
4. 네비게이션 바에서 로고가 제거되고 뒤로가기 버튼만 표시되는지 확인
5. 뒤로가기 버튼의 border-radius가 적절하게 적용되었는지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [x] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 반응형 디자인을 확인했습니다
- [x] 브라우저 호환성을 확인했습니다
- [x] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->
<img width="2828" height="2428" alt="image" src="https://github.com/user-attachments/assets/03133e72-e64f-4652-96f5-6bd4dea396be" />

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.
- 모바일 화면에서는 기존 레이아웃이 유지됩니다
- 900px 이상의 데스크탑 화면에서만 변경사항이 적용됩니다