### PR TITLE
[054] 인증 페이지에 공통 AppLayout 적용 및 navbar 통합

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { useLocation } from "react-router-dom";
+import { MobileTabBar } from "@/shared/ui";
+import { HomeNavbar } from "@/pages/home/ui/components/HomeNavbar";
+import { HomeSidebar } from "@/pages/home/ui/components/HomeSidebar";
+import { useHomeStore } from "@/features/home";
+import "@/pages/home/ui/HomePage.css";
+
+type ActiveTab = "home" | "interview" | "resume" | "jd" | "settings";
+
+function getActiveTab(pathname: string): ActiveTab {
+  if (pathname.startsWith("/interview")) return "interview";
+  if (pathname.startsWith("/resume")) return "resume";
+  if (pathname.startsWith("/jd")) return "jd";
+  if (pathname.startsWith("/settings")) return "settings";
+  return "home";
+}
+
+interface AppLayoutProps {
+  children: React.ReactNode;
+}
+
+export function AppLayout({ children }: AppLayoutProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
+  const { data } = useHomeStore();
+
+  const activeTab = getActiveTab(location.pathname);
+
+  return (
+    <>
+      <div className="hp-wrap">
+        <HomeNavbar
+          menuOpen={menuOpen}
+          onMenuToggle={() => setMenuOpen((v) => !v)}
+        />
+        <div
+          className={`hp-sidebar-overlay${menuOpen ? " open" : ""}`}
+          onClick={() => setMenuOpen(false)}
+        />
+        <div className="hp-shell">
+          <HomeSidebar
+            menuOpen={menuOpen}
+            currentStreak={data?.currentStreak ?? 0}
+            jdCount={data?.jobs.length ?? 0}
+          />
+          <main className="hp-page-main">{children}</main>
+        </div>
+      </div>
+      <MobileTabBar activeTab={activeTab} />
+    </>
+  );
+}

--- a/src/app/ProtectedRoute.tsx
+++ b/src/app/ProtectedRoute.tsx
@@ -2,12 +2,8 @@ import { useEffect, useRef } from "react";
 import { Navigate } from "react-router-dom";
 import { toast } from "sonner";
 import { useAuthStore } from "@/features/auth";
+import { AppLayout } from "./AppLayout";
 
-/**
- * 인증이 필요한 라우트를 감싸는 가드 컴포넌트.
- * - initAuth() 완료 전(authReady=false)에는 아무것도 렌더하지 않음
- * - 비로그인 상태면 토스트 메시지 + 소개 페이지(/)로 리다이렉트
- */
 export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, authReady } = useAuthStore();
   const toastFired = useRef(false);
@@ -19,11 +15,8 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
     }
   }, [authReady, user]);
 
-  // 아직 초기화 중이면 빈 화면 유지
   if (!authReady) return null;
-
-  // 비로그인 → 소개 페이지로
   if (!user) return <Navigate to="/" replace />;
 
-  return <>{children}</>;
+  return <AppLayout>{children}</AppLayout>;
 }

--- a/src/pages/home/ui/HomePage.css
+++ b/src/pages/home/ui/HomePage.css
@@ -146,6 +146,24 @@
   background: #ffffff;
 }
 
