### PR TITLE
[018] User API 연결 및 홈 페이지 사용자 이름 표시 개선

### DIFF
--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -1,6 +1,7 @@
 // Home API - Real backend integration with mock fallback
 
 import { apiRequest } from "@/shared/api/client";
+import { userApi } from "@/shared/api/userApi";
 
 const USE_MOCK = true; // Set to false when backend is ready
 
@@ -127,10 +128,31 @@ const MOCK_DATA: HomeData = {
  * GET /api/v1/home/dashboard/
  */
 export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: HomeData; error?: string }> {
-  // Use mock data if backend is not ready
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 400));
-    return { success: true, data: MOCK_DATA };
+  // Fetch real user data
+  try {
+    const userData = await userApi.getMe();
+    
+    // Use mock data if backend is not ready, but with real user name
+    if (USE_MOCK) {
+      await new Promise((r) => setTimeout(r, 400));
+      return { 
+        success: true, 
+        data: {
+          ...MOCK_DATA,
+          user: {
+            ...MOCK_DATA.user,
+            name: userData.name || "사용자",
+          }
+        }
+      };
+    }
+  } catch (error) {
+    console.error("Failed to fetch user data:", error);
+    // Continue with mock data if user fetch fails
+    if (USE_MOCK) {
+      await new Promise((r) => setTimeout(r, 400));
+      return { success: true, data: MOCK_DATA };
+    }
   }
 
   try {

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,3 @@
+export * from "./client";
+export * from "./profileApi";
+export * from "./userApi";

--- a/src/shared/api/userApi.ts
+++ b/src/shared/api/userApi.ts
@@ -1,0 +1,76 @@
+import { apiRequest } from "./client";
+
+/**
+ * 사용자 정보 타입
+ */
+export interface UserMe {
+  name: string;
+  email: string;
+  isEmailConfirmed: boolean;
+  isProfileCompleted: boolean;
+}
+
+/**
+ * 사용자 정보 수정 파라미터
+ */
+export interface UpdateUserParams {
+  name?: string;
+}
+
+/**
+ * 비밀번호 변경 파라미터
+ */
+export interface ChangePasswordParams {
+  currentPassword: string;
+  newPassword: string;
+}
+
+/**
+ * User API
+ * 사용자 정보 조회, 수정, 비밀번호 변경, 계정 삭제 등의 기능 제공
+ */
+export const userApi = {
+  /**
+   * 현재 로그인한 사용자 정보 조회
+   * @returns UserMe 사용자 정보
+   */
+  getMe: () =>
+    apiRequest<UserMe>("/api/v1/users/me/", { auth: true }),
+
+  /**
+   * 사용자 정보 수정
+   * @param params 수정할 사용자 정보
+   * @returns 수정된 사용자 정보
+   */
+  updateMe: (params: UpdateUserParams) =>
+    apiRequest<UserMe>("/api/v1/users/me/", {
+      method: "PATCH",
+      auth: true,
+      body: JSON.stringify(params),
+    }),
+
+  /**
+   * 비밀번호 변경
+   * @param params 현재 비밀번호와 새 비밀번호
+   * @returns 성공 메시지
+   */
+  changePassword: (params: ChangePasswordParams) =>
+    apiRequest<{ message: string }>("/api/v1/users/change-password/", {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify({
+        current_password: params.currentPassword,
+        new_password: params.newPassword,
+      }),
+    }),
+
+  /**
+   * 계정 삭제 (회원 탈퇴)
+   * @returns void
+   */
+  deleteAccount: () =>
+    apiRequest<void>("/api/v1/users/", {
+      method: "DELETE",
+      auth: true,
+    }),
+};


### PR DESCRIPTION
## 관련 이슈
Closes #18 

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- User API 엔드포인트 추가 (getMe, updateMe, changePassword, deleteAccount)
- 홈 페이지에서 실제 로그인한 사용자 이름 표시
- shared/api/index.ts 생성하여 API 모듈 통합 관리

## 변경 유형
해당하는 항목에 체크해주세요.

- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 로그인 후 홈 페이지 접속
2. "안녕하세요, [사용자 이름] 님" 문구에서 실제 로그인한 사용자 이름이 표시되는지 확인
3. API 엔드포인트 확인 (`/api/v1/users/me/`, `/api/v1/users/change-password/` 등)

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [x] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 반응형 디자인을 확인했습니다
- [x] 브라우저 호환성을 확인했습니다
- [x] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
홈 페이지에서 "안녕하세요, 김현준 님" (목 데이터의 고정된 이름)

### After
홈 페이지에서 "안녕하세요, [실제 로그인한 사용자 이름] 님"

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.

- User API는 실제 백엔드 엔드포인트(`https://mefit.xn--hy1by51c.kr/api/v1/users/`)와 연동되어 있습니다
- 홈 API는 현재 `USE_MOCK = true` 상태이지만, 사용자 이름만 실제 API에서 가져옵니다
- API 호출 실패 시 안전하게 목 데이터로 폴백됩니다
- 기존 `authApi.ts`와 `settingsApi.ts`에서 사용하던 엔드포인트와 일관성을 유지했습니다