### PR TITLE
[025] onboardingApi mock 제거 및 실제 API 연동

### DIFF
--- a/src/features/onboarding/api/onboardingApi.ts
+++ b/src/features/onboarding/api/onboardingApi.ts
@@ -17,8 +17,5 @@ export async function submitOnboardingProfileApi(payload: {
   jobCategoryId: number;
   jobIds: number[];
 }): Promise<void> {
-  await profileApi.saveMyProfile({
-    jobCategoryId: payload.jobCategoryId,
-    jobIds: payload.jobIds,
-  });
+  await profileApi.saveMyProfile(payload);
 }

--- a/src/features/onboarding/api/onboardingApi.ts
+++ b/src/features/onboarding/api/onboardingApi.ts
@@ -3,12 +3,6 @@ import type { JobCategory, Job } from "@/shared/api/profileApi";
 
 export type { JobCategory, Job };
 
-export interface OnboardingPayload {
-  jobCategoryId: number;
-  jobIds: number[];
-  jobStatus: string; // 백엔드 미지원, 프론트에서만 보관
-}
-
 export async function fetchJobCategoriesApi(): Promise<JobCategory[]> {
   const res = await profileApi.getJobCategories();
   return res.results;
@@ -19,16 +13,12 @@ export async function fetchJobsByCategoryApi(jobCategoryId: number): Promise<Job
   return res.results;
 }
 
-export async function submitOnboardingProfileApi(
-  payload: OnboardingPayload
-): Promise<{ success: boolean; message: string }> {
-  try {
-    await profileApi.saveMyProfile({
-      jobCategoryId: payload.jobCategoryId,
-      jobIds: payload.jobIds,
-    });
-    return { success: true, message: "프로필이 저장되었습니다." };
-  } catch {
-    return { success: false, message: "프로필 저장에 실패했습니다." };
-  }
+export async function submitOnboardingProfileApi(payload: {
+  jobCategoryId: number;
+  jobIds: number[];
+}): Promise<void> {
+  await profileApi.saveMyProfile({
+    jobCategoryId: payload.jobCategoryId,
+    jobIds: payload.jobIds,
+  });
 }

--- a/src/features/onboarding/model/store.ts
+++ b/src/features/onboarding/model/store.ts
@@ -27,7 +27,7 @@ interface OnboardingState {
   availableJobsLoading: boolean;
   selectedJobIds: number[];
 
-  jobStatus: string;
+  jobStatus: string; // 프론트 전용 (백엔드 미지원)
   isLoading: boolean;
   error: string | null;
 
@@ -93,7 +93,7 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
   setJobStatus: (status) => set({ jobStatus: status }),
 
   submitProfile: async () => {
-    const { selectedJobCategoryId, selectedJobIds, jobStatus } = get();
+    const { selectedJobCategoryId, selectedJobIds } = get();
     if (!selectedJobCategoryId) {
       set({ error: "희망 직군을 선택해주세요." });
       return false;
@@ -103,17 +103,17 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
       return false;
     }
     set({ isLoading: true, error: null });
-    const res = await submitOnboardingProfileApi({
-      jobCategoryId: selectedJobCategoryId,
-      jobIds: selectedJobIds,
-      jobStatus,
-    });
-    if (!res.success) {
-      set({ isLoading: false, error: res.message });
+    try {
+      await submitOnboardingProfileApi({
+        jobCategoryId: selectedJobCategoryId,
+        jobIds: selectedJobIds,
+      });
+      set({ isLoading: false });
+      return true;
+    } catch {
+      set({ isLoading: false, error: "프로필 저장에 실패했습니다." });
       return false;
     }
-    set({ isLoading: false });
-    return true;
   },
 
   clearError: () => set({ error: null }),

--- a/src/features/onboarding/model/store.ts
+++ b/src/features/onboarding/model/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { isApiError } from "@/shared/api/client";
 import {
   fetchJobCategoriesApi,
   fetchJobsByCategoryApi,
@@ -110,8 +111,9 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
       });
       set({ isLoading: false });
       return true;
-    } catch {
-      set({ isLoading: false, error: "프로필 저장에 실패했습니다." });
+    } catch (e) {
+      const message = isApiError(e) && e.message ? e.message : "프로필 저장에 실패했습니다.";
+      set({ isLoading: false, error: message });
       return false;
     }
   },


### PR DESCRIPTION
## 관련 이슈
Closes #25

## 변경 사항
- `OnboardingPayload` 타입에서 `jobStatus` 필드 제거 (백엔드 미지원 필드)
- `submitOnboardingProfileApi`의 `{ success, message }` 래퍼 패턴 제거 → 에러를 직접 throw하도록 변경
- `useOnboardingStore`의 `submitProfile`을 try/catch로 에러 처리하도록 수정
- `profileApi`를 단순 래핑하던 불필요한 레이어 정리

## 변경 유형
- [ ] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 온보딩 페이지에서 희망 직군 선택
2. 희망 직업 1~3개 선택 후 "면접 시작하러 가기" 클릭
3. 프로필 저장 성공 시 `/home`으로 이동, 실패 시 에러 메시지 노출 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경 없음

## 추가 정보
기존 `submitOnboardingProfileApi`는 내부에서 try/catch로 에러를 삼키고 `{ success, message }` 형태로 반환하는 패턴이었습니다. 이로 인해 실제 API 에러 정보가 숨겨지고, store 레이어에서 에러를 제어할 수 없었습니다. 이번 변경으로 API 함수는 실패 시 throw하고, store에서 직접 catch하여 처리하는 일관된 패턴으로 통일했습니다. `jobStatus`는 백엔드 미지원 필드로 API 전송 대상에서 제외했으며, store 내 프론트 전용 상태로만 유지됩니다.