### PR TITLE
[083] 랜딩 navbar 스크롤 시 검은 선 및 레이아웃 점프 수정

### DIFF
--- a/src/widgets/landing-navbar/NavPill.tsx
+++ b/src/widgets/landing-navbar/NavPill.tsx
@@ -27,14 +27,14 @@ export function NavPill() {
         position: "fixed",
         top: 0, left: 0, right: 0,
         zIndex: 200,
-        padding: scrolled ? "0 40px" : "14px 40px",
+        padding: scrolled ? "4px 40px" : "14px 40px",
         display: "flex",
         justifyContent: "center",
         background: scrolled ? "rgba(255,255,255,0.95)" : "transparent",
         backdropFilter: scrolled ? "blur(12px)" : "none",
         WebkitBackdropFilter: scrolled ? "blur(12px)" : "none",
-        borderBottom: scrolled ? "1px solid #E5E7EB" : "none",
-        transition: "all 0.3s",
+        borderBottom: scrolled ? "1px solid #E5E7EB" : "1px solid transparent",
+        transition: "padding 0.3s, background 0.3s, border-bottom 0.3s, backdrop-filter 0.3s",
       }}
     >
       <div
@@ -48,8 +48,8 @@ export function NavPill() {
           backdropFilter: scrolled ? "none" : "blur(12px)",
           WebkitBackdropFilter: scrolled ? "none" : "blur(12px)",
           borderRadius: scrolled ? 0 : 8,
-          border: scrolled ? "none" : "1px solid #E5E7EB",
-          padding: scrolled ? "12px 0" : "10px 10px 10px 24px",
+          border: scrolled ? "1px solid transparent" : "1px solid #E5E7EB",
+          padding: scrolled ? "8px 0" : "10px 10px 10px 24px",
           boxShadow: scrolled ? "none" : "0 1px 3px rgba(0,0,0,0.08)",
           transition: "all 0.3s",
         }}


### PR DESCRIPTION
## 관련 이슈
Closes #83

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.
- 스크롤 시 navbar border가 `none` ↔ `1px solid` 전환되면서 발생하던 검은 선 제거
- `nav` 및 내부 pill div의 `border: "none"` → `border: "1px solid transparent"` 로 변경하여 브라우저 기본 색상 렌더링 방지
- 스크롤 후 navbar 높이가 과도하게 두꺼운 문제 개선 (`nav` padding `0px` → `4px`, 내부 div padding `12px` → `8px`)
- `transition: "all 0.3s"` → 변경되는 속성만 명시하여 불필요한 reflow 감소

## 변경 유형
해당하는 항목에 체크해주세요.
- [x] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.
- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [ ] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 랜딩 페이지 접속 후 스크롤을 아래로 내려 navbar가 pill → 고정 바 형태로 전환되는지 확인
2. 전환 시 검은 선이 순간적으로 나타나지 않는지 확인
3. 스크롤을 다시 위로 올려 pill 형태로 복귀 시 동일하게 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보
- 검은 선 이슈는 Windows 환경에서 주로 발생하는 것으로 보고됨 (Mac에서는 재현 어려움)
- `border: "none"` 사용 시 브라우저가 border를 제거했다가 재생성하는 과정에서 기본 색상(검정)이 순간 렌더링되는 브라우저 동작이 원인
- 배포 후 Windows 환경에서 추가 검증 필요

