### PR TITLE
[061] api 연결

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Toaster } from "sonner";
 import { useAuthStore } from "@/features/auth";
+import { setOnRefreshFailed } from "@/shared/api/client";
 import { ProtectedRoute } from "./ProtectedRoute";
 
 import { LandingPage } from "@/pages/landing";
@@ -26,9 +27,11 @@ import { SubscriptionPage } from "@/pages/subscription";
 import { NotificationsPage } from "@/pages/notifications";
 
 function App() {
-  const { initAuth } = useAuthStore();
+  const { initAuth, logout } = useAuthStore();
 
   useEffect(() => {
+    // refresh 토큰 만료 시 자동 로그아웃
+    setOnRefreshFailed(() => logout());
     initAuth();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Toaster } from "sonner";
 import { useAuthStore } from "@/features/auth";
+import { useNotificationStore } from "@/features/notifications";
 import { setOnRefreshFailed } from "@/shared/api/client";
 import { ProtectedRoute } from "./ProtectedRoute";
 
@@ -27,13 +28,22 @@ import { SubscriptionPage } from "@/pages/subscription";
 import { NotificationsPage } from "@/pages/notifications";
 
 function App() {
-  const { initAuth, logout } = useAuthStore();
+  const { initAuth, logout, user } = useAuthStore();
+  const { connectWs, disconnectWs } = useNotificationStore();
 
   useEffect(() => {
-    // refresh 토큰 만료 시 자동 로그아웃
     setOnRefreshFailed(() => logout());
     initAuth();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // 로그인 상태 변화에 따라 WebSocket 연결/해제
+  useEffect(() => {
+    if (user) {
+      connectWs();
+    } else {
+      disconnectWs();
+    }
+  }, [user, connectWs, disconnectWs]);
 
   return (
     <BrowserRouter>

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -151,3 +151,50 @@ export async function getMeApi(): Promise<UserMe | null> {
     return null;
   }
 }
+
+/* ── Change Password ── */
+export interface ChangePasswordPayload {
+  currentPassword: string;
+  newPassword: string;
+}
+
+export interface ChangePasswordResult {
+  success: boolean;
+  message: string;
+}
+
+export async function changePasswordApi(payload: ChangePasswordPayload): Promise<ChangePasswordResult> {
+  try {
+    await apiRequest("/api/v1/users/change-password/", {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify({
+        current_password: payload.currentPassword,
+        new_password1: payload.newPassword,
+        new_password2: payload.newPassword,
+      }),
+    });
+    return { success: true, message: "비밀번호가 변경되었습니다." };
+  } catch (err: unknown) {
+    return { success: false, message: parseApiError(err, "비밀번호 변경에 실패했습니다.") };
+  }
+}
+
+/* ── Unregister ── */
+export interface UnregisterResult {
+  success: boolean;
+  message: string;
+}
+
+export async function unregisterApi(): Promise<UnregisterResult> {
+  try {
+    await apiRequest("/api/v1/users/unregister/", {
+      method: "DELETE",
+      auth: true,
+    });
+    clearTokens();
+    return { success: true, message: "회원탈퇴가 완료되었습니다." };
+  } catch (err: unknown) {
+    return { success: false, message: parseApiError(err, "회원탈퇴에 실패했습니다.") };
+  }
+}

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,4 +1,5 @@
 import { apiRequest, setTokens, clearTokens, getRefreshToken } from "@/shared/api/client";
+import { getTermsDocumentsApi, postTermsConsentsApi } from "./termsApi";
 
 function parseApiError(err: unknown, fallback: string): string {
   const e = err as { message?: string; fieldErrors?: Record<string, string[]> };
@@ -35,6 +36,10 @@ export interface SignUpResult {
 
 export async function signUpApi(payload: SignUpPayload): Promise<SignUpResult> {
   try {
+    // 1. 약관 목록 조회
+    const terms = await getTermsDocumentsApi();
+
+    // 2. 회원가입
     const res = await apiRequest<AuthResponse>("/api/v1/users/sign-up/", {
       method: "POST",
       body: JSON.stringify({
@@ -45,6 +50,14 @@ export async function signUpApi(payload: SignUpPayload): Promise<SignUpResult> {
       }),
     });
     setTokens(res.access, res.refresh);
+
+    // 3. 약관 일괄 동의 (토큰 세팅 후 auth 요청)
+    if (terms.length > 0) {
+      await postTermsConsentsApi(
+        terms.map((t) => ({ termsDocumentId: t.id, agreed: true }))
+      );
+    }
+
     return {
       success: true,
       message: "회원가입이 완료되었습니다.",
@@ -144,9 +157,9 @@ export async function resendVerifyEmailApi(): Promise<ResendVerifyResult> {
 }
 
 /* ── Get Current User ── */
-export async function getMeApi(): Promise<UserMe | null> {
+export async function getMeApi(options?: { noRetry?: boolean }): Promise<UserMe | null> {
   try {
-    return await apiRequest<UserMe>("/api/v1/users/me/", { auth: true });
+    return await apiRequest<UserMe>("/api/v1/users/me/", { auth: true, noRetry: options?.noRetry });
   } catch {
     return null;
   }

--- a/src/features/auth/api/termsApi.ts
+++ b/src/features/auth/api/termsApi.ts
@@ -1,0 +1,58 @@
+import { apiRequest } from "@/shared/api/client";
+
+/* ── Types ── */
+export interface TermsDocument {
+  id: number;
+  title: string;
+  version: string;
+  isRequired: boolean;
+  content?: string;
+}
+
+export interface MyConsent {
+  termsDocumentId: number;
+  title: string;
+  version: string;
+  agreedAt: string;
+}
+
+/* ── GET /api/v1/terms-documents/ ── */
+export async function getTermsDocumentsApi(): Promise<TermsDocument[]> {
+  try {
+    const res = await apiRequest<TermsDocument[] | { results?: TermsDocument[] }>(
+      "/api/v1/terms-documents/"
+    );
+    return Array.isArray(res) ? res : (res.results ?? []);
+  } catch {
+    return [];
+  }
+}
+
+/* ── POST /api/v1/terms-documents/consents/ ── */
+export async function postTermsConsentsApi(
+  consents: { termsDocumentId: number; agreed: boolean }[]
+): Promise<{ success: boolean; message: string }> {
+  try {
+    await apiRequest("/api/v1/terms-documents/consents/", {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify({ consents }),
+    });
+    return { success: true, message: "약관 동의가 완료되었습니다." };
+  } catch {
+    return { success: false, message: "약관 동의에 실패했습니다." };
+  }
+}
+
+/* ── GET /api/v1/terms-documents/my-consents/ ── */
+export async function getMyConsentsApi(): Promise<MyConsent[]> {
+  try {
+    const res = await apiRequest<MyConsent[] | { results?: MyConsent[] }>(
+      "/api/v1/terms-documents/my-consents/",
+      { auth: true }
+    );
+    return Array.isArray(res) ? res : (res.results ?? []);
+  } catch {
+    return [];
+  }
+}

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,2 +1,4 @@
 export { useAuthStore } from "./model/store";
 export type { UserMe } from "./api/authApi";
+export { changePasswordApi, unregisterApi } from "./api/authApi";
+export type { ChangePasswordPayload, ChangePasswordResult, UnregisterResult } from "./api/authApi";

--- a/src/features/auth/model/store.ts
+++ b/src/features/auth/model/store.ts
@@ -123,7 +123,7 @@ export const useAuthStore = create<AuthState>()((set) => ({
       }
     }
 
-    const me = await getMeApi();
+    const me = await getMeApi({ noRetry: true });
     set({ user: me ?? null, authReady: true });
   },
 

--- a/src/features/notifications/model/store.ts
+++ b/src/features/notifications/model/store.ts
@@ -1,4 +1,6 @@
 import { create } from "zustand";
+import { RealtimeClient } from "@/shared/api/realtimeApi";
+import type { WsNotificationMessage } from "@/shared/api/realtimeApi";
 
 export interface Notification {
   id: number;
@@ -8,26 +10,42 @@ export interface Notification {
   category: "interview" | "resume" | "jd" | "system";
 }
 
-// 프론트 확인용 더미 데이터
-const DUMMY_NOTIFICATIONS: Notification[] = [
-  { id: 1, message: "새로운 채용공고가 등록되었습니다.", time: "방금 전", read: false, category: "jd" },
-  { id: 2, message: "이력서 분석이 완료되었습니다.", time: "10분 전", read: false, category: "resume" },
-  { id: 3, message: "면접 연습 결과를 확인해보세요.", time: "1시간 전", read: true, category: "interview" },
-  { id: 4, message: "스트릭 7일 달성! 보상이 지급되었습니다.", time: "어제", read: true, category: "system" },
-  { id: 5, message: "채용공고 '카카오 프론트엔드' 마감이 3일 남았습니다.", time: "2일 전", read: true, category: "jd" },
-  { id: 6, message: "AI 면접 리포트가 생성되었습니다.", time: "3일 전", read: true, category: "interview" },
-];
+function formatTime(isoString: string): string {
+  const diff = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+  if (diff < 60) return "방금 전";
+  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+  if (diff < 172800) return "어제";
+  return `${Math.floor(diff / 86400)}일 전`;
+}
+
+function wsMessageToNotification(msg: WsNotificationMessage): Notification {
+  return {
+    id: msg.id,
+    message: msg.message,
+    time: formatTime(msg.createdAt),
+    read: false,
+    category: msg.category,
+  };
+}
 
 interface NotificationState {
   notifications: Notification[];
+  connected: boolean;
   markAllRead: () => void;
   markRead: (id: number) => void;
   deleteNotification: (id: number) => void;
   deleteAll: () => void;
+  connectWs: () => void;
+  disconnectWs: () => void;
 }
 
+let _client: RealtimeClient | null = null;
+
 export const useNotificationStore = create<NotificationState>((set) => ({
-  notifications: DUMMY_NOTIFICATIONS,
+  notifications: [],
+  connected: false,
+
   markAllRead: () =>
     set((s) => ({ notifications: s.notifications.map((n) => ({ ...n, read: true })) })),
   markRead: (id) =>
@@ -37,4 +55,23 @@ export const useNotificationStore = create<NotificationState>((set) => ({
   deleteNotification: (id) =>
     set((s) => ({ notifications: s.notifications.filter((n) => n.id !== id) })),
   deleteAll: () => set({ notifications: [] }),
+
+  connectWs: () => {
+    if (_client) return; // 이미 연결 중
+    _client = new RealtimeClient({
+      onMessage: (msg) => {
+        set((s) => ({
+          notifications: [wsMessageToNotification(msg), ...s.notifications],
+        }));
+      },
+      onClose: () => set({ connected: false }),
+    });
+    _client.connect().then(() => set({ connected: true }));
+  },
+
+  disconnectWs: () => {
+    _client?.disconnect();
+    _client = null;
+    set({ connected: false });
+  },
 }));

--- a/src/features/resume-list/api/resumeListApi.ts
+++ b/src/features/resume-list/api/resumeListApi.ts
@@ -1,4 +1,4 @@
-const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+import { apiRequest } from "@/shared/api/client";
 
 export type ResumeStatus = "active" | "inactive" | "parsing";
 export type ResumeType = "file" | "text";
@@ -27,79 +27,85 @@ export interface ResumeSummary {
   recentQuestions: string[];
 }
 
-const MOCK_RESUMES: ResumeItem[] = [
-  {
-    id: "r1",
-    title: "백엔드 개발자 이력서 v2",
-    type: "file",
-    fileExt: "PDF",
-    skills: ["Python", "Django", "PostgreSQL", "AWS"],
-    extraSkillCount: 3,
-    meta: "🏢 스타트업 3년",
-    status: "active",
-    date: "03.20",
-  },
-  {
-    id: "r2",
-    title: "신입 개발자 자기소개",
-    type: "text",
-    skills: ["React", "TypeScript", "Node.js"],
-    extraSkillCount: 0,
-    meta: "🎓 졸업예정 2025",
-    status: "active",
-    date: "03.15",
-  },
-  {
-    id: "r3",
-    title: "프론트엔드 포트폴리오",
-    type: "file",
-    fileExt: "DOCX",
-    skills: ["Vue.js", "Figma"],
-    extraSkillCount: 0,
-    meta: "📂 업로드 완료",
-    status: "parsing",
-    date: "방금 전",
-  },
-];
+/* ── 백엔드 응답 타입 ── */
+interface ResumeApiItem {
+  uuid: string;
+  type: "file" | "text";
+  title: string;
+  isActive: boolean;
+  analysisStatus: "pending" | "processing" | "completed" | "failed";
+  analysisStep: string;
+  analyzedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
 
-const MOCK_SUMMARY: ResumeSummary = {
-  total: 3,
-  active: 2,
-  parsing: 1,
-  inactive: 0,
-  fileCount: 2,
-  textCount: 1,
-  interviewCount: 12,
-  avgScore: 83,
-  recentQuestions: [
-    "Django REST Framework에서 성능 최적화를 위해 사용한 방법은?",
-    "AWS에서 비용을 줄이기 위해 어떤 아키텍처를 선택했나요?",
-    "팀 내 코드 리뷰 문화를 어떻게 형성했나요?",
-  ],
-};
+interface ResumeListApiResponse {
+  count: number;
+  totalPagesCount: number;
+  nextPage: number | null;
+  previousPage: number | null;
+  results: ResumeApiItem[];
+}
+
+function toResumeStatus(item: ResumeApiItem): ResumeStatus {
+  if (item.analysisStatus === "pending" || item.analysisStatus === "processing") return "parsing";
+  if (!item.isActive) return "inactive";
+  return "active";
+}
+
+function formatDate(dateStr: string): string {
+  try {
+    const d = new Date(dateStr);
+    return `${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+  } catch {
+    return "";
+  }
+}
+
+function transformResume(item: ResumeApiItem): ResumeItem {
+  return {
+    id: item.uuid,
+    title: item.title,
+    type: item.type,
+    skills: [],
+    extraSkillCount: 0,
+    meta: "",
+    status: toResumeStatus(item),
+    date: formatDate(item.createdAt),
+  };
+}
+
+function buildSummary(items: ResumeApiItem[]): ResumeSummary {
+  const transformed = items.map(transformResume);
+  return {
+    total: items.length,
+    active: transformed.filter((r) => r.status === "active").length,
+    parsing: transformed.filter((r) => r.status === "parsing").length,
+    inactive: transformed.filter((r) => r.status === "inactive").length,
+    fileCount: items.filter((r) => r.type === "file").length,
+    textCount: items.filter((r) => r.type === "text").length,
+    interviewCount: 0,
+    avgScore: 0,
+    recentQuestions: [],
+  };
+}
 
 export async function fetchResumesApi(): Promise<{
   resumes: ResumeItem[];
   summary: ResumeSummary;
 }> {
-  await delay(400);
+  const response = await apiRequest<ResumeListApiResponse>("/api/v1/resumes/", { auth: true });
+  const items = response.results ?? [];
   return {
-    resumes: MOCK_RESUMES.map((r) => ({ ...r })),
-    summary: { ...MOCK_SUMMARY },
+    resumes: items.map(transformResume),
+    summary: buildSummary(items),
   };
 }
 
-export async function toggleResumeActiveApi(id: string): Promise<void> {
-  await delay(300);
-  const idx = MOCK_RESUMES.findIndex((r) => r.id === id);
-  if (idx !== -1) {
-    const r = MOCK_RESUMES[idx];
-    r.status = r.status === "active" ? "inactive" : "active";
-  }
-}
-
 export async function deleteResumeApi(id: string): Promise<void> {
-  await delay(300);
-  const idx = MOCK_RESUMES.findIndex((r) => r.id === id);
-  if (idx !== -1) MOCK_RESUMES.splice(idx, 1);
+  await apiRequest(`/api/v1/resumes/${id}/`, {
+    method: "DELETE",
+    auth: true,
+  });
 }

--- a/src/features/resume-list/api/resumeListApi.ts
+++ b/src/features/resume-list/api/resumeListApi.ts
@@ -77,18 +77,19 @@ function transformResume(item: ResumeApiItem): ResumeItem {
 }
 
 function buildSummary(items: ResumeApiItem[]): ResumeSummary {
-  const transformed = items.map(transformResume);
-  return {
-    total: items.length,
-    active: transformed.filter((r) => r.status === "active").length,
-    parsing: transformed.filter((r) => r.status === "parsing").length,
-    inactive: transformed.filter((r) => r.status === "inactive").length,
-    fileCount: items.filter((r) => r.type === "file").length,
-    textCount: items.filter((r) => r.type === "text").length,
-    interviewCount: 0,
-    avgScore: 0,
-    recentQuestions: [],
-  };
+  return items.reduce<ResumeSummary>(
+    (acc, item) => {
+      const status = toResumeStatus(item);
+      acc.total++;
+      if (status === "active") acc.active++;
+      else if (status === "parsing") acc.parsing++;
+      else if (status === "inactive") acc.inactive++;
+      if (item.type === "file") acc.fileCount++;
+      else if (item.type === "text") acc.textCount++;
+      return acc;
+    },
+    { total: 0, active: 0, parsing: 0, inactive: 0, fileCount: 0, textCount: 0, interviewCount: 0, avgScore: 0, recentQuestions: [] }
+  );
 }
 
 export async function fetchResumesApi(): Promise<{

--- a/src/features/resume-list/api/resumeListApi.ts
+++ b/src/features/resume-list/api/resumeListApi.ts
@@ -55,12 +55,10 @@ function toResumeStatus(item: ResumeApiItem): ResumeStatus {
 }
 
 function formatDate(dateStr: string): string {
-  try {
-    const d = new Date(dateStr);
-    return `${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
-  } catch {
-    return "";
-  }
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return "";
+  return `${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
 }
 
 function transformResume(item: ResumeApiItem): ResumeItem {

--- a/src/features/resume-list/model/store.ts
+++ b/src/features/resume-list/model/store.ts
@@ -1,7 +1,6 @@
 import { create } from "zustand";
 import {
   fetchResumesApi,
-  toggleResumeActiveApi,
   deleteResumeApi,
 } from "../api/resumeListApi";
 import type { ResumeItem, ResumeSummary } from "../api/resumeListApi";
@@ -17,10 +16,10 @@ interface ResumeListState {
   resumes: ResumeItem[];
   summary: ResumeSummary | null;
   loading: boolean;
+  error: string | null;
   ctxMenu: CtxMenu;
 
   fetchResumes: () => Promise<void>;
-  toggleActive: (id: string) => Promise<void>;
   deleteResume: (id: string) => Promise<void>;
   openCtx: (id: string, x: number, y: number) => void;
   closeCtx: () => void;
@@ -32,38 +31,31 @@ export const useResumeListStore = create<ResumeListState>()((set, get) => ({
   resumes: [],
   summary: null,
   loading: false,
+  error: null,
   ctxMenu: DEFAULT_CTX,
 
   fetchResumes: async () => {
-    set({ loading: true });
-    const { resumes, summary } = await fetchResumesApi();
-    set({ resumes, summary, loading: false });
-  },
-
-  toggleActive: async (id) => {
-    await toggleResumeActiveApi(id);
-    const updated = get().resumes.map((r) => {
-      if (r.id !== id) return r;
-      const next = r.status === "active" ? "inactive" : "active";
-      return { ...r, status: next as ResumeItem["status"] };
-    });
-    const active = updated.filter((r) => r.status === "active").length;
-    const inactive = updated.filter((r) => r.status === "inactive").length;
-    set((s) => ({
-      resumes: updated,
-      summary: s.summary ? { ...s.summary, active, inactive } : s.summary,
-      ctxMenu: DEFAULT_CTX,
-    }));
+    set({ loading: true, error: null });
+    try {
+      const { resumes, summary } = await fetchResumesApi();
+      set({ resumes, summary, loading: false });
+    } catch {
+      set({ loading: false, error: "이력서를 불러오지 못했습니다." });
+    }
   },
 
   deleteResume: async (id) => {
-    await deleteResumeApi(id);
-    const resumes = get().resumes.filter((r) => r.id !== id);
-    set((s) => ({
-      resumes,
-      summary: s.summary ? { ...s.summary, total: resumes.length } : s.summary,
-      ctxMenu: DEFAULT_CTX,
-    }));
+    try {
+      await deleteResumeApi(id);
+      const resumes = get().resumes.filter((r) => r.id !== id);
+      set((s) => ({
+        resumes,
+        summary: s.summary ? { ...s.summary, total: resumes.length } : s.summary,
+        ctxMenu: DEFAULT_CTX,
+      }));
+    } catch {
+      set({ ctxMenu: DEFAULT_CTX });
+    }
   },
 
   openCtx: (resumeId, x, y) => set({ ctxMenu: { open: true, resumeId, x, y } }),

--- a/src/features/resume-list/model/store.ts
+++ b/src/features/resume-list/model/store.ts
@@ -54,7 +54,7 @@ export const useResumeListStore = create<ResumeListState>()((set, get) => ({
         ctxMenu: DEFAULT_CTX,
       }));
     } catch {
-      set({ ctxMenu: DEFAULT_CTX });
+      set({ error: "이력서 삭제에 실패했습니다.", ctxMenu: DEFAULT_CTX });
     }
   },
 

--- a/src/features/resume-upload/api/resumeUploadApi.ts
+++ b/src/features/resume-upload/api/resumeUploadApi.ts
@@ -30,6 +30,7 @@ export async function uploadResumeApi(
 
   try {
     const formData = new FormData();
+    formData.append("type", "file");
     formData.append("title", payload.title);
     formData.append("file", payload.file);
 
@@ -50,7 +51,7 @@ export async function uploadResumeApi(
             resolve({
               success: true,
               message: "이력서가 업로드되었습니다.",
-              resumeId: response.id || response.resumeId,
+              resumeId: response.uuid ?? response.id,
             });
           } catch {
             reject({ message: "서버 응답을 파싱하는 데 실패했습니다." });
@@ -73,8 +74,8 @@ export async function uploadResumeApi(
         reject({ message: "업로드가 취소되었습니다." });
       });
 
-      xhr.open("POST", `${BASE_URL}/api/v1/resumes/upload/`);
-      
+      xhr.open("POST", `${BASE_URL}/api/v1/resumes/`);
+
       const token = getAccessToken();
       if (token) {
         xhr.setRequestHeader("Authorization", `Bearer ${token}`);

--- a/src/features/resume/api/resumeInputApi.ts
+++ b/src/features/resume/api/resumeInputApi.ts
@@ -75,3 +75,20 @@ export interface ResumeDetail {
 export async function fetchResumeDetailApi(uuid: string): Promise<ResumeDetail> {
   return apiRequest<ResumeDetail>(`/api/v1/resumes/${uuid}/`, { auth: true });
 }
+
+export async function updateResumeApi(
+  uuid: string,
+  payload: SaveResumePayload
+): Promise<SaveResumeResponse> {
+  try {
+    await apiRequest<ResumeDetail>(`/api/v1/resumes/${uuid}/`, {
+      method: "PATCH",
+      auth: true,
+      body: JSON.stringify({ title: payload.title, content: payload.content }),
+    });
+    return { success: true, message: "이력서가 수정되었습니다.", resumeId: uuid };
+  } catch (err: unknown) {
+    const e = err as { message?: string };
+    return { success: false, message: e?.message ?? "이력서 수정에 실패했습니다." };
+  }
+}

--- a/src/features/resume/api/resumeInputApi.ts
+++ b/src/features/resume/api/resumeInputApi.ts
@@ -56,3 +56,22 @@ export async function saveResumeApi(
     };
   }
 }
+
+export interface ResumeDetail {
+  uuid: string;
+  type: "text" | "file" | "structured";
+  title: string;
+  isActive: boolean;
+  analysisStatus: string;
+  analysisStep: string;
+  analyzedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  content?: string;
+  originalFilename?: string;
+  fileSizeBytes?: number;
+}
+
+export async function fetchResumeDetailApi(uuid: string): Promise<ResumeDetail> {
+  return apiRequest<ResumeDetail>(`/api/v1/resumes/${uuid}/`, { auth: true });
+}

--- a/src/features/resume/api/resumeInputApi.ts
+++ b/src/features/resume/api/resumeInputApi.ts
@@ -1,4 +1,4 @@
-const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+import { apiRequest } from "@/shared/api/client";
 
 export interface SaveResumePayload {
   title: string;
@@ -11,19 +11,48 @@ export interface SaveResumeResponse {
   resumeId?: string;
 }
 
+interface CreateResumeApiResponse {
+  uuid: string;
+  type: string;
+  title: string;
+  isActive: boolean;
+  analysisStatus: string;
+  analysisStep: string;
+  analyzedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export async function saveResumeApi(
   payload: SaveResumePayload
 ): Promise<SaveResumeResponse> {
-  await delay(900);
   if (!payload.title.trim()) {
     return { success: false, message: "이력서 제목을 입력해 주세요." };
   }
   if (!payload.content.trim()) {
     return { success: false, message: "이력서 내용을 입력해 주세요." };
   }
-  return {
-    success: true,
-    message: "이력서가 저장되었습니다.",
-    resumeId: `resume-${Date.now()}`,
-  };
+
+  try {
+    const response = await apiRequest<CreateResumeApiResponse>("/api/v1/resumes/", {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify({
+        type: "text",
+        title: payload.title,
+        content: payload.content,
+      }),
+    });
+    return {
+      success: true,
+      message: "이력서가 저장되었습니다.",
+      resumeId: response.uuid,
+    };
+  } catch (err: unknown) {
+    const e = err as { message?: string };
+    return {
+      success: false,
+      message: e?.message ?? "이력서 저장에 실패했습니다.",
+    };
+  }
 }

--- a/src/features/resume/model/store.ts
+++ b/src/features/resume/model/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { saveResumeApi } from "../api/resumeInputApi";
+import { saveResumeApi, fetchResumeDetailApi, updateResumeApi } from "../api/resumeInputApi";
 
 /* ── Templates ── */
 export const TEMPLATES: Record<string, string> = {
@@ -105,6 +105,7 @@ function buildSummary(text: string, tags: string[]): string {
 interface ResumeInputState {
   title: string;
   content: string;
+  editingUuid: string | null;
   detectedTags: string[];
   previewSummary: string;
   showPreview: boolean;
@@ -116,6 +117,7 @@ interface ResumeInputState {
   setTitle: (v: string) => void;
   setContent: (v: string) => void;
   applyTemplate: (key: string) => void;
+  loadForEdit: (uuid: string) => Promise<void>;
   submit: () => Promise<void>;
   closeSuccess: () => void;
   reset: () => void;
@@ -126,6 +128,7 @@ let previewTimer: ReturnType<typeof setTimeout> | null = null;
 export const useResumeInputStore = create<ResumeInputState>()((set, get) => ({
   title: "",
   content: "",
+  editingUuid: null,
   detectedTags: [],
   previewSummary: "",
   showPreview: false,
@@ -156,10 +159,23 @@ export const useResumeInputStore = create<ResumeInputState>()((set, get) => ({
 
   applyTemplate: (key) => get().setContent(TEMPLATES[key] ?? ""),
 
+  loadForEdit: async (uuid) => {
+    set({ error: null });
+    try {
+      const detail = await fetchResumeDetailApi(uuid);
+      get().setContent(detail.content ?? "");
+      set({ title: detail.title, editingUuid: uuid });
+    } catch {
+      set({ error: "이력서를 불러오지 못했습니다." });
+    }
+  },
+
   submit: async () => {
-    const { title, content } = get();
+    const { title, content, editingUuid } = get();
     set({ isSubmitting: true, error: null });
-    const res = await saveResumeApi({ title, content });
+    const res = editingUuid
+      ? await updateResumeApi(editingUuid, { title, content })
+      : await saveResumeApi({ title, content });
     if (!res.success) {
       set({ isSubmitting: false, error: res.message });
       return;
@@ -173,6 +189,7 @@ export const useResumeInputStore = create<ResumeInputState>()((set, get) => ({
     set({
       title: "",
       content: "",
+      editingUuid: null,
       detectedTags: [],
       previewSummary: "",
       showPreview: false,

--- a/src/features/settings/api/settingsApi.ts
+++ b/src/features/settings/api/settingsApi.ts
@@ -1,6 +1,7 @@
 import { apiRequest } from "@/shared/api/client";
 import { profileApi } from "@/shared/api/profileApi";
 import { getMeApi } from "@/features/auth/api/authApi";
+import { getMyConsentsApi } from "@/features/auth/api/termsApi";
 import type { JobCategory, Job } from "@/shared/api/profileApi";
 
 export type { JobCategory, Job };
@@ -37,6 +38,8 @@ export interface SettingsConsents {
   termsAgreedAt: string;
   privacyAgreedAt: string;
   aiDataAgreed: boolean;
+  // my-consents API 원본 데이터
+  myConsents: { termsDocumentId: number; title: string; version: string; agreedAt: string }[];
 }
 
 export interface SettingsData {
@@ -68,11 +71,7 @@ const MOCK_SUBSCRIPTION: SettingsSubscription = {
   nextBillingDate: null,
 };
 
-const MOCK_CONSENTS: SettingsConsents = {
-  termsAgreedAt: "2025.01.15",
-  privacyAgreedAt: "2025.01.15",
-  aiDataAgreed: false,
-};
+
 
 /* ── Fetch Settings ──
    - 사용자 기본정보: GET /api/v1/users/me/
@@ -81,13 +80,15 @@ const MOCK_CONSENTS: SettingsConsents = {
 */
 export async function fetchSettingsApi(): Promise<{ success: boolean; data?: SettingsData; error?: string }> {
   try {
-    const [me, userProfile] = await Promise.allSettled([
+    const [me, userProfile, myConsents] = await Promise.allSettled([
       getMeApi(),
       profileApi.getMyProfile(),
+      getMyConsentsApi(),
     ]);
 
     const meData = me.status === "fulfilled" ? me.value : null;
     const profileData = userProfile.status === "fulfilled" ? userProfile.value : null;
+    const consentsData = myConsents.status === "fulfilled" ? myConsents.value : [];
 
     const profile: SettingsProfile = {
       name: meData?.name ?? "",
@@ -99,13 +100,34 @@ export async function fetchSettingsApi(): Promise<{ success: boolean; data?: Set
       jobs: profileData?.jobs ?? [],
     };
 
+    // my-consents에서 이용약관/개인정보처리방침 동의일 추출
+    const formatDate = (iso: string) => {
+      if (!iso) return "";
+      const d = new Date(iso);
+      return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+    };
+
+    const termsConsent = consentsData.find((c) =>
+      c.title?.includes("이용약관") || c.title?.toLowerCase().includes("terms")
+    );
+    const privacyConsent = consentsData.find((c) =>
+      c.title?.includes("개인정보") || c.title?.toLowerCase().includes("privacy")
+    );
+
+    const consents: SettingsConsents = {
+      termsAgreedAt: termsConsent ? formatDate(termsConsent.agreedAt) : "",
+      privacyAgreedAt: privacyConsent ? formatDate(privacyConsent.agreedAt) : "",
+      aiDataAgreed: false,
+      myConsents: consentsData,
+    };
+
     return {
       success: true,
       data: {
         profile,
         notifications: MOCK_NOTIFICATIONS,
         subscription: MOCK_SUBSCRIPTION,
-        consents: MOCK_CONSENTS,
+        consents,
       },
     };
   } catch {

--- a/src/features/settings/api/settingsApi.ts
+++ b/src/features/settings/api/settingsApi.ts
@@ -11,7 +11,7 @@ export interface SettingsProfile {
   name: string;
   email: string;
   avatarInitial: string;
-  // 프로필 API 연동 필드
+  avatarUrl: string | null;
   jobCategoryId: number | null;
   jobCategory: JobCategory | null;
   jobIds: number[];
@@ -80,20 +80,23 @@ const MOCK_SUBSCRIPTION: SettingsSubscription = {
 */
 export async function fetchSettingsApi(): Promise<{ success: boolean; data?: SettingsData; error?: string }> {
   try {
-    const [me, userProfile, myConsents] = await Promise.allSettled([
+    const [me, userProfile, myConsents, avatar] = await Promise.allSettled([
       getMeApi(),
       profileApi.getMyProfile(),
       getMyConsentsApi(),
+      profileApi.getAvatar(),
     ]);
 
     const meData = me.status === "fulfilled" ? me.value : null;
     const profileData = userProfile.status === "fulfilled" ? userProfile.value : null;
     const consentsData = myConsents.status === "fulfilled" ? myConsents.value : [];
+    const avatarData = avatar.status === "fulfilled" ? avatar.value : null;
 
     const profile: SettingsProfile = {
       name: meData?.name ?? "",
       email: meData?.email ?? "",
       avatarInitial: meData?.name ? meData.name[0] : "?",
+      avatarUrl: avatarData?.avatarUrl ?? null,
       jobCategoryId: profileData?.jobCategory?.id ?? null,
       jobCategory: profileData?.jobCategory ?? null,
       jobIds: profileData?.jobs?.map((j) => j.id) ?? [],
@@ -132,6 +135,16 @@ export async function fetchSettingsApi(): Promise<{ success: boolean; data?: Set
     };
   } catch {
     return { success: false, error: "설정을 불러오지 못했습니다." };
+  }
+}
+
+/* ── Upload Avatar ── */
+export async function uploadAvatarApi(file: File): Promise<{ success: boolean; avatarUrl?: string; message: string }> {
+  try {
+    const res = await profileApi.uploadAvatar(file);
+    return { success: true, avatarUrl: res.avatarUrl ?? undefined, message: "프로필 사진이 변경되었습니다." };
+  } catch {
+    return { success: false, message: "사진 업로드에 실패했습니다." };
   }
 }
 

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import {
   fetchSettingsApi,
+  uploadAvatarApi,
   updateProfileApi,
   changePasswordApi,
   updateNotificationsApi,
@@ -48,6 +49,7 @@ interface SettingsState {
   loadJobsByCategory: (jobCategoryId: number) => Promise<void>;
   setProfileDraftField: <K extends keyof ProfileDraft>(field: K, value: ProfileDraft[K]) => void;
   toggleJobId: (jobId: number) => void;
+  uploadAvatar: (file: File) => Promise<void>;
   saveProfile: () => Promise<void>;
   resetProfileDraft: () => void;
 
@@ -159,6 +161,23 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       const next = ids.includes(jobId) ? ids.filter((id) => id !== jobId) : [...ids, jobId];
       return { profileDraft: { ...s.profileDraft, jobIds: next } };
     });
+  },
+
+  uploadAvatar: async (file) => {
+    set({ saving: true, error: null, saveMessage: null });
+    const res = await uploadAvatarApi(file);
+    if (res.success) {
+      set((s) => ({
+        saving: false,
+        saveMessage: res.message,
+        data: s.data ? {
+          ...s.data,
+          profile: { ...s.data.profile, avatarUrl: res.avatarUrl ?? null },
+        } : s.data,
+      }));
+    } else {
+      set({ saving: false, error: res.message });
+    }
   },
 
   saveProfile: async () => {

--- a/src/features/streak/api/streakApi.ts
+++ b/src/features/streak/api/streakApi.ts
@@ -1,6 +1,4 @@
-// Streak API — Mocked (set USE_MOCK = false when backend is ready)
-
-const USE_MOCK = true;
+import { apiRequest } from "@/shared/api/client";
 
 /* ── Types ── */
 export interface StreakMilestone {
@@ -23,7 +21,7 @@ export interface StreakRewardHistory {
 export interface StreakNextReward {
   targetDays: number;
   daysRemaining: number;
-  progress: number; // 0–100
+  progress: number;
   reward: string;
   rewardDetail: string;
 }
@@ -41,75 +39,96 @@ export interface StreakData {
   rewardHistory: StreakRewardHistory[];
 }
 
-/* ── Mock Data ── */
-const MOCK_DATA: StreakData = {
-  currentStreak: 12,
-  bestStreak: 28,
-  totalDays: 43,
-  rewardsCount: 3,
-  todayCompleted: true,
-  calendarDoneMap: {
-    "2026-4": [1, 2, 3],
-    "2026-3": [1, 3, 4, 5, 6, 7, 8, 10, 12, 14, 15, 16, 17, 18, 20, 22, 24, 25, 26, 27, 28, 29, 30, 31],
-    "2026-2": [3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21],
-    "2025-12": [10, 11, 12, 15, 16, 17, 20, 21, 22, 23, 24],
-  },
-  nextReward: {
-    targetDays: 14,
-    daysRemaining: 2,
-    progress: 86,
-    reward: "시선 추적 3회",
-    rewardDetail: "14일 연속 달성 시 시선 추적 분석 3회를 무료로 받을 수 있어요. 오늘도 면접 연습으로 스트릭을 이어가세요!",
-  },
-  milestones: [
-    { days: 7,  reward: "시선 추적 5회 제공",       rewardIcon: "👁️", status: "achieved", daysRemaining: 0  },
-    { days: 14, reward: "시선 추적 3회 제공",        rewardIcon: "🔥", status: "next",     daysRemaining: 2  },
-    { days: 30, reward: "실전 모드 5회 제공",        rewardIcon: "🔒", status: "locked",   daysRemaining: 18 },
-    { days: 60, reward: "상세 리포트 PDF 10회 제공", rewardIcon: "🔒", status: "locked",   daysRemaining: 48 },
-  ],
-  rewardHistory: [
-    {
-      id: "r1",
-      icon: "👁️",
-      iconBg: "cyan",
-      title: "시선 추적 5회 제공",
-      description: "7일 스트릭 달성",
-      date: "2026.04.01",
-    },
-    {
-      id: "r2",
-      icon: "⚡",
-      iconBg: "green",
-      title: "실전 모드 3회 제공",
-      description: "30일 스트릭 달성",
-      date: "2026.03.20",
-    },
-    {
-      id: "r3",
-      icon: "📄",
-      iconBg: "amber",
-      title: "상세 리포트 PDF 3회 제공",
-      description: "7일 스트릭 달성",
-      date: "2026.02.14",
-    },
-  ],
-};
+/* ── API Response Types ── */
+interface StreakStatisticsResponse {
+  currentStreak: number;
+  longestStreak: number;
+  lastParticipatedDate: string | null;
+}
+
+interface StreakLogEntry {
+  date: string; // "YYYY-MM-DD"
+  interviewResultsCount: number;
+}
+
+/* ── Helpers ── */
+function buildCalendarDoneMap(logs: StreakLogEntry[]): Record<string, number[]> {
+  const map: Record<string, number[]> = {};
+  for (const log of logs) {
+    if (log.interviewResultsCount < 1) continue;
+    const [year, month, day] = log.date.split("-").map(Number);
+    const key = `${year}-${month}`;
+    if (!map[key]) map[key] = [];
+    map[key].push(day);
+  }
+  return map;
+}
+
+function buildMilestones(currentStreak: number): StreakMilestone[] {
+  const MILESTONES = [
+    { days: 7,  reward: "시선 추적 5회 제공",       rewardIcon: "👁️" },
+    { days: 14, reward: "시선 추적 3회 제공",        rewardIcon: "🔥" },
+    { days: 30, reward: "실전 모드 5회 제공",        rewardIcon: "⚡" },
+    { days: 60, reward: "상세 리포트 PDF 10회 제공", rewardIcon: "📄" },
+  ];
+  return MILESTONES.map((m) => {
+    const daysRemaining = Math.max(0, m.days - currentStreak);
+    const status: StreakMilestone["status"] =
+      currentStreak >= m.days ? "achieved" : daysRemaining === m.days - currentStreak && daysRemaining <= 7 ? "next" : "locked";
+    return { ...m, status: currentStreak >= m.days ? "achieved" : status, daysRemaining };
+  });
+}
+
+function buildNextReward(currentStreak: number): StreakNextReward {
+  const TARGETS = [7, 14, 30, 60];
+  const REWARDS = [
+    { reward: "시선 추적 5회", detail: "7일 연속 달성 시 시선 추적 분석 5회를 무료로 받을 수 있어요." },
+    { reward: "시선 추적 3회", detail: "14일 연속 달성 시 시선 추적 분석 3회를 무료로 받을 수 있어요." },
+    { reward: "실전 모드 5회", detail: "30일 연속 달성 시 실전 모드 5회를 무료로 받을 수 있어요." },
+    { reward: "상세 리포트 PDF 10회", detail: "60일 연속 달성 시 상세 리포트 PDF 10회를 무료로 받을 수 있어요." },
+  ];
+  const idx = TARGETS.findIndex((t) => currentStreak < t);
+  const target = idx === -1 ? TARGETS[TARGETS.length - 1] : TARGETS[idx];
+  const info = idx === -1 ? REWARDS[REWARDS.length - 1] : REWARDS[idx];
+  const daysRemaining = Math.max(0, target - currentStreak);
+  const progress = Math.min(100, Math.round((currentStreak / target) * 100));
+  return { targetDays: target, daysRemaining, progress, reward: info.reward, rewardDetail: info.detail };
+}
 
 /* ── Fetch Streak Data ── */
 export async function fetchStreakApi(): Promise<{ success: boolean; data?: StreakData; error?: string }> {
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 380));
-    return { success: true, data: MOCK_DATA };
-  }
   try {
-    const res = await fetch("/api/v1/streak/", {
-      method: "GET",
-      credentials: "include",
-    });
-    if (!res.ok) return { success: true, data: MOCK_DATA };
-    const json = await res.json();
-    return { success: true, data: json };
+    // 통계 + 최근 6개월 로그 병렬 조회
+    const now = new Date();
+    const startDate = new Date(now.getFullYear(), now.getMonth() - 5, 1);
+    const startStr = startDate.toISOString().slice(0, 10);
+    const endStr = now.toISOString().slice(0, 10);
+
+    const [stats, logs] = await Promise.all([
+      apiRequest<StreakStatisticsResponse>("/api/v1/streaks/statistics/", { auth: true }),
+      apiRequest<StreakLogEntry[]>(`/api/v1/streaks/logs/?start_date=${startStr}&end_date=${endStr}`, { auth: true }),
+    ]);
+
+    const logsArray = Array.isArray(logs) ? logs : [];
+    const today = now.toISOString().slice(0, 10);
+    const todayLog = logsArray.find((l) => l.date === today);
+    const todayCompleted = (todayLog?.interviewResultsCount ?? 0) > 0;
+    const totalDays = logsArray.filter((l) => l.interviewResultsCount > 0).length;
+
+    const data: StreakData = {
+      currentStreak: stats.currentStreak,
+      bestStreak: stats.longestStreak,
+      totalDays,
+      rewardsCount: 0,
+      todayCompleted,
+      calendarDoneMap: buildCalendarDoneMap(logsArray),
+      nextReward: buildNextReward(stats.currentStreak),
+      milestones: buildMilestones(stats.currentStreak),
+      rewardHistory: [],
+    };
+
+    return { success: true, data };
   } catch {
-    return { success: true, data: MOCK_DATA };
+    return { success: false, error: "스트릭 정보를 불러오지 못했습니다." };
   }
 }

--- a/src/pages/home/ui/components/HomeNavbar.tsx
+++ b/src/pages/home/ui/components/HomeNavbar.tsx
@@ -35,7 +35,7 @@ export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
 
   const handleLogout = async () => {
     await logout();
-    navigate("/login");
+    navigate("/");
   };
 
   const handleNotiOpen = () => {

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useJdListStore, type JdListItem } from "@/features/jd";
 
@@ -217,13 +217,13 @@ export function JdListPage() {
           return (
             <div className="relative overflow-hidden bg-gradient-to-br from-[#065F79] to-[#0991B2] rounded-lg px-6 py-[22px] mb-7 shadow-[0_12px_32px_rgba(9,145,178,.35)] animate-[jdl-fadeUp_.5s_ease_.05s_both] flex items-center gap-[18px] flex-wrap before:content-[''] before:absolute before:top-[-40px] before:right-[-40px] before:w-[160px] before:h-[160px] before:rounded-full before:bg-[rgba(255,255,255,.07)] md:px-9 md:py-7 md:gap-8">
               {statItems.map((item, i) => (
-                <>
-                  <div key={item.label} className="flex flex-col gap-[2px] relative">
+                <Fragment key={item.label}>
+                  <div className="flex flex-col gap-[2px] relative">
                     <span className="font-inter text-[clamp(28px,4vw,46px)] font-black text-white leading-none">{item.value}</span>
                     <span className="text-[12px] font-semibold text-white/65">{item.label}</span>
                   </div>
                   {i < statItems.length - 1 && <div className="w-px h-10 bg-white/20 shrink-0" />}
-                </>
+                </Fragment>
               ))}
               <div className="flex gap-2 flex-wrap relative ml-auto">
                 {badges.map((badge) => (

--- a/src/pages/resume-input/ui/ResumeInputPage.tsx
+++ b/src/pages/resume-input/ui/ResumeInputPage.tsx
@@ -55,7 +55,7 @@ export function ResumeInputPage() {
     } else {
       reset();
     }
-  }, [editingUuid]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [editingUuid, loadForEdit, reset]);
 
   const contentLen = content.length;
   const titleLen = title.length;

--- a/src/pages/resume-input/ui/ResumeInputPage.tsx
+++ b/src/pages/resume-input/ui/ResumeInputPage.tsx
@@ -1,4 +1,5 @@
-import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useResumeInputStore } from "@/features/resume";
 import {
   Card,
@@ -26,6 +27,7 @@ const CHIPS = [
 
 export function ResumeInputPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const {
     title,
     content,
@@ -39,9 +41,21 @@ export function ResumeInputPage() {
     setTitle,
     setContent,
     applyTemplate,
+    loadForEdit,
     submit,
     closeSuccess,
+    reset,
   } = useResumeInputStore();
+
+  const editingUuid = searchParams.get("uuid");
+
+  useEffect(() => {
+    if (editingUuid) {
+      loadForEdit(editingUuid);
+    } else {
+      reset();
+    }
+  }, [editingUuid]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const contentLen = content.length;
   const titleLen = title.length;

--- a/src/pages/resume-list/ui/ResumeListPage.tsx
+++ b/src/pages/resume-list/ui/ResumeListPage.tsx
@@ -123,8 +123,8 @@ export function ResumeListPage() {
   const ctxRef = useRef<HTMLDivElement>(null);
 
   const {
-    resumes, summary, loading, ctxMenu,
-    fetchResumes, toggleActive, deleteResume, openCtx, closeCtx,
+    resumes, summary, loading, error, ctxMenu,
+    fetchResumes, deleteResume, openCtx, closeCtx,
   } = useResumeListStore();
 
   useEffect(() => {
@@ -187,12 +187,6 @@ export function ResumeListPage() {
             </div>
             <div className="flex gap-2 flex-wrap relative ml-auto">
               <span className="flex items-center gap-[5px] bg-white/15 backdrop-blur-[8px] rounded-full px-[13px] py-[6px] text-[12px] font-semibold text-white">
-                <span className="w-[6px] h-[6px] rounded-full bg-[#34D399] shrink-0" />활성 {summary.active}개
-              </span>
-              <span className="flex items-center gap-[5px] bg-white/15 backdrop-blur-[8px] rounded-full px-[13px] py-[6px] text-[12px] font-semibold text-white">
-                <span className="w-[6px] h-[6px] rounded-full bg-white/40 shrink-0" />비활성 {summary.inactive}개
-              </span>
-              <span className="flex items-center gap-[5px] bg-white/15 backdrop-blur-[8px] rounded-full px-[13px] py-[6px] text-[12px] font-semibold text-white">
                 📎 파일 {summary.fileCount} · ✏️ 텍스트 {summary.textCount}
               </span>
             </div>
@@ -212,6 +206,11 @@ export function ResumeListPage() {
               <div className="flex items-center justify-center gap-3 py-[60px] text-[14px] text-[#6B7280] font-semibold">
                 <div className="w-6 h-6 rounded-full border-2 border-[#E5E7EB] border-t-[#0991B2] animate-[rl-spin_.8s_linear_infinite]" />
                 <span>이력서를 불러오는 중...</span>
+              </div>
+            ) : error ? (
+              <div className="flex flex-col items-center justify-center gap-3 py-[60px] text-[14px] text-[#EF4444] font-semibold">
+                <span>⚠️ {error}</span>
+                <button className="text-[13px] font-bold px-4 py-2 rounded-lg bg-[#0A0A0A] text-white" onClick={fetchResumes}>다시 시도</button>
               </div>
             ) : (
               <div className="grid grid-cols-1 gap-[14px] pb-20 sm:grid-cols-2 lg:grid-cols-3">
@@ -291,16 +290,6 @@ export function ResumeListPage() {
               <div>
                 <div className="text-[14px] font-bold text-[#0A0A0A] md:text-[13px]">수정하기</div>
                 <div className="text-[12px] text-[#6B7280] font-medium md:hidden">이력서 내용을 편집합니다</div>
-              </div>
-            </button>
-
-            <button className="flex items-center gap-3 px-[14px] py-3 rounded-lg bg-[#F9FAFB] border border-[#E5E7EB] mb-2 cursor-pointer w-full text-left transition-[background] duration-[120ms] active:scale-[.97] md:bg-transparent md:border-none md:mb-[2px] md:px-[10px] md:py-[9px] md:hover:bg-[rgba(9,145,178,.07)]" onClick={() => ctxMenu.resumeId && toggleActive(ctxMenu.resumeId)}>
-              <div className="w-9 h-9 rounded-lg flex items-center justify-center text-[15px] shrink-0 bg-gradient-to-br from-[#A7F3D0] to-[#059669] md:w-7 md:h-7 md:text-[13px]">🔄</div>
-              <div>
-                <div className="text-[14px] font-bold text-[#0A0A0A] md:text-[13px]">
-                  {activeResume?.status === "active" ? "비활성화" : "활성화"}
-                </div>
-                <div className="text-[12px] text-[#6B7280] font-medium md:hidden">면접 질문 생성에서 제외됩니다</div>
               </div>
             </button>
 

--- a/src/pages/resume-list/ui/ResumeListPage.tsx
+++ b/src/pages/resume-list/ui/ResumeListPage.tsx
@@ -285,7 +285,7 @@ export function ResumeListPage() {
             <div className="font-inter text-[14px] font-extrabold text-[#0A0A0A] mb-1 text-center md:text-[13px] md:text-left md:ml-1">{activeResume?.title ?? ""}</div>
             <div className="text-[12px] text-[#6B7280] text-center mb-[14px] md:hidden">이 이력서에 대해 무엇을 할까요?</div>
 
-            <button className="flex items-center gap-3 px-[14px] py-3 rounded-lg bg-[#F9FAFB] border border-[#E5E7EB] mb-2 cursor-pointer w-full text-left transition-[background] duration-[120ms] active:scale-[.97] md:bg-transparent md:border-none md:mb-[2px] md:px-[10px] md:py-[9px] md:hover:bg-[rgba(9,145,178,.07)]" onClick={() => { navigate("/resume/input"); closeCtx(); }}>
+            <button className="flex items-center gap-3 px-[14px] py-3 rounded-lg bg-[#F9FAFB] border border-[#E5E7EB] mb-2 cursor-pointer w-full text-left transition-[background] duration-[120ms] active:scale-[.97] md:bg-transparent md:border-none md:mb-[2px] md:px-[10px] md:py-[9px] md:hover:bg-[rgba(9,145,178,.07)]" onClick={() => { navigate(`/resume/input?uuid=${ctxMenu.resumeId}`); closeCtx(); }}>
               <div className="w-9 h-9 rounded-lg flex items-center justify-center text-[15px] shrink-0 bg-gradient-to-br from-[#BAE6FD] to-[#2563EB] md:w-7 md:h-7 md:text-[13px]">✏️</div>
               <div>
                 <div className="text-[14px] font-bold text-[#0A0A0A] md:text-[13px]">수정하기</div>

--- a/src/pages/resume-list/ui/ResumeListPage.tsx
+++ b/src/pages/resume-list/ui/ResumeListPage.tsx
@@ -134,8 +134,7 @@ export function ResumeListPage() {
 
   useEffect(() => {
     fetchResumes();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [fetchResumes]);
 
   /* close ctx on outside click */
   useEffect(() => {

--- a/src/pages/resume-list/ui/ResumeListPage.tsx
+++ b/src/pages/resume-list/ui/ResumeListPage.tsx
@@ -122,14 +122,20 @@ export function ResumeListPage() {
   const navigate = useNavigate();
   const ctxRef = useRef<HTMLDivElement>(null);
 
-  const {
-    resumes, summary, loading, error, ctxMenu,
-    fetchResumes, deleteResume, openCtx, closeCtx,
-  } = useResumeListStore();
+  const resumes = useResumeListStore((s) => s.resumes);
+  const summary = useResumeListStore((s) => s.summary);
+  const loading = useResumeListStore((s) => s.loading);
+  const error = useResumeListStore((s) => s.error);
+  const ctxMenu = useResumeListStore((s) => s.ctxMenu);
+  const fetchResumes = useResumeListStore((s) => s.fetchResumes);
+  const deleteResume = useResumeListStore((s) => s.deleteResume);
+  const openCtx = useResumeListStore((s) => s.openCtx);
+  const closeCtx = useResumeListStore((s) => s.closeCtx);
 
   useEffect(() => {
     fetchResumes();
-  }, [fetchResumes]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /* close ctx on outside click */
   useEffect(() => {
@@ -221,7 +227,7 @@ export function ResumeListPage() {
                     delay={0.06 + i * 0.06}
                     onMenu={handleMenu}
                     onUse={(id) => { void id; navigate("/interview/setup"); }}
-                    onEdit={(id) => { void id; navigate("/resume/input"); }}
+                    onEdit={(id) => navigate(`/resume/input?uuid=${id}`)}
                   />
                 ))}
 

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useSettingsStore } from "@/features/settings";
 import type { SettingsPanel } from "@/features/settings";
@@ -33,7 +33,7 @@ export function SettingsPage() {
     jobCategories, jobCategoriesLoading, availableJobs, availableJobsLoading,
     fetchSettings, setActivePanel,
     loadJobCategories,
-    setProfileDraftField, toggleJobId, saveProfile, resetProfileDraft,
+    setProfileDraftField, toggleJobId, uploadAvatar, saveProfile, resetProfileDraft,
     setPasswordDraft, savePassword, resetPasswordDraft,
     toggleNotification, saveNotifications, resetNotificationsDraft,
     setAiDataDraft, saveConsents,
@@ -43,6 +43,7 @@ export function SettingsPage() {
 
   const [searchParams] = useSearchParams();
   const [deleteConfirm, setDeleteConfirm] = useState<"data" | "account" | null>(null);
+  const avatarInputRef = useRef<HTMLInputElement>(null);
 
   // URL 쿼리로 패널 초기화 (?panel=notifications)
   useEffect(() => {
@@ -105,15 +106,17 @@ export function SettingsPage() {
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
                     <div className="font-inter text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">👤 프로필 사진</div>
                     <div className="flex items-center gap-4 mb-5">
-                      <div className="w-16 h-16 rounded-full bg-[#0991B2] flex items-center justify-center font-inter text-[24px] font-black text-white shadow-[0_2px_8px_rgba(9,145,178,0.3)] shrink-0">
-                        {data.profile.avatarInitial}
-                      </div>
+                      {data.profile.avatarUrl ? (
+                        <img src={data.profile.avatarUrl} alt="프로필" className="w-16 h-16 rounded-full object-cover shadow-[0_2px_8px_rgba(9,145,178,0.3)] shrink-0" />
+                      ) : (
+                        <div className="w-16 h-16 rounded-full bg-[#0991B2] flex items-center justify-center font-inter text-[24px] font-black text-white shadow-[0_2px_8px_rgba(9,145,178,0.3)] shrink-0">
+                          {data.profile.avatarInitial}
+                        </div>
+                      )}
                       <div className="flex flex-col gap-[6px]">
-                        <button className="font-inter text-[13px] font-bold text-[#0991B2] bg-[rgba(9,145,178,0.08)] border-[1.5px] border-[rgba(9,145,178,0.25)] rounded-lg px-4 py-[7px] cursor-pointer transition-all duration-150 hover:bg-[rgba(9,145,178,0.14)]">
+                        <input ref={avatarInputRef} type="file" accept="image/jpeg,image/png,image/webp" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; if (f) uploadAvatar(f); e.target.value = ""; }} />
+                        <button className="font-inter text-[13px] font-bold text-[#0991B2] bg-[rgba(9,145,178,0.08)] border-[1.5px] border-[rgba(9,145,178,0.25)] rounded-lg px-4 py-[7px] cursor-pointer transition-all duration-150 hover:bg-[rgba(9,145,178,0.14)]" onClick={() => avatarInputRef.current?.click()} disabled={saving}>
                           사진 변경
-                        </button>
-                        <button className="font-inter text-[12px] font-semibold text-[#6B7280] bg-none border-none cursor-pointer transition-[color] duration-150 hover:text-[#0A0A0A]">
-                          사진 삭제
                         </button>
                       </div>
                     </div>

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -411,7 +411,13 @@ export function SettingsPage() {
                           <span className="text-[10px] text-[#EF4444] font-bold">(필수)</span>
                         </div>
                         <p className="text-[12px] text-[#6B7280] leading-[1.55]">서비스 이용에 관한 권리·의무 및 규칙에 동의합니다</p>
-                        <div className="inline-flex items-center gap-1 text-[10px] font-bold text-[#0991B2] bg-[#E6F7FA] px-2 py-0.5 rounded-full mt-[5px]">v2025-01 · {data.consents.termsAgreedAt} 동의</div>
+                        {data.consents.termsAgreedAt ? (
+                          <div className="inline-flex items-center gap-1 text-[10px] font-bold text-[#0991B2] bg-[#E6F7FA] px-2 py-0.5 rounded-full mt-[5px]">
+                            {data.consents.myConsents.find((c) => c.title?.includes("이용약관") || c.title?.toLowerCase().includes("terms"))?.version ?? "v2025-01"} · {data.consents.termsAgreedAt} 동의
+                          </div>
+                        ) : (
+                          <div className="inline-flex items-center gap-1 text-[10px] font-bold text-[#9CA3AF] bg-[#F3F4F6] px-2 py-0.5 rounded-full mt-[5px]">동의 정보 없음</div>
+                        )}
                       </div>
                     </div>
 
@@ -423,7 +429,13 @@ export function SettingsPage() {
                           <span className="text-[10px] text-[#EF4444] font-bold">(필수)</span>
                         </div>
                         <p className="text-[12px] text-[#6B7280] leading-[1.55]">수집되는 개인정보의 항목, 목적, 보존 기간에 동의합니다</p>
-                        <div className="inline-flex items-center gap-1 text-[10px] font-bold text-[#0991B2] bg-[#E6F7FA] px-2 py-0.5 rounded-full mt-[5px]">v2025-01 · {data.consents.privacyAgreedAt} 동의</div>
+                        {data.consents.privacyAgreedAt ? (
+                          <div className="inline-flex items-center gap-1 text-[10px] font-bold text-[#0991B2] bg-[#E6F7FA] px-2 py-0.5 rounded-full mt-[5px]">
+                            {data.consents.myConsents.find((c) => c.title?.includes("개인정보") || c.title?.toLowerCase().includes("privacy"))?.version ?? "v2025-01"} · {data.consents.privacyAgreedAt} 동의
+                          </div>
+                        ) : (
+                          <div className="inline-flex items-center gap-1 text-[10px] font-bold text-[#9CA3AF] bg-[#F3F4F6] px-2 py-0.5 rounded-full mt-[5px]">동의 정보 없음</div>
+                        )}
                       </div>
                     </div>
 

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -128,6 +128,8 @@ export function SettingsPage() {
                           이름 <span className="text-[#EF4444] text-[10px]">*</span>
                         </label>
                         <input
+                          id="settings-name"
+                          name="name"
                           type="text"
                           className={inputClass}
                           value={profileDraft.name ?? ""}
@@ -137,7 +139,7 @@ export function SettingsPage() {
                       </div>
                       <div className="flex flex-col gap-[5px]">
                         <label className="font-inter text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px]">이메일 주소</label>
-                        <input type="email" className={inputClass} value={data.profile.email} readOnly />
+                        <input id="settings-email" name="email" type="email" className={inputClass} value={data.profile.email} readOnly />
                         <p className="text-[11px] text-[#6B7280] leading-[1.45]">이메일 주소는 변경할 수 없습니다. 고객센터로 문의해주세요.</p>
                       </div>
                       <div className="flex flex-col gap-4">
@@ -226,11 +228,11 @@ export function SettingsPage() {
                     <div className="flex flex-col gap-4">
                       <div className="flex flex-col gap-[5px]">
                         <label className="font-inter text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px] flex items-center gap-1">현재 비밀번호 <span className="text-[#EF4444] text-[10px]">*</span></label>
-                        <input type="password" className={inputClass} value={passwordDraft.currentPassword} onChange={(e) => setPasswordDraft("currentPassword", e.target.value)} placeholder="현재 비밀번호를 입력하세요" />
+                        <input id="settings-current-password" name="currentPassword" type="password" className={inputClass} value={passwordDraft.currentPassword} onChange={(e) => setPasswordDraft("currentPassword", e.target.value)} placeholder="현재 비밀번호를 입력하세요" />
                       </div>
                       <div className="flex flex-col gap-[5px]">
                         <label className="font-inter text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px] flex items-center gap-1">새 비밀번호 <span className="text-[#EF4444] text-[10px]">*</span></label>
-                        <input type="password" className={inputClass} value={passwordDraft.newPassword} onChange={(e) => setPasswordDraft("newPassword", e.target.value)} placeholder="새 비밀번호를 입력하세요" />
+                        <input id="settings-new-password" name="newPassword" type="password" className={inputClass} value={passwordDraft.newPassword} onChange={(e) => setPasswordDraft("newPassword", e.target.value)} placeholder="새 비밀번호를 입력하세요" />
                         <div className="h-1 bg-[#E5E7EB] rounded-full mt-2 overflow-hidden">
                           <div className="h-full rounded-full transition-[width_0.4s_ease,background_0.3s]" style={{ width: pwdStrength.width, background: pwdStrength.color }} />
                         </div>
@@ -238,7 +240,7 @@ export function SettingsPage() {
                       </div>
                       <div className="flex flex-col gap-[5px]">
                         <label className="font-inter text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px] flex items-center gap-1">새 비밀번호 확인 <span className="text-[#EF4444] text-[10px]">*</span></label>
-                        <input type="password" className={inputClass} value={passwordDraft.confirmPassword} onChange={(e) => setPasswordDraft("confirmPassword", e.target.value)} placeholder="새 비밀번호를 다시 입력하세요" />
+                        <input id="settings-confirm-password" name="confirmPassword" type="password" className={inputClass} value={passwordDraft.confirmPassword} onChange={(e) => setPasswordDraft("confirmPassword", e.target.value)} placeholder="새 비밀번호를 다시 입력하세요" />
                         {passwordDraft.confirmPassword && (
                           <p className="text-[11px] leading-[1.45]" style={{ color: pwdMatch ? "#059669" : "#EF4444" }}>
                             {pwdMatch ? "✓ 비밀번호가 일치합니다" : "✕ 비밀번호가 일치하지 않습니다"}

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -65,10 +65,13 @@ async function _request<T>(
   options: RequestInit & { auth?: boolean },
   isRetry: boolean
 ): Promise<T> {
-  const { auth = false, ...fetchOptions } = options;
+  const { auth = false, ...fetchOptions } = options as RequestInit & { auth?: boolean; noRetry?: boolean };
+  delete (fetchOptions as Record<string, unknown>).noRetry;
 
+  // FormData일 때는 Content-Type을 브라우저에 맡김 (multipart/form-data + boundary 자동 설정)
+  const isFormData = fetchOptions.body instanceof FormData;
   const headers: Record<string, string> = {
-    "Content-Type": "application/json",
+    ...(isFormData ? {} : { "Content-Type": "application/json" }),
     ...(fetchOptions.headers as Record<string, string>),
   };
 

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -32,9 +32,9 @@ export { isApiError };
 /* ── Core fetch wrapper ── */
 export async function apiRequest<T>(
   path: string,
-  options: RequestInit & { auth?: boolean } = {}
+  options: RequestInit & { auth?: boolean; noRetry?: boolean } = {}
 ): Promise<T> {
-  return _request<T>(path, options, false);
+  return _request<T>(path, options, options.noRetry ?? false);
 }
 
 /* ── Path validation ── */
@@ -118,6 +118,12 @@ async function _request<T>(
 
 /* ── Token refresh helper ── */
 
+// refresh 실패 시 호출할 콜백 (순환 의존 방지를 위해 런타임에 등록)
+let _onRefreshFailed: (() => void) | null = null;
+export function setOnRefreshFailed(cb: () => void) {
+  _onRefreshFailed = cb;
+}
+
 // 동시에 여러 요청이 401을 받아도 refresh는 한 번만 실행되도록 뮤텍스
 let _refreshPromise: Promise<boolean> | null = null;
 
@@ -140,6 +146,7 @@ async function _doRefresh(): Promise<boolean> {
     });
     if (!res.ok) {
       clearTokens();
+      _onRefreshFailed?.();
       return false;
     }
     const data = await res.json() as { access: string; refresh?: string };
@@ -147,6 +154,7 @@ async function _doRefresh(): Promise<boolean> {
     return true;
   } catch {
     clearTokens();
+    _onRefreshFailed?.();
     return false;
   }
 }

--- a/src/shared/api/profileApi.ts
+++ b/src/shared/api/profileApi.ts
@@ -31,6 +31,10 @@ export interface PaginatedJobCategories {
   results: JobCategory[];
 }
 
+export interface AvatarResponse {
+  avatarUrl: string | null;
+}
+
 export const profileApi = {
   getJobCategories: () =>
     apiRequest<PaginatedJobCategories>("/api/v1/job-categories/?per_page=100"),
@@ -49,4 +53,19 @@ export const profileApi = {
       auth: true,
       body: JSON.stringify({ jobCategoryId: params.jobCategoryId, jobIds: params.jobIds }),
     }),
+
+  getAvatar: () =>
+    apiRequest<AvatarResponse>("/api/v1/profiles/me/avatar/", { auth: true }),
+
+  uploadAvatar: (file: File) => {
+    const formData = new FormData();
+    formData.append("avatar", file);
+    // Content-Type은 브라우저가 multipart/form-data로 자동 설정
+    return apiRequest<AvatarResponse>("/api/v1/profiles/me/avatar/", {
+      method: "POST",
+      auth: true,
+      headers: {},
+      body: formData,
+    });
+  },
 };

--- a/src/shared/api/realtimeApi.ts
+++ b/src/shared/api/realtimeApi.ts
@@ -37,6 +37,8 @@ export class RealtimeClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private handlers: WsEventHandlers;
   private stopped = false;
+  private retryCount = 0;
+  private readonly MAX_RETRIES = 3;
 
   constructor(handlers: WsEventHandlers) {
     this.handlers = handlers;
@@ -50,6 +52,10 @@ export class RealtimeClient {
     const url = buildWsUrl(ticket);
     this.ws = new WebSocket(url);
 
+    this.ws.onopen = () => {
+      this.retryCount = 0; // 연결 성공 시 재시도 카운트 초기화
+    };
+
     this.ws.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data) as WsNotificationMessage;
@@ -61,9 +67,10 @@ export class RealtimeClient {
 
     this.ws.onclose = () => {
       this.handlers.onClose?.();
-      // 연결 끊기면 5초 후 재연결 (stopped가 아닐 때만)
-      if (!this.stopped) {
-        this.reconnectTimer = setTimeout(() => this.connect(), 5000);
+      if (!this.stopped && this.retryCount < this.MAX_RETRIES) {
+        this.retryCount++;
+        const delay = Math.min(5000 * this.retryCount, 30000); // 5s, 10s, 15s
+        this.reconnectTimer = setTimeout(() => this.connect(), delay);
       }
     };
 

--- a/src/shared/api/realtimeApi.ts
+++ b/src/shared/api/realtimeApi.ts
@@ -1,0 +1,81 @@
+import { apiRequest, BASE_URL } from "./client";
+
+/* ── WebSocket 티켓 발급 ── */
+async function fetchWsTicket(): Promise<string | null> {
+  try {
+    const res = await apiRequest<{ ticket: string }>("/api/v1/realtime/ws-ticket/", {
+      method: "POST",
+      auth: true,
+    });
+    return res.ticket;
+  } catch {
+    return null;
+  }
+}
+
+/* ── WebSocket URL 생성 (https → wss) ── */
+function buildWsUrl(ticket: string): string {
+  const wsBase = BASE_URL.replace(/^https/, "wss").replace(/^http/, "ws");
+  return `${wsBase}/ws/notifications/?ticket=${ticket}`;
+}
+
+export type WsNotificationMessage = {
+  id: number;
+  message: string;
+  category: "interview" | "resume" | "jd" | "system";
+  createdAt: string;
+};
+
+type WsEventHandlers = {
+  onMessage: (msg: WsNotificationMessage) => void;
+  onClose?: () => void;
+};
+
+/* ── WebSocket 연결 관리 ── */
+export class RealtimeClient {
+  private ws: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private handlers: WsEventHandlers;
+  private stopped = false;
+
+  constructor(handlers: WsEventHandlers) {
+    this.handlers = handlers;
+  }
+
+  async connect() {
+    this.stopped = false;
+    const ticket = await fetchWsTicket();
+    if (!ticket) return;
+
+    const url = buildWsUrl(ticket);
+    this.ws = new WebSocket(url);
+
+    this.ws.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data) as WsNotificationMessage;
+        this.handlers.onMessage(data);
+      } catch {
+        // 파싱 실패 무시
+      }
+    };
+
+    this.ws.onclose = () => {
+      this.handlers.onClose?.();
+      // 연결 끊기면 5초 후 재연결 (stopped가 아닐 때만)
+      if (!this.stopped) {
+        this.reconnectTimer = setTimeout(() => this.connect(), 5000);
+      }
+    };
+
+    this.ws.onerror = () => {
+      this.ws?.close();
+    };
+  }
+
+  disconnect() {
+    this.stopped = true;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.ws?.close();
+    this.ws = null;
+  }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #61

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.
- `ResumeListPage`에서 Zustand store를 구조분해 대신 개별 selector로 구독하도록 변경
- `closeCtx` 참조 안정성 확보로 `useEffect` dependency array 크기 변경 경고 수정
- `SettingsPage` input 요소에 `id` / `name` 속성 추가

## 변경 유형
해당하는 항목에 체크해주세요.
- [x] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [x] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.
- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 로그인 후 `/resume` 페이지 진입 시 콘솔 경고 없음 확인
2. 이력서 컨텍스트 메뉴 열고 외부 클릭 시 정상 닫힘 확인
3. `/settings` 페이지에서 input 필드 접근성 경고 없음 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보