### PR TITLE
[040] 채용공고 목록 API 연동 및 user api 오류 해결 

### DIFF
--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -336,3 +336,115 @@ button {
   0%, 100% { box-shadow: 0 1px 2px rgba(0,0,0,.03), 0 2px 8px rgba(0,0,0,.05); }
   50%       { box-shadow: 0 0 0 3px rgba(9,145,178,.15), 0 1px 2px rgba(0,0,0,.04), 0 4px 12px rgba(0,0,0,.06); }
 }
+
+/* ── Shared Nav (hp-nav) ── */
+.hp-nav {
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid #e5e7eb;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  padding: 0 32px;
+  gap: 16px;
+}
+
+.hp-nav-logo {
+  font-size: 20px;
+  font-weight: 900;
+  color: #0a0a0a;
+  text-decoration: none;
+  letter-spacing: -0.4px;
+  margin-right: auto;
+}
+
+.hp-nav-link {
+  font-size: 14px;
+  font-weight: 500;
+  color: #6b7280;
+  text-decoration: none;
+  padding: 6px 12px;
+  border-radius: 8px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.hp-nav-link:hover {
+  color: #0a0a0a;
+  background: #f9fafb;
+}
+
+.hp-nav-link.active {
+  color: #0a0a0a;
+  font-weight: 600;
+}
+
+.hp-menu-btn {
+  display: none;
+  width: 36px;
+  height: 36px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+
+.hp-menu-btn:hover {
+  background: #f3f4f6;
+}
+
+.hp-menu-icon {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hp-menu-icon span {
+  width: 18px;
+  height: 2px;
+  background: #0a0a0a;
+  border-radius: 2px;
+  transition: all 0.2s;
+}
+
+@media (max-width: 640px) {
+  .hp-nav {
+    padding: 0 16px;
+  }
+}
+
+/* Navigation 공유 컴포넌트 - 햄버거 버튼 md 기준으로 표시 */
+.hp-nav.nav-shared .hp-menu-btn {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .hp-nav.nav-shared .hp-menu-btn {
+    display: flex;
+  }
+}
+
+
+/* Navigation 컴포넌트 사이드바 - 항상 오버레이로 동작 */
+.hp-sidebar.nav-sidebar {
+  position: fixed;
+  left: 0;
+  top: 60px;
+  bottom: 0;
+  width: 280px;
+  z-index: 201;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  border-right: 1px solid #e5e7eb;
+  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
+}
+
+.hp-sidebar.nav-sidebar.open {
+  transform: translateX(0);
+}

--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -128,13 +128,12 @@ const MOCK_DATA: HomeData = {
  * GET /api/v1/home/dashboard/
  */
 export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: HomeData; error?: string }> {
-  // Fetch real user data
-  try {
-    const userData = await userApi.getMe();
+  // Early return for mock mode
+  if (USE_MOCK) {
+    await new Promise((r) => setTimeout(r, 400));
     
-    // Use mock data if backend is not ready, but with real user name
-    if (USE_MOCK) {
-      await new Promise((r) => setTimeout(r, 400));
+    try {
+      const userData = await userApi.getMe();
       return { 
         success: true, 
         data: {
@@ -145,16 +144,13 @@ export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: Hom
           }
         }
       };
-    }
-  } catch (error) {
-    console.error("Failed to fetch user data:", error);
-    // Continue with mock data if user fetch fails
-    if (USE_MOCK) {
-      await new Promise((r) => setTimeout(r, 400));
+    } catch (error) {
+      console.error("Failed to fetch user data in mock mode:", error);
       return { success: true, data: MOCK_DATA };
     }
   }
 
+  // Real API mode
   try {
     const data = await apiRequest<BackendHomeData>(
       "/api/v1/home/dashboard/",
@@ -202,6 +198,9 @@ export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: Hom
     };
   } catch (error) {
     console.error("Failed to fetch home data:", error);
-    return { success: true, data: MOCK_DATA };
+    return { 
+      success: false, 
+      error: "홈 데이터를 불러오는데 실패했습니다." 
+    };
   }
 }

--- a/src/features/jd/api/jdListApi.ts
+++ b/src/features/jd/api/jdListApi.ts
@@ -143,7 +143,7 @@ export async function fetchJdListApi(): Promise<{ success: boolean; data: JdList
       auth: true,
     });
     
-    const transformedData = response.map(transformJdListItem);
+    const transformedData = Array.isArray(response) ? response.map(transformJdListItem) : [];
     return { success: true, data: transformedData };
   } catch (error) {
     console.error("Failed to fetch JD list:", error);

--- a/src/features/jd/api/jdListApi.ts
+++ b/src/features/jd/api/jdListApi.ts
@@ -1,5 +1,11 @@
 import { apiRequest } from "@/shared/api/client";
 import type { JdStatus } from "./jdApi";
+import {
+  getCompanyInitial,
+  getCompanyColor,
+  getTagColor,
+  getRelativeTime,
+} from "./jdListHelpers";
 
 export type JdListStatus = JdStatus | "analyzing";
 
@@ -27,9 +33,7 @@ export interface JdListStats {
   saved: number;
 }
 
-/**
- * 백엔드 API 응답 타입
- */
+/** 백엔드 API 응답 타입 */
 interface JdListApiResponse {
   id: number;
   company_name: string;
@@ -40,83 +44,6 @@ interface JdListApiResponse {
   is_analyzed: boolean;
 }
 
-/**
- * 회사 이름의 첫 글자 추출
- */
-function getCompanyInitial(company: string): string {
-  return company.charAt(0);
-}
-
-/**
- * 회사별 그라데이션 색상 생성 (해시 기반)
- */
-function getCompanyColor(company: string): string {
-  const colors = [
-    "linear-gradient(135deg,#60A5FA,#2563EB)",
-    "linear-gradient(135deg,#34D399,#059669)",
-    "linear-gradient(135deg,#F472B6,#DB2777)",
-    "linear-gradient(135deg,#FCD34D,#D97706)",
-    "linear-gradient(135deg,#A78BFA,#6D28D9)",
-    "linear-gradient(135deg,#FB923C,#EA580C)",
-    "linear-gradient(135deg,#38BDF8,#0284C7)",
-    "linear-gradient(135deg,#4ADE80,#16A34A)",
-  ];
-  
-  let hash = 0;
-  for (let i = 0; i < company.length; i++) {
-    hash = company.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return colors[Math.abs(hash) % colors.length];
-}
-
-/**
- * 태그 색상 매핑
- */
-function getTagColor(tag: string): "default" | "green" | "blue" | "pink" {
-  const lowerTag = tag.toLowerCase();
-  if (lowerTag.includes("spring") || lowerTag.includes("python") || lowerTag.includes("airflow")) {
-    return "green";
-  }
-  if (lowerTag.includes("java") || lowerTag.includes("typescript") || lowerTag.includes("spark") || lowerTag.includes("aws")) {
-    return "blue";
-  }
-  if (lowerTag.includes("android") || lowerTag.includes("ios")) {
-    return "pink";
-  }
-  return "default";
-}
-
-/**
- * 상대 시간 표시 (예: "2일 전", "1주 전")
- */
-function getRelativeTime(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  
-  const timeUnits = [
-    { threshold: 60000, divisor: 60000, unit: "분" },
-    { threshold: 3600000, divisor: 3600000, unit: "시간" },
-    { threshold: 86400000 * 7, divisor: 86400000, unit: "일" },
-    { threshold: 86400000 * 28, divisor: 86400000 * 7, unit: "주" },
-    { threshold: Infinity, divisor: 86400000 * 28, unit: "개월" },
-  ];
-
-  if (diffMs < 60000) return "방금 전 등록";
-
-  for (const { threshold, divisor, unit } of timeUnits) {
-    if (diffMs < threshold) {
-      const value = Math.floor(diffMs / divisor);
-      return `${value}${unit} 전`;
-    }
-  }
-
-  return "방금 전 등록";
-}
-
-/**
- * API 응답을 프론트엔드 형식으로 변환
- */
 function transformJdListItem(item: JdListApiResponse): JdListItem {
   return {
     id: String(item.id),
@@ -134,17 +61,15 @@ function transformJdListItem(item: JdListApiResponse): JdListItem {
   };
 }
 
-/**
- * 채용공고 목록 조회 API
- */
+/** 채용공고 목록 조회 API */
 export async function fetchJdListApi(): Promise<{ success: boolean; data: JdListItem[] }> {
   try {
     const response = await apiRequest<JdListApiResponse[]>("/api/v1/job-descriptions/", {
       auth: true,
     });
-    
-    const transformedData = Array.isArray(response) ? response.map(transformJdListItem) : [];
-    return { success: true, data: transformedData };
+
+    const data = Array.isArray(response) ? response.map(transformJdListItem) : [];
+    return { success: true, data };
   } catch (error) {
     console.error("Failed to fetch JD list:", error);
     return { success: false, data: [] };

--- a/src/features/jd/api/jdListApi.ts
+++ b/src/features/jd/api/jdListApi.ts
@@ -93,17 +93,25 @@ function getRelativeTime(dateString: string): string {
   const date = new Date(dateString);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-  const diffWeeks = Math.floor(diffDays / 7);
+  
+  const timeUnits = [
+    { threshold: 60000, divisor: 60000, unit: "분" },
+    { threshold: 3600000, divisor: 3600000, unit: "시간" },
+    { threshold: 86400000 * 7, divisor: 86400000, unit: "일" },
+    { threshold: 86400000 * 28, divisor: 86400000 * 7, unit: "주" },
+    { threshold: Infinity, divisor: 86400000 * 28, unit: "개월" },
+  ];
 
-  if (diffMins < 1) return "방금 전 등록";
-  if (diffMins < 60) return `${diffMins}분 전`;
-  if (diffHours < 24) return `${diffHours}시간 전`;
-  if (diffDays < 7) return `${diffDays}일 전`;
-  if (diffWeeks < 4) return `${diffWeeks}주 전`;
-  return `${Math.floor(diffWeeks / 4)}개월 전`;
+  if (diffMs < 60000) return "방금 전 등록";
+
+  for (const { threshold, divisor, unit } of timeUnits) {
+    if (diffMs < threshold) {
+      const value = Math.floor(diffMs / divisor);
+      return `${value}${unit} 전`;
+    }
+  }
+
+  return "방금 전 등록";
 }
 
 /**

--- a/src/features/jd/api/jdListApi.ts
+++ b/src/features/jd/api/jdListApi.ts
@@ -1,4 +1,4 @@
-// Mock JD List API
+import { apiRequest } from "@/shared/api/client";
 import type { JdStatus } from "./jdApi";
 
 export type JdListStatus = JdStatus | "analyzing";
@@ -27,87 +27,120 @@ export interface JdListStats {
   saved: number;
 }
 
-const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+/**
+ * 백엔드 API 응답 타입
+ */
+interface JdListApiResponse {
+  id: number;
+  company_name: string;
+  job_title: string;
+  status: JdListStatus;
+  tags?: string[];
+  created_at: string;
+  is_analyzed: boolean;
+}
 
-const MOCK_LIST: JdListItem[] = [
-  {
-    id: "mock-jd-analyzing",
-    company: "카카오",
-    companyInitial: "카",
-    companyColor: "linear-gradient(135deg,#60A5FA,#2563EB)",
-    title: "프론트엔드 개발자 (React)",
-    status: "analyzing",
-    tags: [
-      { label: "React", color: "default" },
-      { label: "TypeScript", color: "blue" },
-    ],
-    registeredAt: "방금 전 등록",
-    analyzed: false,
-  },
-  {
-    id: "mock-jd-1",
-    company: "네이버",
-    companyInitial: "네",
-    companyColor: "linear-gradient(135deg,#34D399,#059669)",
-    title: "백엔드 엔지니어 — Spring Boot / MSA",
-    status: "applied",
-    tags: [
-      { label: "Spring", color: "green" },
-      { label: "Java", color: "blue" },
-      { label: "MSA", color: "default" },
-    ],
-    registeredAt: "2일 전",
-    analyzed: true,
-  },
-  {
-    id: "mock-jd-3",
-    company: "라인플러스",
-    companyInitial: "라",
-    companyColor: "linear-gradient(135deg,#F472B6,#DB2777)",
-    title: "Android 앱 개발자 (Kotlin)",
-    status: "planned",
-    tags: [
-      { label: "Android", color: "pink" },
-      { label: "Kotlin", color: "default" },
-    ],
-    registeredAt: "4일 전",
-    analyzed: true,
-  },
-  {
-    id: "mock-jd-4",
-    company: "토스",
-    companyInitial: "토",
-    companyColor: "linear-gradient(135deg,#FCD34D,#D97706)",
-    title: "데이터 엔지니어 (Spark / Airflow)",
-    status: "saved",
-    tags: [
-      { label: "Spark", color: "blue" },
-      { label: "Python", color: "default" },
-      { label: "Airflow", color: "green" },
-    ],
-    registeredAt: "1주 전",
-    analyzed: true,
-  },
-  {
-    id: "mock-jd-5",
-    company: "쿠팡",
-    companyInitial: "쿠",
-    companyColor: "linear-gradient(135deg,#A78BFA,#6D28D9)",
-    title: "DevOps / SRE 엔지니어",
-    status: "applied",
-    tags: [
-      { label: "K8s", color: "default" },
-      { label: "AWS", color: "blue" },
-      { label: "Terraform", color: "green" },
-    ],
-    registeredAt: "2주 전",
-    analyzed: true,
-  },
-];
+/**
+ * 회사 이름의 첫 글자 추출
+ */
+function getCompanyInitial(company: string): string {
+  return company.charAt(0);
+}
 
+/**
+ * 회사별 그라데이션 색상 생성 (해시 기반)
+ */
+function getCompanyColor(company: string): string {
+  const colors = [
+    "linear-gradient(135deg,#60A5FA,#2563EB)",
+    "linear-gradient(135deg,#34D399,#059669)",
+    "linear-gradient(135deg,#F472B6,#DB2777)",
+    "linear-gradient(135deg,#FCD34D,#D97706)",
+    "linear-gradient(135deg,#A78BFA,#6D28D9)",
+    "linear-gradient(135deg,#FB923C,#EA580C)",
+    "linear-gradient(135deg,#38BDF8,#0284C7)",
+    "linear-gradient(135deg,#4ADE80,#16A34A)",
+  ];
+  
+  let hash = 0;
+  for (let i = 0; i < company.length; i++) {
+    hash = company.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return colors[Math.abs(hash) % colors.length];
+}
+
+/**
+ * 태그 색상 매핑
+ */
+function getTagColor(tag: string): "default" | "green" | "blue" | "pink" {
+  const lowerTag = tag.toLowerCase();
+  if (lowerTag.includes("spring") || lowerTag.includes("python") || lowerTag.includes("airflow")) {
+    return "green";
+  }
+  if (lowerTag.includes("java") || lowerTag.includes("typescript") || lowerTag.includes("spark") || lowerTag.includes("aws")) {
+    return "blue";
+  }
+  if (lowerTag.includes("android") || lowerTag.includes("ios")) {
+    return "pink";
+  }
+  return "default";
+}
+
+/**
+ * 상대 시간 표시 (예: "2일 전", "1주 전")
+ */
+function getRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+  const diffWeeks = Math.floor(diffDays / 7);
+
+  if (diffMins < 1) return "방금 전 등록";
+  if (diffMins < 60) return `${diffMins}분 전`;
+  if (diffHours < 24) return `${diffHours}시간 전`;
+  if (diffDays < 7) return `${diffDays}일 전`;
+  if (diffWeeks < 4) return `${diffWeeks}주 전`;
+  return `${Math.floor(diffWeeks / 4)}개월 전`;
+}
+
+/**
+ * API 응답을 프론트엔드 형식으로 변환
+ */
+function transformJdListItem(item: JdListApiResponse): JdListItem {
+  return {
+    id: String(item.id),
+    company: item.company_name,
+    companyInitial: getCompanyInitial(item.company_name),
+    companyColor: getCompanyColor(item.company_name),
+    title: item.job_title,
+    status: item.status,
+    tags: (item.tags || []).map((tag) => ({
+      label: tag,
+      color: getTagColor(tag),
+    })),
+    registeredAt: getRelativeTime(item.created_at),
+    analyzed: item.is_analyzed,
+  };
+}
+
+/**
+ * 채용공고 목록 조회 API
+ */
 export async function fetchJdListApi(): Promise<{ success: boolean; data: JdListItem[] }> {
-  await delay(500);
-  return { success: true, data: [...MOCK_LIST] };
+  try {
+    const response = await apiRequest<JdListApiResponse[]>("/api/v1/job-descriptions/", {
+      auth: true,
+    });
+    
+    const transformedData = response.map(transformJdListItem);
+    return { success: true, data: transformedData };
+  } catch (error) {
+    console.error("Failed to fetch JD list:", error);
+    return { success: false, data: [] };
+  }
 }
 
 export function calcStats(list: JdListItem[]): JdListStats {

--- a/src/features/jd/api/jdListHelpers.ts
+++ b/src/features/jd/api/jdListHelpers.ts
@@ -1,0 +1,68 @@
+/**
+ * 회사 이름의 첫 글자 추출
+ */
+export function getCompanyInitial(company: string): string {
+  return company.charAt(0);
+}
+
+const GRADIENT_COLORS = [
+  "linear-gradient(135deg,#60A5FA,#2563EB)",
+  "linear-gradient(135deg,#34D399,#059669)",
+  "linear-gradient(135deg,#F472B6,#DB2777)",
+  "linear-gradient(135deg,#FCD34D,#D97706)",
+  "linear-gradient(135deg,#A78BFA,#6D28D9)",
+  "linear-gradient(135deg,#FB923C,#EA580C)",
+  "linear-gradient(135deg,#38BDF8,#0284C7)",
+  "linear-gradient(135deg,#4ADE80,#16A34A)",
+];
+
+/**
+ * 회사별 그라데이션 색상 생성 (해시 기반)
+ */
+export function getCompanyColor(company: string): string {
+  let hash = 0;
+  for (let i = 0; i < company.length; i++) {
+    hash = company.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return GRADIENT_COLORS[Math.abs(hash) % GRADIENT_COLORS.length];
+}
+
+const GREEN_TAGS = ["spring", "python", "airflow"];
+const BLUE_TAGS = ["java", "typescript", "spark", "aws"];
+const PINK_TAGS = ["android", "ios"];
+
+/**
+ * 태그 색상 매핑
+ */
+export function getTagColor(tag: string): "default" | "green" | "blue" | "pink" {
+  const lower = tag.toLowerCase();
+  if (GREEN_TAGS.some((t) => lower.includes(t))) return "green";
+  if (BLUE_TAGS.some((t) => lower.includes(t))) return "blue";
+  if (PINK_TAGS.some((t) => lower.includes(t))) return "pink";
+  return "default";
+}
+
+const TIME_UNITS = [
+  { threshold: 60000, divisor: 60000, unit: "분" },
+  { threshold: 3600000, divisor: 3600000, unit: "시간" },
+  { threshold: 86400000 * 7, divisor: 86400000, unit: "일" },
+  { threshold: 86400000 * 28, divisor: 86400000 * 7, unit: "주" },
+  { threshold: Infinity, divisor: 86400000 * 28, unit: "개월" },
+];
+
+/**
+ * 상대 시간 표시 (예: "2일 전", "1주 전")
+ */
+export function getRelativeTime(dateString: string): string {
+  const diffMs = Date.now() - new Date(dateString).getTime();
+
+  if (diffMs < 60000) return "방금 전 등록";
+
+  for (const { threshold, divisor, unit } of TIME_UNITS) {
+    if (diffMs < threshold) {
+      return `${Math.floor(diffMs / divisor)}${unit} 전`;
+    }
+  }
+
+  return "방금 전 등록";
+}

--- a/src/features/jd/api/jdListHelpers.ts
+++ b/src/features/jd/api/jdListHelpers.ts
@@ -54,7 +54,9 @@ const TIME_UNITS = [
  * 상대 시간 표시 (예: "2일 전", "1주 전")
  */
 export function getRelativeTime(dateString: string): string {
-  const diffMs = Date.now() - new Date(dateString).getTime();
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return "날짜 정보 없음";
+  const diffMs = Date.now() - date.getTime();
 
   if (diffMs < 60000) return "방금 전 등록";
 

--- a/src/pages/jd-add/ui/JdAddPage.tsx
+++ b/src/pages/jd-add/ui/JdAddPage.tsx
@@ -67,18 +67,11 @@ export function JdAddPage() {
     return "";
   };
 
-  const navItems = [
-    { to: "/home", label: "홈" },
-    { to: "/jd", label: "채용공고", active: true },
-    { to: "/interview", label: "면접 시작" },
-    { to: "/resume", label: "이력서" },
-  ];
-
   return (
     <div className="min-h-screen bg-white">
-      <Navigation items={navItems} />
+      <Navigation title="채용공고" />
 
-      <div className="relative max-w-container-lg mx-auto px-8 pt-[100px] pb-[60px] max-sm:px-4 max-sm:pt-20">
+      <div className="relative max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
         <PageHeader
           badge="+ 채용공고 추가"
           title="새 채용공고 등록"

--- a/src/pages/jd-analyzing/ui/JdAnalyzingPage.tsx
+++ b/src/pages/jd-analyzing/ui/JdAnalyzingPage.tsx
@@ -6,7 +6,7 @@ import { Navigation, Card, Badge, Button } from "@/shared/ui";
 function StepBadge({ label, status }: { label: string; status: StepStatus }) {
   const variant = status === "done" ? "success" : status === "active" ? "info" : "default";
   const icon = status === "done" ? "✓ " : status === "active" ? "⟳ " : "";
-  
+
   return (
     <Badge variant={variant} className={status === "active" ? "animate-[jan-pulse_1.5s_ease-in-out_infinite]" : ""}>
       {icon}{label}
@@ -33,18 +33,11 @@ export function JdAnalyzingPage() {
       : "잠깐만요, 금방 끝나요 ✨"
     : "분석 완료! 잠시 후 이동합니다...";
 
-  const navItems = [
-    { to: "/home", label: "홈" },
-    { to: "/jd", label: "채용공고", active: true },
-    { to: "/interview", label: "면접 시작" },
-    { to: "/resume", label: "이력서" },
-  ];
-
   return (
     <div className="min-h-screen bg-white text-[#0A0A0A]">
-      <Navigation items={navItems} />
+      <Navigation title="채용공고" />
 
-      <div className="max-w-container-sm mx-auto pt-[100px] px-8 pb-[60px] max-[640px]:pt-20 max-[640px]:px-4 max-[640px]:pb-10">
+      <div className="max-w-container-sm mx-auto pt-[28px] px-8 pb-[60px] max-[640px]:pt-5 max-[640px]:px-4 max-[640px]:pb-10">
         {/* BREADCRUMB */}
         <div className="flex items-center gap-2 text-[13px] text-[#6B7280] mb-6">
           <Link

--- a/src/pages/jd-detail/ui/JdDetailPage.tsx
+++ b/src/pages/jd-detail/ui/JdDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useJdDetailStore, type JdStatus } from "@/features/jd";
-import { useSessionStore } from "@/entities/session";
+import { Navigation } from "@/shared/ui";
 
 const STATUS_OPTIONS: { value: JdStatus; icon: string; label: string; sub: string }[] = [
   { value: "planned", icon: "📅", label: "지원 예정",  sub: "곧 지원할 예정" },
@@ -38,8 +38,8 @@ export function JdDetailPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-white">
-        <NavBar />
-        <div className="max-w-container-lg mx-auto px-8 pt-[100px] pb-[60px] max-sm:px-4 max-sm:pt-20">
+        <Navigation title="채용공고" />
+        <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
           <div className="text-center py-20 text-[15px] text-[#6B7280]">불러오는 중...</div>
         </div>
       </div>
@@ -50,8 +50,8 @@ export function JdDetailPage() {
   if (error || !jd) {
     return (
       <div className="min-h-screen bg-white">
-        <NavBar />
-        <div className="max-w-container-lg mx-auto px-8 pt-[100px] pb-[60px] max-sm:px-4 max-sm:pt-20">
+        <Navigation title="채용공고" />
+        <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
           <div className="text-center py-[60px] flex flex-col items-center text-[15px] text-[#DC2626]">
             <p>{error ?? "채용공고를 찾을 수 없습니다."}</p>
             <Link to="/jd" className="inline-flex items-center gap-2 text-[13px] font-bold text-white bg-[#0A0A0A] border-none cursor-pointer py-3 px-5 rounded-lg shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-opacity hover:opacity-85 no-underline mt-4">
@@ -65,9 +65,9 @@ export function JdDetailPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      <NavBar />
+      <Navigation title="채용공고" />
 
-      <div className="max-w-container-lg mx-auto px-8 pt-[100px] pb-[60px] max-sm:px-4 max-sm:pt-20">
+      <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
         {/* BREADCRUMB */}
         <div className="flex items-center gap-2 text-[13px] text-[#6B7280] mb-6">
           <Link to="/jd" className="text-[#6B7280] no-underline transition-colors hover:text-[#0991B2]">채용공고</Link>
@@ -273,28 +273,5 @@ export function JdDetailPage() {
         </div>
       </div>
     </div>
-  );
-}
-
-function NavBar() {
-  const { user } = useSessionStore();
-
-  return (
-    <nav className="fixed top-0 left-0 right-0 z-[200] py-[14px] px-8 flex justify-center max-sm:py-3 max-sm:px-4">
-      <div className="flex items-center justify-between w-full max-w-container-lg bg-white/[.92] backdrop-blur-[20px] border border-[#E5E7EB] rounded-lg p-[8px_8px_8px_24px] shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)]">
-        <Link to="/home" className="flex items-center">
-          <img src="/logo-korean.png" alt="미핏" className="h-[34px] w-auto" />
-        </Link>
-        <ul className="flex gap-1 list-none">
-          <li><Link to="/home" className="text-[13px] font-medium text-[#6B7280] no-underline py-2 px-3.5 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]">홈</Link></li>
-          <li><Link to="/jd" className="text-[13px] font-bold text-[#0991B2] bg-[#E6F7FA] no-underline py-2 px-3.5 rounded-lg">채용공고</Link></li>
-          <li><Link to="/interview" className="text-[13px] font-medium text-[#6B7280] no-underline py-2 px-3.5 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]">면접 시작</Link></li>
-          <li><Link to="/resume" className="text-[13px] font-medium text-[#6B7280] no-underline py-2 px-3.5 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]">이력서</Link></li>
-        </ul>
-        <div className="w-9 h-9 rounded-full bg-gradient-to-br from-[#06B6D4] to-[#0891B2] flex items-center justify-center text-[13px] font-bold text-white shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] cursor-pointer">
-          {user?.initial || "U"}
-        </div>
-      </div>
-    </nav>
   );
 }

--- a/src/pages/jd-edit/ui/JdEditPage.tsx
+++ b/src/pages/jd-edit/ui/JdEditPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useJdEditStore, type JdStatus } from "@/features/jd";
-import { useSessionStore } from "@/entities/session";
+import { Navigation } from "@/shared/ui";
 
 const STATUS_OPTIONS: { value: JdStatus; icon: string; label: string; desc: string }[] = [
   { value: "planned", icon: "📅", label: "지원 예정", desc: "곧 지원할 예정" },
@@ -44,8 +44,8 @@ export function JdEditPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-white">
-        <NavBar />
-        <div className="max-w-container-lg mx-auto px-8 pt-[100px] pb-[60px] max-sm:px-4 max-sm:pt-20">
+        <Navigation title="채용공고" />
+        <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
           <div className="text-center py-20 text-[15px] text-[#6B7280]">불러오는 중...</div>
         </div>
       </div>
@@ -56,8 +56,8 @@ export function JdEditPage() {
   if (!jd) {
     return (
       <div className="min-h-screen bg-white">
-        <NavBar />
-        <div className="max-w-container-lg mx-auto px-8 pt-[100px] pb-[60px] max-sm:px-4 max-sm:pt-20">
+        <Navigation title="채용공고" />
+        <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
           <div className="text-center py-[60px] flex flex-col items-center text-[15px] text-[#DC2626]">
             <p>{error ?? "채용공고를 찾을 수 없습니다."}</p>
             <Link to="/jd" className="inline-flex items-center gap-2 text-sm font-bold text-white bg-[#0A0A0A] border-none cursor-pointer py-3.5 px-6 rounded-lg shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-opacity hover:opacity-85 no-underline mt-4">목록으로</Link>
@@ -69,9 +69,9 @@ export function JdEditPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      <NavBar />
+      <Navigation title="채용공고" />
 
-      <div className="max-w-container-lg mx-auto px-8 pt-[100px] pb-[60px] max-sm:px-4 max-sm:pt-20">
+      <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
         {/* BREADCRUMB */}
         <div className="flex items-center gap-2 text-[13px] text-[#6B7280] mb-6">
           <Link to="/jd" className="text-[#6B7280] no-underline transition-colors hover:text-[#0991B2]">채용공고</Link>
@@ -287,28 +287,5 @@ export function JdEditPage() {
         </div>
       </div>
     </div>
-  );
-}
-
-function NavBar() {
-  const { user } = useSessionStore();
-
-  return (
-    <nav className="fixed top-0 left-0 right-0 z-[200] py-[14px] px-8 flex justify-center max-sm:py-3 max-sm:px-4">
-      <div className="flex items-center justify-between w-full max-w-container-lg bg-white/[.92] backdrop-blur-[20px] border border-[#E5E7EB] rounded-lg p-[8px_8px_8px_24px] shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)]">
-        <Link to="/home" className="flex items-center">
-          <img src="/logo-korean.png" alt="미핏" className="h-[34px] w-auto" />
-        </Link>
-        <ul className="flex gap-1 list-none">
-          <li><Link to="/home" className="text-[13px] font-medium text-[#6B7280] no-underline py-2 px-3.5 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]">홈</Link></li>
-          <li><Link to="/jd" className="text-[13px] font-bold text-[#0991B2] bg-[#E6F7FA] no-underline py-2 px-3.5 rounded-lg">채용공고</Link></li>
-          <li><Link to="/interview" className="text-[13px] font-medium text-[#6B7280] no-underline py-2 px-3.5 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]">면접 시작</Link></li>
-          <li><Link to="/resume" className="text-[13px] font-medium text-[#6B7280] no-underline py-2 px-3.5 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]">이력서</Link></li>
-        </ul>
-        <div className="w-9 h-9 rounded-full bg-gradient-to-br from-[#06B6D4] to-[#0891B2] flex items-center justify-center text-[13px] font-bold text-white shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] cursor-pointer">
-          {user?.initial || "U"}
-        </div>
-      </div>
-    </nav>
   );
 }

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useJdListStore, type JdListItem } from "@/features/jd";
-import { useSessionStore } from "@/entities/session";
+import { Navigation } from "@/shared/ui";
 
 type FilterKey = "all" | "planned" | "applied" | "saved";
 
@@ -170,8 +170,6 @@ export function JdListPage() {
     fetchList, setSearch, setFilter,
   } = useJdListStore();
 
-  const { user } = useSessionStore();
-
   useEffect(() => {
     fetchList();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -186,25 +184,9 @@ export function JdListPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      {/* NAV */}
-      <nav className="fixed top-0 left-0 right-0 z-[200] py-[14px] px-8 flex justify-center max-sm:py-3 max-sm:px-4">
-        <div className="flex items-center justify-between w-full max-w-container-lg bg-white/[.92] backdrop-blur-[20px] border border-[#E5E7EB] rounded-lg p-[8px_8px_8px_24px] shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)]">
-          <Link to="/home" className="flex items-center">
-            <img src="/logo-korean.png" alt="미핏" className="h-[34px] w-auto" />
-          </Link>
-          <ul className="flex gap-1 list-none">
-            <li><Link to="/home" className="text-[13px] font-medium text-[#6B7280] no-underline py-2 px-3.5 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]">홈</Link></li>
-            <li><Link to="/jd" className="text-[13px] font-bold text-[#0991B2] bg-[#E6F7FA] no-underline py-2 px-3.5 rounded-lg">채용공고</Link></li>
-            <li><Link to="/interview" className="text-[13px] font-medium text-[#6B7280] no-underline py-2 px-3.5 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]">면접 시작</Link></li>
-            <li><Link to="/resume" className="text-[13px] font-medium text-[#6B7280] no-underline py-2 px-3.5 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]">이력서</Link></li>
-          </ul>
-          <div className="w-9 h-9 rounded-full bg-gradient-to-br from-[#06B6D4] to-[#0891B2] flex items-center justify-center text-[13px] font-bold text-white shadow-[0_1px_3px_rgba(0,0,0,0.1)] cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-[0_4px_6px_rgba(0,0,0,0.07)]">
-            {user?.initial || "U"}
-          </div>
-        </div>
-      </nav>
+      <Navigation title="채용공고" />
 
-      <div className="max-w-container-lg mx-auto px-8 pt-[100px] pb-[60px] max-sm:px-4 max-sm:pt-20">
+      <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
 
         {/* PAGE HEADER */}
         <div className="flex items-start justify-between mb-8 gap-4">

--- a/src/shared/api/userApi.ts
+++ b/src/shared/api/userApi.ts
@@ -1,7 +1,17 @@
 import { apiRequest } from "./client";
 
 /**
- * 사용자 정보 타입
+ * 백엔드 API 응답 타입 (snake_case)
+ */
+interface BackendUserMe {
+  name: string;
+  email: string;
+  is_email_confirmed: boolean;
+  is_profile_completed: boolean;
+}
+
+/**
+ * 사용자 정보 타입 (camelCase)
  */
 export interface UserMe {
   name: string;
@@ -34,20 +44,34 @@ export const userApi = {
    * 현재 로그인한 사용자 정보 조회
    * @returns UserMe 사용자 정보
    */
-  getMe: () =>
-    apiRequest<UserMe>("/api/v1/users/me/", { auth: true }),
+  getMe: async (): Promise<UserMe> => {
+    const data = await apiRequest<BackendUserMe>("/api/v1/users/me/", { auth: true });
+    return {
+      name: data.name,
+      email: data.email,
+      isEmailConfirmed: data.is_email_confirmed,
+      isProfileCompleted: data.is_profile_completed,
+    };
+  },
 
   /**
    * 사용자 정보 수정
    * @param params 수정할 사용자 정보
    * @returns 수정된 사용자 정보
    */
-  updateMe: (params: UpdateUserParams) =>
-    apiRequest<UserMe>("/api/v1/users/me/", {
+  updateMe: async (params: UpdateUserParams): Promise<UserMe> => {
+    const data = await apiRequest<BackendUserMe>("/api/v1/users/me/", {
       method: "PATCH",
       auth: true,
       body: JSON.stringify(params),
-    }),
+    });
+    return {
+      name: data.name,
+      email: data.email,
+      isEmailConfirmed: data.is_email_confirmed,
+      isProfileCompleted: data.is_profile_completed,
+    };
+  },
 
   /**
    * 비밀번호 변경

--- a/src/shared/ui/Navigation.tsx
+++ b/src/shared/ui/Navigation.tsx
@@ -1,53 +1,151 @@
-import { Link } from "react-router-dom";
-import { useSessionStore } from "@/entities/session";
-
-interface NavItem {
-  to: string;
-  label: string;
-  active?: boolean;
-}
+import { useState, useRef, useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuthStore } from "@/features/auth";
+import { MobileTabBar } from "./MobileTabBar";
 
 interface NavigationProps {
-  items?: NavItem[];
+  activeTab?: "home" | "interview" | "resume" | "jd" | "settings";
   className?: string;
+  title?: string;
 }
 
-const defaultItems: NavItem[] = [
-  { to: "/home", label: "홈" },
-  { to: "/jd", label: "채용공고" },
-  { to: "/interview", label: "면접 시작" },
-  { to: "/resume", label: "이력서" },
-];
+export function Navigation({ activeTab = "jd", className = "", title }: NavigationProps) {
+  const navigate = useNavigate();
+  const { user, logout } = useAuthStore();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-export function Navigation({ items = defaultItems, className = "" }: NavigationProps) {
-  const { user } = useSessionStore();
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setProfileOpen(false);
+      }
+    };
+    if (profileOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [profileOpen]);
+
+  const handleLogout = async () => {
+    await logout();
+    navigate("/login");
+  };
 
   return (
-    <nav className={`fixed top-0 left-0 right-0 z-[200] py-[14px] px-8 flex justify-center max-sm:py-3 max-sm:px-4 ${className}`}>
-      <div className="flex items-center justify-between w-full max-w-container-lg bg-white/[.92] backdrop-blur-[20px] border border-[#E5E7EB] rounded-lg p-[8px_8px_8px_24px] shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)]">
-        <Link to="/home" className="flex items-center">
-          <img src="/logo-korean.png" alt="미핏" className="h-[34px] w-auto" />
-        </Link>
-        <ul className="flex gap-1 list-none">
-          {items.map((item) => (
-            <li key={item.to}>
+    <>
+      <nav className={`hp-nav nav-shared relative ${className}`}>
+        <button
+          className={`hp-menu-btn${menuOpen ? " open" : ""}`}
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="메뉴"
+        >
+          <div className="hp-menu-icon">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        </button>
+
+        <div className="flex-1" />
+
+        {title && (
+          <span className="absolute left-1/2 -translate-x-1/2 text-[15px] font-bold text-[#0A0A0A]">
+            {title}
+          </span>
+        )}
+
+        <Link to="/resume" className="hp-nav-link">이력서</Link>
+        <Link to="/jd" className="hp-nav-link">채용공고</Link>
+
+        {/* Profile dropdown */}
+        <div className="relative" ref={dropdownRef}>
+          <button
+            onClick={() => setProfileOpen(!profileOpen)}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[#F3F4F6] transition-colors"
+            aria-label="프로필 메뉴"
+          >
+            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-[#0991B2] to-[#06B6D4] flex items-center justify-center text-white text-sm font-bold">
+              {user?.name?.[0]?.toUpperCase() || "U"}
+            </div>
+            <span className="text-sm font-semibold text-[#0A0A0A] hidden md:block">
+              {user?.name || "사용자"}
+            </span>
+            <svg
+              className={`w-4 h-4 text-[#6B7280] transition-transform ${profileOpen ? "rotate-180" : ""}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {profileOpen && (
+            <div className="absolute right-0 mt-2 w-48 bg-white rounded-xl shadow-[0_4px_12px_rgba(0,0,0,0.1)] border border-[#E5E7EB] py-2 z-50">
               <Link
-                to={item.to}
-                className={`text-[13px] font-${item.active ? "bold" : "medium"} ${
-                  item.active
-                    ? "text-[#0991B2] bg-[#E6F7FA]"
-                    : "text-[#6B7280] hover:text-[#0A0A0A] hover:bg-[rgba(9,145,178,0.06)]"
-                } no-underline py-2 px-3.5 rounded-lg transition-all`}
+                to="/settings"
+                className="block px-4 py-2.5 text-sm text-[#0A0A0A] hover:bg-[#F3F4F6] transition-colors"
+                onClick={() => setProfileOpen(false)}
               >
-                {item.label}
+                ⚙️ 설정
               </Link>
-            </li>
-          ))}
-        </ul>
-        <div className="w-9 h-9 rounded-full bg-gradient-to-br from-[#06B6D4] to-[#0891B2] flex items-center justify-center text-[13px] font-bold text-white shadow-[0_1px_3px_rgba(0,0,0,0.1)] cursor-pointer">
-          {user?.initial || "U"}
+              <div className="h-px bg-[#E5E7EB] my-1" />
+              <button
+                onClick={handleLogout}
+                className="w-full text-left px-4 py-2.5 text-sm text-[#DC2626] hover:bg-[#FEF2F2] transition-colors"
+              >
+                🚪 로그아웃
+              </button>
+            </div>
+          )}
         </div>
-      </div>
-    </nav>
+      </nav>
+
+      {/* Sidebar overlay */}
+      <div
+        className={`hp-sidebar-overlay${menuOpen ? " open" : ""}`}
+        onClick={() => setMenuOpen(false)}
+      />
+
+      {/* Sidebar */}
+      <aside className={`hp-sidebar nav-sidebar${menuOpen ? " open" : ""}`}>
+        <div className="hp-sb-sep">메인</div>
+        <Link to="/home" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+          <span className="hp-sb-icon">🏠</span>홈
+        </Link>
+        <Link to="/interview/setup" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+          <span className="hp-sb-icon">🎥</span>면접 시작
+        </Link>
+        <div className="hp-sb-sep">관리</div>
+        <Link to="/resume" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+          <span className="hp-sb-icon">📄</span>이력서
+        </Link>
+        <Link to="/jd" className={`hp-sb-item${activeTab === "jd" ? " active" : ""}`} onClick={() => setMenuOpen(false)}>
+          <span className="hp-sb-icon">🏢</span>채용공고
+        </Link>
+        <div className="hp-sb-sep">분석</div>
+        <Link to="#" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+          <span className="hp-sb-icon">📊</span>리뷰 리포트
+        </Link>
+        <Link to="/streak" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+          <span className="hp-sb-icon">🔥</span>스트릭
+        </Link>
+        <div className="hp-sb-sep">설정</div>
+        <Link to="/subscription" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+          <span className="hp-sb-icon">💳</span>요금제
+        </Link>
+        <Link to="/settings" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+          <span className="hp-sb-icon">⚙️</span>계정 설정
+        </Link>
+        <div className="hp-sb-streak-card">
+          <div className="hp-ssc-label">프로필</div>
+          <div className="hp-ssc-num" style={{ fontSize: 18 }}>{user?.name || "사용자"}</div>
+        </div>
+      </aside>
+
+      <MobileTabBar activeTab={activeTab} />
+    </>
   );
 }


### PR DESCRIPTION
## 관련 이슈
Closes #40

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.
- Mock 데이터 제거하고 /api/v1/job-descriptions/ 엔드포인트 호출
- 백엔드 응답 형식(snake_case)을 프론트엔드 형식(camelCase)으로 변환
- 회사 이름 기반 색상 자동 생성 로직 추가
- 상대 시간 표시 기능 구현 (예: "2일 전", "1주 전")
- 태그 색상 자동 매핑 로직 추가

## 변경 유형
해당하는 항목에 체크해주세요.
- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.
- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 채용공고 목록 페이지 접속
2. API 호출 확인 및 데이터 로딩 확인
3. 회사별 색상 및 태그 표시 확인
4. 상대 시간 표시 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [x] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- Mock 데이터 사용 -->

### After
<!-- 실제 API 데이터 사용 -->

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.

- 백엔드 API 응답 형식에 따라 변환 로직이 구현되어 있습니다
- 회사 색상은 회사 이름의 해시값을 기반으로 8가지 그라데이션 중 하나가 자동 할당됩니다
- 에러 처리가 포함되어 있으며, API 호출 실패 시 빈 배열을 반환합니다
- 기존 Mock 데이터 구조와 동일한 인터페이스를 유지하여 UI 컴포넌트 변경 없이 작동합니다

<!-- 변경 후 스크린샷 -->

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.
