### PR TITLE
[066] 이력서 목록 빈 상태 UI 개선 및 검색 기능 추가

### DIFF
--- a/src/pages/resume-list/ui/ResumeListHeader.tsx
+++ b/src/pages/resume-list/ui/ResumeListHeader.tsx
@@ -1,22 +1,26 @@
-import { Plus } from "lucide-react";
-
 interface ResumeListHeaderProps {
   totalCount: number;
-  onAdd: () => void;
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
 }
 
-export function ResumeListHeader({ totalCount, onAdd }: ResumeListHeaderProps) {
+export function ResumeListHeader({ totalCount, searchQuery, onSearchChange }: ResumeListHeaderProps) {
   return (
-    <div className="flex items-center justify-between mt-6">
-      <h2 className="text-[15px] font-extrabold text-[#0A0A0A]">
+    <div className="flex items-center gap-4 mt-6 flex-wrap">
+      <h2 className="text-[15px] font-extrabold text-[#0A0A0A] shrink-0">
         전체 이력서 <span className="text-[#0991B2]">{totalCount}</span>개
       </h2>
-      <button
-        onClick={onAdd}
-        className="inline-flex items-center gap-1.5 text-[13px] font-bold text-white bg-[#0A0A0A] rounded-lg py-2.5 px-4 hover:opacity-85 transition-opacity"
-      >
-        <Plus size={14} /> 이력서 추가하기
-      </button>
+      <div className="flex-1 min-w-[220px] relative max-sm:min-w-0">
+        <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-base pointer-events-none">🔍</span>
+        <input
+          type="text"
+          className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg py-2.5 pr-4 pl-11 text-sm font-medium text-[#0A0A0A] shadow-[0_1px_3px_rgba(0,0,0,0.08)] outline-none transition-[border-color] focus:border-[#0991B2] focus:shadow-[0_1px_3px_rgba(0,0,0,0.1)] placeholder:text-[#9CA3AF]"
+          placeholder="이력서 제목 검색..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          aria-label="이력서 검색"
+        />
+      </div>
     </div>
   );
 }

--- a/src/pages/resume-list/ui/ResumeListPage.tsx
+++ b/src/pages/resume-list/ui/ResumeListPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Plus, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useInfiniteList } from "@/shared/hooks/useInfiniteList";
 import { openSseStream } from "@/shared/api/sse";
 import {
@@ -20,6 +20,7 @@ export function ResumeListPage() {
   });
 
   const [countStats, setCountStats] = useState<ResumeCountStats | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
     resumeStatsApi.count().then(setCountStats).catch(() => {});
@@ -113,41 +114,74 @@ export function ResumeListPage() {
     <div className="min-h-screen bg-white">
       <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
         {/* 페이지 타이틀 */}
-        <div className="mb-6">
-          <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">내 이력서</h1>
-          <p className="text-sm text-[#6B7280] mt-1.5">면접 연습에 사용할 이력서를 관리하세요.</p>
+        <div className="flex items-start justify-between mb-8 gap-4">
+          <div>
+            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">📄 이력서</div>
+            <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">내 이력서</h1>
+            <p className="text-sm text-[#6B7280] mt-1.5">면접 연습에 사용할 이력서를 관리하세요.</p>
+          </div>
+          <button
+            onClick={() => navigate("/resume/new")}
+            className="inline-flex items-center gap-2 text-sm font-bold text-white bg-[#0A0A0A] border-none cursor-pointer py-3.5 px-6 rounded-lg shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-opacity hover:opacity-85 whitespace-nowrap"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+            이력서 추가
+          </button>
         </div>
 
         {/* 통계 스트립 */}
         {countStats && <ResumeStatsStrip count={countStats} />}
 
-        {/* 리스트 헤더: "전체 이력서 X개" + 추가 버튼 */}
+        {/* 리스트 헤더: "전체 이력서 X개" + 검색 */}
         <ResumeListHeader
           totalCount={totalCount}
-          onAdd={() => navigate("/resume/new")}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
         />
 
         {/* 리스트 */}
         <div className="flex flex-col gap-3 mt-4">
-          {items.map((item) => (
-            <ResumeCard
-              key={item.uuid}
-              resume={item}
-              onDetail={() => navigate(`/resume/${item.uuid}`)}
-              onEdit={() => navigate(`/resume/${item.uuid}`)}
-              onDelete={() => handleDelete(item.uuid)}
-              onToggleActive={() => handleToggleActive(item)}
-            />
-          ))}
-          {items.length === 0 && !isLoading && (
-            <div className="bg-[#F9FAFB] border border-dashed border-[#E5E7EB] rounded-xl p-12 text-center">
-              <p className="text-[#6B7280] mb-4">아직 등록된 이력서가 없어요.</p>
-              <button
-                onClick={() => navigate("/resume/new")}
-                className="inline-flex items-center gap-2 text-sm font-bold text-white bg-[#0A0A0A] rounded-lg py-3 px-6 hover:opacity-85"
-              >
-                <Plus size={14} /> 이력서 추가하기
-              </button>
+          {items
+            .filter((item) =>
+              searchQuery.trim() === "" ||
+              item.title.toLowerCase().includes(searchQuery.toLowerCase()),
+            )
+            .map((item) => (
+              <ResumeCard
+                key={item.uuid}
+                resume={item}
+                onDetail={() => navigate(`/resume/${item.uuid}`)}
+                onEdit={() => navigate(`/resume/${item.uuid}`)}
+                onDelete={() => handleDelete(item.uuid)}
+                onToggleActive={() => handleToggleActive(item)}
+              />
+            ))}
+          {items.filter((item) =>
+            searchQuery.trim() === "" ||
+            item.title.toLowerCase().includes(searchQuery.toLowerCase()),
+          ).length === 0 && !isLoading && (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              {searchQuery ? (
+                <>
+                  <span className="text-5xl mb-5">🔍</span>
+                  <p className="text-[15px] font-extrabold text-[#0A0A0A] mb-2">검색 결과가 없어요</p>
+                  <p className="text-sm text-[#9CA3AF]">다른 검색어를 입력해 보세요</p>
+                </>
+              ) : (
+                <>
+                  <span className="text-5xl mb-5">📄</span>
+                  <p className="text-[15px] font-extrabold text-[#0A0A0A] mb-2">아직 등록된 이력서가 없어요</p>
+                  <p className="text-sm text-[#9CA3AF] mb-6">이력서를 추가해 AI 면접을 시작해 보세요</p>
+                  <button
+                    onClick={() => navigate("/resume/new")}
+                    className="inline-flex items-center gap-2 text-sm font-bold text-white bg-[#0A0A0A] rounded-lg py-3 px-6 hover:opacity-85 transition-opacity"
+                  >
+                    이력서 추가하기
+                  </button>
+                </>
+              )}
             </div>
           )}
           {isLoading && (

--- a/src/pages/resume-list/ui/__tests__/ResumeListHeader.test.tsx
+++ b/src/pages/resume-list/ui/__tests__/ResumeListHeader.test.tsx
@@ -1,16 +1,32 @@
 import { render, screen } from "@testing-library/react";
 import { ResumeListHeader } from "../ResumeListHeader";
 
+const defaultProps = {
+  totalCount: 7,
+  searchQuery: "",
+  onSearchChange: () => {},
+};
+
 describe("ResumeListHeader", () => {
   it("총 개수를 강조 표시한다", () => {
-    render(<ResumeListHeader totalCount={7} />);
+    render(<ResumeListHeader {...defaultProps} totalCount={7} />);
     expect(screen.getByText("7")).toBeInTheDocument();
     expect(screen.getByText(/전체 이력서/)).toBeInTheDocument();
     expect(screen.getByText(/개/)).toBeInTheDocument();
   });
 
   it("totalCount가 0일 때도 렌더링된다", () => {
-    render(<ResumeListHeader totalCount={0} />);
+    render(<ResumeListHeader {...defaultProps} totalCount={0} />);
     expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("검색 인풋이 렌더링된다", () => {
+    render(<ResumeListHeader {...defaultProps} />);
+    expect(screen.getByRole("textbox", { name: "이력서 검색" })).toBeInTheDocument();
+  });
+
+  it("searchQuery 값이 인풋에 반영된다", () => {
+    render(<ResumeListHeader {...defaultProps} searchQuery="프론트엔드" />);
+    expect(screen.getByDisplayValue("프론트엔드")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 관련 이슈
Closes #66 

## 변경 사항
- 이력서 목록 빈 상태 UI를 이모지 + 굵은 제목 + 서브텍스트 중앙 정렬 레이아웃으로 개선
- 검색어 유무에 따라 빈 상태 메시지 분기 처리 (검색 결과 없음 / 이력서 없음)
- `ResumeListHeader`에 이력서 제목 검색 인풋 추가 (채용공고 목록과 동일한 스타일)
- `ResumeListPage`에 클라이언트 사이드 필터링 로직 적용
- `ResumeListHeader` 테스트에 새 props 및 검색 인풋 관련 케이스 추가

## 변경 유형
- [ ] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [x] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
- [x] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 이력서가 없는 상태에서 목록 페이지 진입 → 이모지+제목+서브텍스트+버튼 빈 상태 UI 확인
2. 이력서가 있는 상태에서 검색어 입력 → 제목 기준 실시간 필터링 동작 확인
3. 검색 결과가 없는 경우 → "검색 결과가 없어요" 메시지 표시 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보
