### PR TITLE
[068] 루트 페이지에 랜딩과 홈 대시보드 병합

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,7 +11,6 @@ import { SignUpPage } from "@/pages/sign-up";
 import { LoginPage } from "@/pages/login";
 import { VerifyEmailPage } from "@/pages/verify-email";
 import { OnboardingPage } from "@/pages/onboarding";
-import { HomePage } from "@/pages/home";
 import { JdAddPage } from "@/pages/jd-add";
 import { JdDetailPage } from "@/pages/jd-detail";
 import { JdListPage } from "@/pages/jd-list";
@@ -60,7 +59,6 @@ function App() {
         <Route path="/onboarding" element={<OnboardingPage />} />
 
         {/* ── 보호 라우트 (로그인 필요) ── */}
-        <Route path="/home" element={<ProtectedRoute><HomePage /></ProtectedRoute>} />
         <Route path="/jd/add" element={<ProtectedRoute><JdAddPage /></ProtectedRoute>} />
         <Route path="/jd/:uuid" element={<ProtectedRoute><JdDetailPage /></ProtectedRoute>} />
         <Route path="/jd" element={<ProtectedRoute><JdListPage /></ProtectedRoute>} />

--- a/src/pages/home/index.ts
+++ b/src/pages/home/index.ts
@@ -1,1 +1,2 @@
 export { HomePage } from "./ui/HomePage";
+export { HomeContent } from "./ui/HomeContent";

--- a/src/pages/home/ui/HomeContent.tsx
+++ b/src/pages/home/ui/HomeContent.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { useHomeStore } from "@/features/home";
+import {
+  HomeHeader,
+  QuickStartHero,
+  StatsGrid,
+  RecentSessions,
+  StreakCalendar,
+  JobStatus,
+  LoadingSkeleton,
+} from "./components";
+import "./HomePage.css";
+
+export function HomeContent() {
+  const { data, loading, fetchHome } = useHomeStore();
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    fetchHome();
+  }, [fetchHome]);
+
+  useEffect(() => {
+    if (!data) return;
+    const t = setTimeout(() => setRevealed(true), 50);
+    return () => clearTimeout(t);
+  }, [data]);
+
+  return (
+    <div className="hp-main">
+      {loading && !data ? (
+        <LoadingSkeleton />
+      ) : data ? (
+        <>
+          <HomeHeader
+            greeting={data.user.greeting}
+            userName={data.user.name}
+            lastInterviewDaysAgo={data.user.lastInterviewDaysAgo}
+          />
+
+          <QuickStartHero revealed={revealed} />
+
+          <StatsGrid stats={data.stats} revealed={revealed} />
+
+          <RecentSessions sessions={data.recentSessions} revealed={revealed} />
+
+          <div className="hp-bottom">
+            <StreakCalendar streakData={data.streakData} revealed={revealed} />
+            <JobStatus jobs={data.jobs} revealed={revealed} />
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -1,54 +1,5 @@
-import { useEffect, useState } from "react";
-import { useHomeStore } from "@/features/home";
-import {
-  HomeHeader,
-  QuickStartHero,
-  StatsGrid,
-  RecentSessions,
-  StreakCalendar,
-  JobStatus,
-  LoadingSkeleton,
-} from "./components";
-import "./HomePage.css";
+import { HomeContent } from "./HomeContent";
 
 export function HomePage() {
-  const { data, loading, fetchHome } = useHomeStore();
-  const [revealed, setRevealed] = useState(false);
-
-  useEffect(() => {
-    fetchHome();
-  }, [fetchHome]);
-
-  useEffect(() => {
-    if (!data) return;
-    const t = setTimeout(() => setRevealed(true), 50);
-    return () => clearTimeout(t);
-  }, [data]);
-
-  return (
-    <div className="hp-main">
-      {loading && !data ? (
-        <LoadingSkeleton />
-      ) : data ? (
-        <>
-          <HomeHeader
-            greeting={data.user.greeting}
-            userName={data.user.name}
-            lastInterviewDaysAgo={data.user.lastInterviewDaysAgo}
-          />
-
-          <QuickStartHero revealed={revealed} />
-
-          <StatsGrid stats={data.stats} revealed={revealed} />
-
-          <RecentSessions sessions={data.recentSessions} revealed={revealed} />
-
-          <div className="hp-bottom">
-            <StreakCalendar streakData={data.streakData} revealed={revealed} />
-            <JobStatus jobs={data.jobs} revealed={revealed} />
-          </div>
-        </>
-      ) : null}
-    </div>
-  );
+  return <HomeContent />;
 }

--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -58,7 +58,7 @@ export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = f
       </Link>
       <div className="hp-sb-sep">알림</div>
       <button
-        className={`hp-sb-item w-full text-left border-none bg-transparent${isActive("/settings") && path === "/settings" ? "" : ""}`}
+        className="hp-sb-item w-full text-left border-none bg-transparent"
         onClick={() => { setActivePanel("notifications"); navigate("/settings"); }}
       >
         <span className="hp-sb-icon">🔔</span>알림 설정

--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -1,4 +1,6 @@
 import { Link, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { useSettingsStore } from "@/features/settings";
 
 interface HomeSidebarProps {
   menuOpen: boolean;
@@ -11,11 +13,14 @@ interface HomeSidebarProps {
 
 export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = false, activeItem }: HomeSidebarProps) {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { setActivePanel } = useSettingsStore();
   const path = location.pathname;
 
   const isActive = (prefix: string) => {
     if (activeItem === "results" && prefix === "/interview/results") return true;
-    if (activeItem === "home" && prefix === "/home") return true;
+    if (activeItem === "home" && prefix === "/") return true;
+    if (prefix === "/") return path === "/";
     return path === prefix || path.startsWith(prefix + "/");
   };
 
@@ -23,7 +28,7 @@ export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = f
   return (
     <aside className={cls}>
       <div className="hp-sb-sep">메인</div>
-      <Link to="/home" className={`hp-sb-item${isActive("/home") ? " active" : ""}`}>
+      <Link to="/" className={`hp-sb-item${isActive("/") ? " active" : ""}`}>
         <span className="hp-sb-icon">🏠</span>홈
       </Link>
       <Link to="/interview/setup" className={`hp-sb-item${isActive("/interview/setup") ? " active" : ""}`}>
@@ -50,6 +55,16 @@ export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = f
       </Link>
       <Link to="/settings" className={`hp-sb-item${isActive("/settings") ? " active" : ""}`}>
         <span className="hp-sb-icon">⚙️</span>계정 설정
+      </Link>
+      <div className="hp-sb-sep">알림</div>
+      <button
+        className={`hp-sb-item w-full text-left border-none bg-transparent${isActive("/settings") && path === "/settings" ? "" : ""}`}
+        onClick={() => { setActivePanel("notifications"); navigate("/settings"); }}
+      >
+        <span className="hp-sb-icon">🔔</span>알림 설정
+      </button>
+      <Link to="/notifications" className={`hp-sb-item${isActive("/notifications") ? " active" : ""}`}>
+        <span className="hp-sb-icon">📬</span>알림 내역
       </Link>
       <div className="hp-sb-streak-card">
         <div className="hp-ssc-label">스트릭</div>

--- a/src/pages/interview-complete/ui/InterviewCompletePage.tsx
+++ b/src/pages/interview-complete/ui/InterviewCompletePage.tsx
@@ -27,7 +27,7 @@ export function InterviewCompletePage() {
             면접 결과 보기 →
           </Link>
           <Link
-            to="/home"
+            to="/"
             className="w-full py-3.5 rounded-xl font-bold text-base text-[#374151] bg-white border border-[#E5E7EB] flex items-center justify-center no-underline hover:bg-[#F9FAFB] transition-colors"
           >
             홈으로 이동

--- a/src/pages/landing/ui/LandingPage.tsx
+++ b/src/pages/landing/ui/LandingPage.tsx
@@ -29,8 +29,10 @@ export function LandingPage() {
     }
   }, [authReady, user, navigate]);
 
+  if (!authReady) return null;
+
   // 로그인 완료된 사용자: 홈 대시보드를 AppLayout 안에서 렌더
-  if (authReady && user?.isEmailConfirmed && user?.isProfileCompleted) {
+  if (user?.isEmailConfirmed && user?.isProfileCompleted) {
     return (
       <AppLayout>
         <HomeContent />

--- a/src/pages/landing/ui/LandingPage.tsx
+++ b/src/pages/landing/ui/LandingPage.tsx
@@ -12,6 +12,8 @@ import { WhySection } from "./WhySection";
 import { CtaSection } from "./CtaSection";
 import { FooterSection } from "./FooterSection";
 import { useAuthStore } from "@/features/auth";
+import { AppLayout } from "@/app/AppLayout";
+import { HomeContent } from "@/pages/home/ui/HomeContent";
 
 export function LandingPage() {
   const navigate = useNavigate();
@@ -19,16 +21,24 @@ export function LandingPage() {
 
   useEffect(() => {
     if (!authReady || !user) return;
-    // 이미 로그인된 사용자를 적절한 화면으로 리다이렉트
+    // 이메일 미인증 또는 프로필 미완성 사용자는 해당 페이지로 이동
     if (!user.isEmailConfirmed) {
       navigate("/verify-email", { replace: true });
     } else if (!user.isProfileCompleted) {
       navigate("/onboarding", { replace: true });
-    } else {
-      navigate("/home", { replace: true });
     }
   }, [authReady, user, navigate]);
 
+  // 로그인 완료된 사용자: 홈 대시보드를 AppLayout 안에서 렌더
+  if (authReady && user?.isEmailConfirmed && user?.isProfileCompleted) {
+    return (
+      <AppLayout>
+        <HomeContent />
+      </AppLayout>
+    );
+  }
+
+  // 비로그인 사용자 또는 인증 대기 중: 랜딩 페이지
   return (
     <>
       <Navbar />

--- a/src/pages/login/ui/LoginPage.tsx
+++ b/src/pages/login/ui/LoginPage.tsx
@@ -34,7 +34,7 @@ export function LoginPage() {
       } else if (result.isProfileCompleted === false) {
         navigate("/onboarding");
       } else {
-        navigate("/home");
+        navigate("/");
       }
     }
   };

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -75,7 +75,7 @@ export function OnboardingPage() {
     const ok = await submitProfile();
     if (ok) {
       await useAuthStore.getState().fetchMe();
-      navigate("/home");
+      navigate("/");
     }
   };
 

--- a/src/widgets/landing-navbar/NavPill.tsx
+++ b/src/widgets/landing-navbar/NavPill.tsx
@@ -104,7 +104,7 @@ export function NavPill() {
         <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
           {isAuthenticated ? (
             <button
-              onClick={() => navigate("/home")}
+              onClick={() => navigate("/")}
               style={{
                 fontFamily: "'Inter', sans-serif",
                 fontSize: 14,


### PR DESCRIPTION
## 관련 이슈
Closes #68

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.
- 기존 `/` (랜딩) 와 `/home` (대시보드) 라우트를 `/` 하나로 통합
- 비로그인 사용자는 기존과 동일하게 랜딩 페이지 노출
- 로그인 완료 사용자는 `/`에서 바로 홈 대시보드 렌더링 (리다이렉트 없음)
- `HomeContent` 컴포넌트를 분리하여 `LandingPage`와 `HomePage` 양쪽에서 재사용
- `/home`으로 향하던 모든 `navigate` 및 `Link`를 `/`로 변경

## 변경 유형
해당하는 항목에 체크해주세요.
- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.
- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 비로그인 상태에서 `/` 접속 → 랜딩 페이지가 정상 노출되는지 확인
2. 로그인 후 `/` 접속 → 홈 대시보드가 AppLayout(사이드바/네비바 포함)과 함께 렌더링되는지 확인
3. 로그인 후 사이드바 홈 링크 클릭 → `/`로 이동하며 홈 대시보드 유지되는지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보
