### PR TITLE
[056] 현재 페이지 기반으로 네비게이션 active 상태 동적 처리

### DIFF
--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 interface HomeSidebarProps {
   menuOpen: boolean;
@@ -9,21 +9,26 @@ interface HomeSidebarProps {
 }
 
 export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = false }: HomeSidebarProps) {
+  const location = useLocation();
+  const path = location.pathname;
+
+  const isActive = (prefix: string) => path.startsWith(prefix);
+
   const cls = `hp-sidebar${floating ? " hp-sidebar--floating" : ""}${menuOpen ? " open" : ""}`;
   return (
     <aside className={cls}>
       <div className="hp-sb-sep">메인</div>
-      <Link to="/home" className="hp-sb-item active">
+      <Link to="/home" className={`hp-sb-item${isActive("/home") ? " active" : ""}`}>
         <span className="hp-sb-icon">🏠</span>홈
       </Link>
-      <Link to="/interview/setup" className="hp-sb-item">
+      <Link to="/interview/setup" className={`hp-sb-item${isActive("/interview") ? " active" : ""}`}>
         <span className="hp-sb-icon">🎥</span>면접 시작
       </Link>
       <div className="hp-sb-sep">관리</div>
-      <Link to="/resume" className="hp-sb-item">
+      <Link to="/resume" className={`hp-sb-item${isActive("/resume") ? " active" : ""}`}>
         <span className="hp-sb-icon">📄</span>이력서
       </Link>
-      <Link to="/jd" className="hp-sb-item">
+      <Link to="/jd" className={`hp-sb-item${isActive("/jd") ? " active" : ""}`}>
         <span className="hp-sb-icon">🏢</span>채용공고
         {jdCount > 0 && <span className="hp-sb-badge">{jdCount}</span>}
       </Link>
@@ -31,14 +36,14 @@ export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = f
       <Link to="#" className="hp-sb-item">
         <span className="hp-sb-icon">📊</span>리뷰 리포트
       </Link>
-      <Link to="/streak" className="hp-sb-item">
+      <Link to="/streak" className={`hp-sb-item${isActive("/streak") ? " active" : ""}`}>
         <span className="hp-sb-icon">🔥</span>스트릭
       </Link>
       <div className="hp-sb-sep">설정</div>
-      <Link to="/subscription" className="hp-sb-item">
+      <Link to="/subscription" className={`hp-sb-item${isActive("/subscription") ? " active" : ""}`}>
         <span className="hp-sb-icon">💳</span>요금제
       </Link>
-      <Link to="/settings" className="hp-sb-item">
+      <Link to="/settings" className={`hp-sb-item${isActive("/settings") ? " active" : ""}`}>
         <span className="hp-sb-icon">⚙️</span>계정 설정
       </Link>
       <div className="hp-sb-streak-card">

--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -12,7 +12,7 @@ export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = f
   const location = useLocation();
   const path = location.pathname;
 
-  const isActive = (prefix: string) => path.startsWith(prefix);
+  const isActive = (prefix: string) => path === prefix || path.startsWith(prefix + "/");
 
   const cls = `hp-sidebar${floating ? " hp-sidebar--floating" : ""}${menuOpen ? " open" : ""}`;
   return (

--- a/src/shared/ui/Navigation.tsx
+++ b/src/shared/ui/Navigation.tsx
@@ -18,6 +18,8 @@ export function Navigation({ className = "", title }: NavigationProps) {
     if (path.startsWith("/interview")) return "interview";
     if (path.startsWith("/resume")) return "resume";
     if (path.startsWith("/jd")) return "jd";
+    if (path.startsWith("/streak")) return "streak";
+    if (path.startsWith("/subscription")) return "subscription";
     if (path.startsWith("/settings")) return "settings";
     return null;
   };

--- a/src/shared/ui/Navigation.tsx
+++ b/src/shared/ui/Navigation.tsx
@@ -1,16 +1,28 @@
 import { useState, useRef, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useAuthStore } from "@/features/auth";
 
 interface NavigationProps {
-  activeTab?: "home" | "interview" | "resume" | "jd" | "settings";
   className?: string;
   title?: string;
 }
 
-export function Navigation({ activeTab = "jd", className = "", title }: NavigationProps) {
+export function Navigation({ className = "", title }: NavigationProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { user, logout } = useAuthStore();
+
+  const getActiveTab = () => {
+    const path = location.pathname;
+    if (path.startsWith("/home")) return "home";
+    if (path.startsWith("/interview")) return "interview";
+    if (path.startsWith("/resume")) return "resume";
+    if (path.startsWith("/jd")) return "jd";
+    if (path.startsWith("/settings")) return "settings";
+    return null;
+  };
+
+  const activeTab = getActiveTab();
   const [menuOpen, setMenuOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -55,8 +67,8 @@ export function Navigation({ activeTab = "jd", className = "", title }: Navigati
           </span>
         )}
 
-        <Link to="/resume" className="hp-nav-link">이력서</Link>
-        <Link to="/jd" className="hp-nav-link">채용공고</Link>
+        <Link to="/resume" className={`hp-nav-link${activeTab === "resume" ? " active" : ""}`}>이력서</Link>
+        <Link to="/jd" className={`hp-nav-link${activeTab === "jd" ? " active" : ""}`}>채용공고</Link>
 
         {/* Profile dropdown */}
         <div className="relative" ref={dropdownRef}>
@@ -111,14 +123,14 @@ export function Navigation({ activeTab = "jd", className = "", title }: Navigati
       {/* Sidebar */}
       <aside className={`hp-sidebar nav-sidebar${menuOpen ? " open" : ""}`}>
         <div className="hp-sb-sep">메인</div>
-        <Link to="/home" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+        <Link to="/home" className={`hp-sb-item${activeTab === "home" ? " active" : ""}`} onClick={() => setMenuOpen(false)}>
           <span className="hp-sb-icon">🏠</span>홈
         </Link>
-        <Link to="/interview/setup" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+        <Link to="/interview/setup" className={`hp-sb-item${activeTab === "interview" ? " active" : ""}`} onClick={() => setMenuOpen(false)}>
           <span className="hp-sb-icon">🎥</span>면접 시작
         </Link>
         <div className="hp-sb-sep">관리</div>
-        <Link to="/resume" className="hp-sb-item" onClick={() => setMenuOpen(false)}>
+        <Link to="/resume" className={`hp-sb-item${activeTab === "resume" ? " active" : ""}`} onClick={() => setMenuOpen(false)}>
           <span className="hp-sb-icon">📄</span>이력서
         </Link>
         <Link to="/jd" className={`hp-sb-item${activeTab === "jd" ? " active" : ""}`} onClick={() => setMenuOpen(false)}>


### PR DESCRIPTION
## 관련 이슈
Closes #56 

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.
- `HomeSidebar.tsx`: 홈에 하드코딩된 `active` 클래스를 `useLocation` 기반 동적 처리로 교체
- `Navigation.tsx`: `activeTab` prop 제거 후 내부에서 `useLocation`으로 현재 경로 자동 감지
- 데스크탑 navbar 링크(이력서, 채용공고)에도 active 클래스 적용

## 변경 유형
- [x] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 각 페이지(홈, 이력서, 채용공고, 설정 등)로 이동
2. 데스크탑 화면에서 사이드바의 현재 페이지 항목이 파란색으로 표시되는지 확인
3. 모바일 화면에서 햄버거 메뉴 열었을 때 동일하게 현재 페이지 항목이 active 상태인지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->
<img width="216" height="916" alt="image" src="https://github.com/user-attachments/assets/a47e69ac-cf4e-4231-b01b-00483f190425" />

## 추가 정보
`HomeSidebar`에 `active` 클래스가 `/home` 경로에 하드코딩되어 있어 다른 페이지에서도 항상 홈이 활성화되는 문제였습니다. `useLocation`을 사용해 경로 prefix 기반으로 동적 처리했습니다.