+/* grid 밖에서 렌더될 때: 항상 fixed로 슬라이드 */
+.hp-sidebar--floating {
+  position: fixed;
+  left: 0;
+  top: 60px;
+  bottom: 0;
+  width: 280px;
+  z-index: 201;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  border-right: 1px solid #e5e7eb;
+  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
+}
+
+.hp-sidebar--floating.open {
+  transform: translateX(0);
+}
+
 .hp-sidebar-overlay {
   display: none;
   position: fixed;
@@ -252,6 +270,12 @@
 .hp-main {
   padding: 28px 32px 100px;
   min-width: 0;
+}
+
+/* 다른 페이지용: 각 페이지가 자체 padding 관리 */
+.hp-page-main {
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* ── BADGE ── */

--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState } from "react";
 import { useHomeStore } from "@/features/home";
-import { MobileTabBar } from "@/shared/ui";
 import {
-  HomeNavbar,
-  HomeSidebar,
   HomeHeader,
   QuickStartHero,
   StatsGrid,
@@ -17,7 +14,6 @@ import "./HomePage.css";
 export function HomePage() {
   const { data, loading, fetchHome } = useHomeStore();
   const [revealed, setRevealed] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     fetchHome();
@@ -30,50 +26,29 @@ export function HomePage() {
   }, [data]);
 
   return (
-    <>
-      <div className="hp-wrap">
-        <HomeNavbar menuOpen={menuOpen} onMenuToggle={() => setMenuOpen(!menuOpen)} />
-
-        <div 
-          className={`hp-sidebar-overlay${menuOpen ? " open" : ""}`}
-          onClick={() => setMenuOpen(false)}
-        />
-
-        <div className="hp-shell">
-          <HomeSidebar 
-            menuOpen={menuOpen} 
-            currentStreak={data?.currentStreak ?? 0}
-            jdCount={data?.jobs.length ?? 0}
+    <div className="hp-main">
+      {loading && !data ? (
+        <LoadingSkeleton />
+      ) : data ? (
+        <>
+          <HomeHeader
+            greeting={data.user.greeting}
+            userName={data.user.name}
+            lastInterviewDaysAgo={data.user.lastInterviewDaysAgo}
           />
 
-          <main className="hp-main">
-            {loading && !data ? (
-              <LoadingSkeleton />
-            ) : data ? (
-              <>
-                <HomeHeader
-                  greeting={data.user.greeting}
-                  userName={data.user.name}
-                  lastInterviewDaysAgo={data.user.lastInterviewDaysAgo}
-                />
+          <QuickStartHero revealed={revealed} />
 
-                <QuickStartHero revealed={revealed} />
+          <StatsGrid stats={data.stats} revealed={revealed} />
 
-                <StatsGrid stats={data.stats} revealed={revealed} />
+          <RecentSessions sessions={data.recentSessions} revealed={revealed} />
 
-                <RecentSessions sessions={data.recentSessions} revealed={revealed} />
-
-                <div className="hp-bottom">
-                  <StreakCalendar streakData={data.streakData} revealed={revealed} />
-                  <JobStatus jobs={data.jobs} revealed={revealed} />
-                </div>
-              </>
-            ) : null}
-          </main>
-        </div>
-      </div>
-
-      <MobileTabBar activeTab="home" />
-    </>
+          <div className="hp-bottom">
+            <StreakCalendar streakData={data.streakData} revealed={revealed} />
+            <JobStatus jobs={data.jobs} revealed={revealed} />
+          </div>
+        </>
+      ) : null}
+    </div>
   );
 }

--- a/src/pages/home/ui/components/HomeNavbar.tsx
+++ b/src/pages/home/ui/components/HomeNavbar.tsx
@@ -50,8 +50,6 @@ export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
       <Link to="/" className="hp-nav-logo flex items-center">
         <img src="/logo-korean.png" alt="미핏" className="h-[36px] w-auto" />
       </Link>
-      <Link to="/resume" className="hp-nav-link">이력서</Link>
-      <Link to="/jd" className="hp-nav-link">채용공고</Link>
       
       {/* User Profile Dropdown */}
       <div className="relative" ref={dropdownRef}>

--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -4,11 +4,14 @@ interface HomeSidebarProps {
   menuOpen: boolean;
   currentStreak: number;
   jdCount?: number;
+  /** grid 밖에서 렌더될 때 항상 fixed position으로 동작 */
+  floating?: boolean;
 }
 
-export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0 }: HomeSidebarProps) {
+export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = false }: HomeSidebarProps) {
+  const cls = `hp-sidebar${floating ? " hp-sidebar--floating" : ""}${menuOpen ? " open" : ""}`;
   return (
-    <aside className={`hp-sidebar${menuOpen ? " open" : ""}`}>
+    <aside className={cls}>
       <div className="hp-sb-sep">메인</div>
       <Link to="/home" className="hp-sb-item active">
         <span className="hp-sb-icon">🏠</span>홈

--- a/src/pages/interview-precheck/ui/InterviewPreCheckPage.tsx
+++ b/src/pages/interview-precheck/ui/InterviewPreCheckPage.tsx
@@ -83,17 +83,6 @@ export function InterviewPreCheckPage() {
 
   return (
     <>
-      {/* ── NAV ── */}
-      <nav className="sticky top-0 z-[200] bg-white/[.92] backdrop-blur-[20px] border-b border-[#E5E7EB] h-[60px] flex items-center px-8 gap-4">
-        <a className="flex items-center mr-auto" href="/home">
-          <img src="/logo-korean.png" alt="미핏" className="h-[36px] w-auto" />
-        </a>
-        <a className="text-sm font-medium text-[#6B7280] no-underline px-3 py-1.5 rounded-lg transition-colors hover:text-[#0A0A0A] hover:bg-[#F9FAFB]" href="/home">홈</a>
-        <a className="text-sm font-medium text-[#6B7280] no-underline px-3 py-1.5 rounded-lg transition-colors hover:text-[#0A0A0A] hover:bg-[#F9FAFB]" href="#">이력서</a>
-        <a className="text-sm font-medium text-[#6B7280] no-underline px-3 py-1.5 rounded-lg transition-colors hover:text-[#0A0A0A] hover:bg-[#F9FAFB]" href="#">채용공고</a>
-        <a className="inline-flex items-center gap-1.5 text-[13px] font-bold text-white bg-[#0A0A0A] border-none rounded-lg py-[9px] px-[18px] cursor-pointer no-underline whitespace-nowrap transition-[opacity,transform] hover:opacity-85 hover:-translate-y-px" href="/interview/setup">면접 설정</a>
-      </nav>
-
       <div className="max-w-container-md mx-auto px-8 pt-9 pb-[60px]">
 
         {/* ── BREADCRUMB ── */}

--- a/src/pages/interview-setup/ui/InterviewSetupPage.tsx
+++ b/src/pages/interview-setup/ui/InterviewSetupPage.tsx
@@ -19,58 +19,7 @@ export function InterviewSetupPage() {
 
   return (
     <>
-      {/* NAV */}
-      <nav className="sticky top-0 z-[200] bg-white/[.92] backdrop-blur-[20px] border-b border-[#E5E7EB] h-[60px] flex items-center px-8 gap-4 max-sm:px-4">
-        <Link to="/home" className="flex items-center mr-auto">
-          <img src="/logo-korean.png" alt="미핏" className="h-[36px] w-auto" />
-        </Link>
-        <Link to="/home" className="text-sm font-medium text-[#6B7280] no-underline px-3 py-1.5 rounded-lg transition-colors hover:text-[#0A0A0A] hover:bg-[#F9FAFB]">홈</Link>
-        <Link to="/resume/input" className="text-sm font-medium text-[#6B7280] no-underline px-3 py-1.5 rounded-lg transition-colors hover:text-[#0A0A0A] hover:bg-[#F9FAFB]">이력서</Link>
-        <Link to="/jd" className="text-sm font-medium text-[#6B7280] no-underline px-3 py-1.5 rounded-lg transition-colors hover:text-[#0A0A0A] hover:bg-[#F9FAFB]">채용공고</Link>
-        <Link to="/interview/setup" className="inline-flex items-center gap-1.5 text-[13px] font-bold text-white bg-[#0A0A0A] border-none rounded-lg py-[9px] px-[18px] cursor-pointer no-underline whitespace-nowrap transition-[opacity,transform] hover:opacity-85 hover:-translate-y-px">면접 시작 →</Link>
-      </nav>
-
-      <div className="grid grid-cols-[220px_1fr] min-h-[calc(100vh-60px)] max-lg:grid-cols-1">
-        {/* SIDEBAR */}
-        <aside className="sticky top-[60px] h-[calc(100vh-60px)] overflow-y-auto border-r border-[#E5E7EB] py-5 px-3 flex flex-col gap-0.5 bg-white max-lg:hidden">
-          <div className="text-[10px] font-bold tracking-[.1em] uppercase text-[#9CA3AF] px-3 pt-4 pb-1.5">메인</div>
-          <Link to="/home" className="flex items-center gap-[9px] px-3 py-2 rounded-lg text-[13px] font-medium text-[#6B7280] cursor-pointer transition-all no-underline hover:bg-[#F9FAFB] hover:text-[#0A0A0A]">
-            <span className="w-7 h-7 rounded-lg flex items-center justify-center text-sm shrink-0 bg-[#F9FAFB]">🏠</span>홈
-          </Link>
-          <Link to="/interview/setup" className="flex items-center gap-[9px] px-3 py-2 rounded-lg text-[13px] font-bold text-[#0991B2] bg-[#E6F7FA] cursor-pointer transition-all no-underline">
-            <span className="w-7 h-7 rounded-lg flex items-center justify-center text-sm shrink-0 bg-[rgba(9,145,178,.12)]">🎥</span>면접 시작
-          </Link>
-          <div className="text-[10px] font-bold tracking-[.1em] uppercase text-[#9CA3AF] px-3 pt-4 pb-1.5">관리</div>
-          <Link to="/resume/input" className="flex items-center gap-[9px] px-3 py-2 rounded-lg text-[13px] font-medium text-[#6B7280] cursor-pointer transition-all no-underline hover:bg-[#F9FAFB] hover:text-[#0A0A0A]">
-            <span className="w-7 h-7 rounded-lg flex items-center justify-center text-sm shrink-0 bg-[#F9FAFB]">📄</span>이력서
-          </Link>
-          <Link to="/jd" className="flex items-center gap-[9px] px-3 py-2 rounded-lg text-[13px] font-medium text-[#6B7280] cursor-pointer transition-all no-underline hover:bg-[#F9FAFB] hover:text-[#0A0A0A]">
-            <span className="w-7 h-7 rounded-lg flex items-center justify-center text-sm shrink-0 bg-[#F9FAFB]">🏢</span>채용공고
-            <span className="ml-auto text-[10px] font-bold bg-[#E6F7FA] text-[#0991B2] py-0.5 px-[7px] rounded-full">3</span>
-          </Link>
-          <div className="text-[10px] font-bold tracking-[.1em] uppercase text-[#9CA3AF] px-3 pt-4 pb-1.5">분석</div>
-          <Link to="#" className="flex items-center gap-[9px] px-3 py-2 rounded-lg text-[13px] font-medium text-[#6B7280] cursor-pointer transition-all no-underline hover:bg-[#F9FAFB] hover:text-[#0A0A0A]">
-            <span className="w-7 h-7 rounded-lg flex items-center justify-center text-sm shrink-0 bg-[#F9FAFB]">📊</span>리뷰 리포트
-          </Link>
-          <Link to="#" className="flex items-center gap-[9px] px-3 py-2 rounded-lg text-[13px] font-medium text-[#6B7280] cursor-pointer transition-all no-underline hover:bg-[#F9FAFB] hover:text-[#0A0A0A]">
-            <span className="w-7 h-7 rounded-lg flex items-center justify-center text-sm shrink-0 bg-[#F9FAFB]">🔥</span>스트릭
-          </Link>
-          <div className="text-[10px] font-bold tracking-[.1em] uppercase text-[#9CA3AF] px-3 pt-4 pb-1.5">설정</div>
-          <Link to="#" className="flex items-center gap-[9px] px-3 py-2 rounded-lg text-[13px] font-medium text-[#6B7280] cursor-pointer transition-all no-underline hover:bg-[#F9FAFB] hover:text-[#0A0A0A]">
-            <span className="w-7 h-7 rounded-lg flex items-center justify-center text-sm shrink-0 bg-[#F9FAFB]">💳</span>요금제
-          </Link>
-          <Link to="#" className="flex items-center gap-[9px] px-3 py-2 rounded-lg text-[13px] font-medium text-[#6B7280] cursor-pointer transition-all no-underline hover:bg-[#F9FAFB] hover:text-[#0A0A0A]">
-            <span className="w-7 h-7 rounded-lg flex items-center justify-center text-sm shrink-0 bg-[#F9FAFB]">⚙️</span>계정 설정
-          </Link>
-          <div className="mt-auto bg-[#0991B2] rounded-lg p-4 text-white">
-            <div className="text-[10px] font-semibold opacity-70 mb-1">🔥 현재 스트릭</div>
-            <div className="text-[30px] font-black leading-none tracking-[-1px]">12</div>
-            <div className="text-[11px] opacity-65 mt-0.5">연속 일수</div>
-          </div>
-        </aside>
-
-        {/* MAIN */}
-        <main className="p-[28px_32px] min-w-0 max-sm:p-[20px_16px]">
+      <main className="p-[28px_32px] min-w-0 max-sm:p-[20px_16px]">
           {/* Page Header */}
           <div className="mb-6 animate-[isetup-fadeUp_.4s_ease_both]">
             <div className="flex items-center gap-1.5 text-[12px] text-[#6B7280] mb-2.5">
@@ -341,7 +290,6 @@ export function InterviewSetupPage() {
             </div>
           </div>
         </main>
-      </div>
     </>
   );
 }

--- a/src/pages/jd-add/ui/JdAddPage.tsx
+++ b/src/pages/jd-add/ui/JdAddPage.tsx
@@ -1,7 +1,6 @@
 import { Link, useNavigate } from "react-router-dom";
 import { useJdAddStore, type JdStatus } from "@/features/jd";
 import {
-  Navigation,
   PageHeader,
   Card,
   Input,
@@ -69,7 +68,6 @@ export function JdAddPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      <Navigation title="채용공고" />
 
       <div className="relative max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
         <PageHeader

--- a/src/pages/jd-analyzing/ui/JdAnalyzingPage.tsx
+++ b/src/pages/jd-analyzing/ui/JdAnalyzingPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useJdAnalyzingStore, type StepStatus } from "@/features/jd";
-import { Navigation, Card, Badge, Button } from "@/shared/ui";
+import { Card, Badge, Button } from "@/shared/ui";
 
 function StepBadge({ label, status }: { label: string; status: StepStatus }) {
   const variant = status === "done" ? "success" : status === "active" ? "info" : "default";
@@ -35,7 +35,6 @@ export function JdAnalyzingPage() {
 
   return (
     <div className="min-h-screen bg-white text-[#0A0A0A]">
-      <Navigation title="채용공고" />
 
       <div className="max-w-container-sm mx-auto pt-[28px] px-8 pb-[60px] max-[640px]:pt-5 max-[640px]:px-4 max-[640px]:pb-10">
         {/* BREADCRUMB */}

--- a/src/pages/jd-detail/ui/JdDetailPage.tsx
+++ b/src/pages/jd-detail/ui/JdDetailPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useJdDetailStore, type JdStatus } from "@/features/jd";
-import { Navigation } from "@/shared/ui";
 
 const STATUS_OPTIONS: { value: JdStatus; icon: string; label: string; sub: string }[] = [
   { value: "planned", icon: "📅", label: "지원 예정",  sub: "곧 지원할 예정" },
@@ -38,7 +37,6 @@ export function JdDetailPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-white">
-        <Navigation title="채용공고" />
         <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
           <div className="text-center py-20 text-[15px] text-[#6B7280]">불러오는 중...</div>
         </div>
@@ -50,7 +48,6 @@ export function JdDetailPage() {
   if (error || !jd) {
     return (
       <div className="min-h-screen bg-white">
-        <Navigation title="채용공고" />
         <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
           <div className="text-center py-[60px] flex flex-col items-center text-[15px] text-[#DC2626]">
             <p>{error ?? "채용공고를 찾을 수 없습니다."}</p>
@@ -65,7 +62,6 @@ export function JdDetailPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      <Navigation title="채용공고" />
 
       <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
         {/* BREADCRUMB */}

--- a/src/pages/jd-edit/ui/JdEditPage.tsx
+++ b/src/pages/jd-edit/ui/JdEditPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useJdEditStore, type JdStatus } from "@/features/jd";
-import { Navigation } from "@/shared/ui";
 
 const STATUS_OPTIONS: { value: JdStatus; icon: string; label: string; desc: string }[] = [
   { value: "planned", icon: "📅", label: "지원 예정", desc: "곧 지원할 예정" },
@@ -44,7 +43,6 @@ export function JdEditPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-white">
-        <Navigation title="채용공고" />
         <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
           <div className="text-center py-20 text-[15px] text-[#6B7280]">불러오는 중...</div>
         </div>
@@ -56,7 +54,6 @@ export function JdEditPage() {
   if (!jd) {
     return (
       <div className="min-h-screen bg-white">
-        <Navigation title="채용공고" />
         <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
           <div className="text-center py-[60px] flex flex-col items-center text-[15px] text-[#DC2626]">
             <p>{error ?? "채용공고를 찾을 수 없습니다."}</p>
@@ -69,7 +66,6 @@ export function JdEditPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      <Navigation title="채용공고" />
 
       <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
         {/* BREADCRUMB */}

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useJdListStore, type JdListItem } from "@/features/jd";
-import { Navigation } from "@/shared/ui";
 
 type FilterKey = "all" | "planned" | "applied" | "saved";
 
@@ -184,7 +183,6 @@ export function JdListPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      <Navigation title="채용공고" />
 
       <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
 

--- a/src/pages/resume-input/ui/ResumeInputPage.tsx
+++ b/src/pages/resume-input/ui/ResumeInputPage.tsx
@@ -57,31 +57,6 @@ export function ResumeInputPage() {
 
   return (
     <div className="bg-white font-inter text-[#0A0A0A] min-h-screen pb-[100px] antialiased">
-      {/* ── NAV ── */}
-      <nav className="sticky top-0 z-[100] bg-white/92 backdrop-blur-[24px] border-b border-[#E5E7EB]">
-        <div className="max-w-container-xl mx-auto px-6 h-16 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-[10px]">
-            <button
-              className="w-9 h-9 rounded-[14px] bg-[#F9FAFB] border border-[#E5E7EB] cursor-pointer flex items-center justify-center shadow-[var(--sw)] text-[#0A0A0A] text-[18px] transition-[background] duration-150 hover:bg-[#F3F4F6]"
-              onClick={() => navigate(-1)}
-              aria-label="뒤로가기"
-            >
-              ←
-            </button>
-            <a
-              href="/home"
-              className="flex items-center"
-            >
-              <img src="/logo-korean.png" alt="미핏" className="h-[36px] w-auto" />
-            </a>
-          </div>
-          <span className="font-inter text-[16px] font-extrabold text-[#0A0A0A] md:text-[18px]">
-            이력서 등록
-          </span>
-          <div style={{ width: 36 }} />
-        </div>
-      </nav>
-
       {/* ── STEP BAR ── */}
       <div className="bg-white/50 backdrop-blur-[12px] border-b border-[#E5E7EB]">
         <div className="max-w-container-xl mx-auto px-6 py-[14px] flex items-center justify-center gap-2 md:gap-3 md:py-4 md:px-8">

--- a/src/pages/resume-list/ui/ResumeListPage.tsx
+++ b/src/pages/resume-list/ui/ResumeListPage.tsx
@@ -151,17 +151,6 @@ export function ResumeListPage() {
   return (
     <div className="bg-white font-inter text-[#0A0A0A] min-h-screen pb-20 [-webkit-font-smoothing:antialiased]">
 
-      {/* ── NAV ── */}
-      <nav className="sticky top-0 z-[100] bg-[rgba(255,255,255,.92)] backdrop-blur-[24px] border-b border-[#E5E7EB]">
-        <div className="max-w-container-xl mx-auto px-8 h-[60px] flex items-center justify-between gap-4">
-          <div className="flex items-center gap-4">
-            <button className="w-9 h-9 rounded-lg bg-[#F9FAFB] border border-[#E5E7EB] cursor-pointer flex items-center justify-center shadow-[var(--sw)] text-[#0A0A0A] text-[18px] transition-[background] duration-[150ms] hover:bg-[#F3F4F6]" onClick={() => navigate("/home")} aria-label="홈으로">←</button>
-          </div>
-          <span className="font-inter text-[17px] font-extrabold text-[#0A0A0A]">내 이력서</span>
-          <button className="w-9 h-9 rounded-lg bg-[#0A0A0A] border-none cursor-pointer flex items-center justify-center text-white text-[20px] font-bold shadow-[var(--sb)] transition-opacity duration-[150ms] hover:opacity-85" onClick={() => navigate("/resume/upload")} aria-label="이력서 추가">＋</button>
-        </div>
-      </nav>
-
       {/* ── MAIN ── */}
       <main className="max-w-container-xl mx-auto px-5 md:px-10">
 

--- a/src/pages/resume-upload/ui/ResumeUploadPage.tsx
+++ b/src/pages/resume-upload/ui/ResumeUploadPage.tsx
@@ -106,21 +106,6 @@ export function ResumeUploadPage() {
   return (
     <div className="bg-white font-['Inter',sans-serif] text-[#0A0A0A] min-h-screen pb-[100px] antialiased">
 
-      {/* ── NAV ── */}
-      <nav className="sticky top-0 z-[100] bg-[rgba(255,255,255,.92)] backdrop-blur-[24px] border-b border-[#E5E7EB]">
-        <div className="max-w-container-xl mx-auto px-6 h-16 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-[10px]">
-            <button
-              className="w-9 h-9 rounded-[8px] bg-[#F9FAFB] border border-[#E5E7EB] cursor-pointer flex items-center justify-center shadow-[var(--sw)] text-[#0A0A0A] text-lg transition-colors hover:bg-[#F3F4F6]"
-              onClick={() => navigate(-1)}
-              aria-label="뒤로가기"
-            >←</button>
-          </div>
-          <span className="text-base md:text-lg font-extrabold text-[#0A0A0A]">이력서 등록</span>
-          <div style={{ width: 36 }} />
-        </div>
-      </nav>
-
       {/* ── STEP BAR ── */}
       <div className="bg-[rgba(255,255,255,.5)] backdrop-blur-[12px] border-b border-[#E5E7EB]">
         <div className="max-w-container-xl mx-auto px-6 py-[14px] md:py-4 md:px-8 flex items-center justify-center gap-2 md:gap-3">

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useSettingsStore } from "@/features/settings";
 import type { SettingsPanel } from "@/features/settings";
 
@@ -85,26 +85,6 @@ export function SettingsPage() {
   return (
     <>
       <div className="sp-wrap">
-        {/* NAV */}
-        <nav className="sticky top-0 z-[200] bg-white/92 backdrop-blur-[20px] border-b border-[#E5E7EB] h-[60px] flex items-center px-8 gap-4">
-          <button
-            className={`${menuOpen ? "open" : ""} hidden w-10 h-10 bg-none border border-[#E5E7EB] rounded-lg cursor-pointer items-center justify-center transition-[background] duration-150 hover:bg-[#F9FAFB] max-[1024px]:flex`}
-            onClick={() => setMenuOpen(!menuOpen)}
-            aria-label="메뉴"
-          >
-            <div className="flex flex-col gap-1">
-              <span className={`w-[18px] h-0.5 bg-[#0A0A0A] rounded-sm transition-all duration-200 ${menuOpen ? "rotate-45 translate-x-[5px] translate-y-[5px]" : ""}`} />
-              <span className={`w-[18px] h-0.5 bg-[#0A0A0A] rounded-sm transition-all duration-200 ${menuOpen ? "opacity-0" : ""}`} />
-              <span className={`w-[18px] h-0.5 bg-[#0A0A0A] rounded-sm transition-all duration-200 ${menuOpen ? "-rotate-45 translate-x-[5px] -translate-y-[5px]" : ""}`} />
-            </div>
-          </button>
-          <Link to="/home" className="flex items-center mr-auto">
-            <img src="/logo-korean.png" alt="미핏" className="h-[36px] w-auto" />
-          </Link>
-          <Link to="/home" className="text-[13px] font-semibold text-[#6B7280] no-underline px-3 py-[6px] rounded-lg flex items-center gap-1 transition-[color,background] duration-150 hover:text-[#0A0A0A] hover:bg-[#F9FAFB]">
-            ← 홈으로
-          </Link>
-        </nav>
 
         {/* Overlay */}
         <div

--- a/src/pages/streak/ui/StreakPage.tsx
+++ b/src/pages/streak/ui/StreakPage.tsx
@@ -30,28 +30,6 @@ export function StreakPage() {
 
   return (
     <>
-      {/* NAV */}
-      <nav className="sticky top-0 z-[200] bg-white/[.92] backdrop-blur-[20px] border-b border-[#E5E7EB] h-[60px] flex items-center px-8 gap-3 max-sm:px-4">
-        <Link
-          to="/home"
-          className="flex items-center mr-auto"
-        >
-          <img src="/logo-korean.png" alt="미핏" className="h-[36px] w-auto" />
-        </Link>
-        <Link
-          to="/home"
-          className="text-[13px] font-semibold text-[#6B7280] no-underline py-1.5 px-3 rounded-lg transition-colors hover:text-[#0A0A0A] hover:bg-[#F9FAFB]"
-        >
-          ← 홈으로
-        </Link>
-        <Link
-          to="/interview/setup"
-          className="text-[13px] font-bold text-white bg-[#0A0A0A] border-none rounded-lg py-[9px] px-[18px] cursor-pointer no-underline whitespace-nowrap inline-flex items-center gap-[5px] transition-[opacity,transform] hover:opacity-85 hover:-translate-y-px"
-        >
-          면접 시작 →
-        </Link>
-      </nav>
-
       <div className="bg-white min-h-[calc(100vh-60px)] p-8 max-w-container mx-auto max-sm:p-[20px_16px]">
         {loading && !data ? (
           <div className="flex flex-col gap-4">

--- a/src/pages/subscription/ui/SubscriptionPage.tsx
+++ b/src/pages/subscription/ui/SubscriptionPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { Link } from "react-router-dom";
 import { useSubscriptionStore } from "@/features/subscription";
 
 /* ── Feature comparison rows ── */
@@ -93,22 +92,6 @@ export function SubscriptionPage() {
 
   return (
     <>
-      {/* NAV */}
-      <nav className="sticky top-0 z-[200] bg-[rgba(255,255,255,.92)] backdrop-blur-[20px] border-b border-[#E5E7EB] h-[60px] flex items-center px-4 sm:px-8 gap-3">
-        <Link
-          to="/home"
-          className="flex items-center mr-auto"
-        >
-          <img src="/logo-korean.png" alt="미핏" className="h-[36px] w-auto" />
-        </Link>
-        <Link
-          to="/home"
-          className="text-[13px] font-semibold text-[#6B7280] no-underline px-3 py-1.5 rounded-lg transition-[color,background] hover:text-[#0A0A0A] hover:bg-[#F9FAFB]"
-        >
-          ← 홈으로
-        </Link>
-      </nav>
-
       <div className="bg-white min-h-[calc(100vh-60px)] pb-20">
         <div className="max-w-[900px] mx-auto px-4 sm:px-8">
 

--- a/src/shared/ui/Navigation.tsx
+++ b/src/shared/ui/Navigation.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "@/features/auth";
-import { MobileTabBar } from "./MobileTabBar";
 
 interface NavigationProps {
   activeTab?: "home" | "interview" | "resume" | "jd" | "settings";
@@ -144,8 +143,6 @@ export function Navigation({ activeTab = "jd", className = "", title }: Navigati
           <div className="hp-ssc-num" style={{ fontSize: 18 }}>{user?.name || "사용자"}</div>
         </div>
       </aside>
-
-      <MobileTabBar activeTab={activeTab} />
     </>
   );
 }


### PR DESCRIPTION
## 관련 이슈
Closes #54 

## 변경 사항
- `AppLayout` 컴포넌트 신규 생성 — 공통 Navbar(상단) + Sidebar(좌측) + MobileTabBar(하단) 포함
- `ProtectedRoute`에 `AppLayout` 적용하여 모든 인증 페이지에 자동으로 레이아웃 적용
- `HomePage`에서 중복 Navbar/Sidebar 제거, content만 유지
- `InterviewSetupPage` 자체 중복 Sidebar/grid 제거
- 각 페이지(jd, resume, settings, streak, subscription 등)에서 개별 `<nav>` 및 `Navigation` 컴포넌트 제거
- 상단 Navbar에서 이력서/채용공고 링크 버튼 제거
- 반응형 처리: 데스크탑(>1024px) — 좌측 Sidebar 고정 노출 / 중간(≤1024px) — 햄버거 버튼으로 슬라이드 Sidebar / 모바일(≤640px) — MobileTabBar

## 변경 유형
- [ ] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 로그인 후 `/home`, `/jd`, `/resume`, `/settings`, `/streak`, `/subscription`, `/interview/setup` 등 각 페이지 진입 시 상단 Navbar + 좌측 Sidebar가 동일하게 노출되는지 확인
2. 브라우저 너비를 1024px 이하로 줄였을 때 Sidebar가 사라지고 햄버거 버튼이 나타나며, 클릭 시 슬라이드 Sidebar가 열리는지 확인
3. 모바일(640px 이하)에서 하단 MobileTabBar가 노출되고 Sidebar/햄버거가 숨겨지는지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
### Before
각 페이지마다 개별 Navbar가 존재하거나 Navbar가 없는 페이지 혼재

### After
모든 인증 페이지에서 동일한 Navbar + Sidebar 레이아웃 적용
<img width="1669" height="979" alt="image" src="https://github.com/user-attachments/assets/04c58e2c-ae55-459c-9621-d45fa0f4effb" />

## 추가 정보
- `AppLayout`은 `src/app/AppLayout.tsx`에 위치하며 `ProtectedRoute`를 통해 자동 적용됩니다
- 기존 `shared/ui/Navigation` 컴포넌트는 현재 미사용 상태이며 추후 정리 예정입니다
- `HomePage.css`의 레이아웃 클래스(`hp-shell`, `hp-nav` 등)를 공통으로 재사용합니다


