### PR TITLE
[071] 이력서 활성화 관련 코드 및 상태 제거 및 배지 단순화

### DIFF
--- a/src/features/resume/api/__tests__/resumeApi.test.ts
+++ b/src/features/resume/api/__tests__/resumeApi.test.ts
@@ -44,11 +44,4 @@ describe("resumeApi", () => {
     await resumeApi.remove("uuid-del");
     expect(mockApiRequest).toHaveBeenCalledWith("/api/v1/resumes/uuid-del/", { method: "DELETE", auth: true });
   });
-
-  it("activate/deactivate 는 올바른 액션 URL로 POST", async () => {
-    await resumeApi.activate("u1");
-    await resumeApi.deactivate("u1");
-    expect(mockApiRequest).toHaveBeenCalledWith("/api/v1/resumes/u1/activate/", { method: "POST", auth: true });
-    expect(mockApiRequest).toHaveBeenCalledWith("/api/v1/resumes/u1/deactivate/", { method: "POST", auth: true });
-  });
 });

--- a/src/features/resume/api/resumeApi.ts
+++ b/src/features/resume/api/resumeApi.ts
@@ -120,12 +120,6 @@ export const resumeApi = {
 
   remove: (uuid: string) =>
     apiRequest<void>(`${BASE}/${uuid}/`, { method: "DELETE", auth: true }),
-
-  activate: (uuid: string) =>
-    apiRequest<ResumeListItem>(`${BASE}/${uuid}/activate/`, { method: "POST", auth: true }),
-
-  deactivate: (uuid: string) =>
-    apiRequest<ResumeListItem>(`${BASE}/${uuid}/deactivate/`, { method: "POST", auth: true }),
 };
 
 

--- a/src/features/resume/api/types.ts
+++ b/src/features/resume/api/types.ts
@@ -102,7 +102,6 @@ export interface ResumeListItem {
   type: ResumeType;
   sourceMode: ResumeSourceMode;
   title: string;
-  isActive: boolean;
   isParsed: boolean;
   isDirty: boolean;
   lastFinalizedAt: string | null;
@@ -140,8 +139,6 @@ export interface ResumeCountStats {
   pending: number;
   completed: number;
   failed: number;
-  active: number;
-  inactive: number;
 }
 
 export interface ResumeTypeStats {

--- a/src/features/resume/ui/ResumeStatusBadge.tsx
+++ b/src/features/resume/ui/ResumeStatusBadge.tsx
@@ -1,9 +1,8 @@
-/** 분석 상태와 활성 여부를 함께 표시하는 배지. */
+/** 분석 상태 배지. */
 import type { AnalysisStatus } from "../api/types";
 
 interface ResumeStatusBadgeProps {
   status: AnalysisStatus;
-  isActive?: boolean;
 }
 
 const STATUS_STYLE: Record<AnalysisStatus, { label: string; cls: string }> = {
@@ -13,18 +12,11 @@ const STATUS_STYLE: Record<AnalysisStatus, { label: string; cls: string }> = {
   failed:     { label: "분석 실패", cls: "text-[#DC2626] bg-[#FEF2F2] border-[#FECACA]" },
 };
 
-export function ResumeStatusBadge({ status, isActive }: ResumeStatusBadgeProps) {
+export function ResumeStatusBadge({ status }: ResumeStatusBadgeProps) {
   const s = STATUS_STYLE[status];
   return (
-    <div className="flex items-center gap-1.5">
-      <span className={`text-[10px] font-bold border rounded-full px-2 py-px ${s.cls}`}>
-        {s.label}
-      </span>
-      {isActive === false && (
-        <span className="text-[10px] font-bold border rounded-full px-2 py-px text-[#6B7280] bg-[#F9FAFB] border-[#E5E7EB]">
-          비활성
-        </span>
-      )}
-    </div>
+    <span className={`text-[10px] font-bold border rounded-full px-2 py-px ${s.cls}`}>
+      {s.label}
+    </span>
   );
 }

--- a/src/features/resume/ui/__tests__/ResumeStatusBadge.test.tsx
+++ b/src/features/resume/ui/__tests__/ResumeStatusBadge.test.tsx
@@ -3,28 +3,22 @@ import { ResumeStatusBadge } from "../ResumeStatusBadge";
 
 describe("ResumeStatusBadge", () => {
   it("processing 상태 라벨을 표시한다", () => {
-    render(<ResumeStatusBadge status="processing" isActive={true} />);
+    render(<ResumeStatusBadge status="processing" />);
     expect(screen.getByText("분석 중")).toBeInTheDocument();
   });
 
   it("completed 상태 라벨을 표시한다", () => {
-    render(<ResumeStatusBadge status="completed" isActive={true} />);
+    render(<ResumeStatusBadge status="completed" />);
     expect(screen.getByText("분석 완료")).toBeInTheDocument();
   });
 
   it("failed 상태 라벨을 표시한다", () => {
-    render(<ResumeStatusBadge status="failed" isActive={true} />);
+    render(<ResumeStatusBadge status="failed" />);
     expect(screen.getByText("분석 실패")).toBeInTheDocument();
   });
 
-  it("isActive=false이면 '비활성' 보조 배지가 함께 표시된다", () => {
-    render(<ResumeStatusBadge status="completed" isActive={false} />);
-    expect(screen.getByText("분석 완료")).toBeInTheDocument();
-    expect(screen.getByText("비활성")).toBeInTheDocument();
-  });
-
-  it("isActive가 undefined면 비활성 배지가 없다", () => {
-    render(<ResumeStatusBadge status="completed" />);
-    expect(screen.queryByText("비활성")).toBeNull();
+  it("pending 상태 라벨을 표시한다", () => {
+    render(<ResumeStatusBadge status="pending" />);
+    expect(screen.getByText("대기")).toBeInTheDocument();
   });
 });

--- a/src/pages/resume-detail/ui/ResumeDetailPage.tsx
+++ b/src/pages/resume-detail/ui/ResumeDetailPage.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Loader2, ArrowLeft, Trash2, Power, PowerOff } from "lucide-react";
+import { Loader2, ArrowLeft, Trash2 } from "lucide-react";
 import {
   resumeApi,
   AnalysisProgress,
@@ -52,7 +52,6 @@ export function ResumeDetailPage() {
   const [parsed, setParsed] = useState<ParsedData>(EMPTY_PARSED);
   const [isLoading, setIsLoading] = useState(true);
   const [isFinalizing, setIsFinalizing] = useState(false);
-  const [isToggling, setIsToggling] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   /** retrieve 재시도 — 네트워크 일시적 실패나 백엔드 커밋 race 를 완충. */
@@ -141,19 +140,6 @@ export function ResumeDetailPage() {
     }
   };
 
-  const handleToggleActive = async () => {
-    if (!resume || isToggling) return;
-    setIsToggling(true);
-    try {
-      const updated = resume.isActive
-        ? await resumeApi.deactivate(resume.uuid)
-        : await resumeApi.activate(resume.uuid);
-      setResume((prev) => (prev ? { ...prev, isActive: updated.isActive } : prev));
-    } finally {
-      setIsToggling(false);
-    }
-  };
-
   const handleDelete = async () => {
     if (!resume) return;
     if (!confirm("이력서를 삭제하시겠습니까?")) return;
@@ -202,7 +188,7 @@ export function ResumeDetailPage() {
               <h1 className="text-[clamp(22px,3vw,32px)] font-black tracking-[-0.5px] text-[#0A0A0A] leading-[1.2]">
                 {resume.title}
               </h1>
-              <ResumeStatusBadge status={resume.analysisStatus} isActive={resume.isActive} />
+              <ResumeStatusBadge status={resume.analysisStatus} />
               <span className="text-[10px] font-bold text-[#6B7280] bg-[#F3F4F6] rounded-full px-2 py-0.5">
                 {resume.sourceMode}
               </span>
@@ -216,14 +202,6 @@ export function ResumeDetailPage() {
           </div>
 
           <div className="flex items-center gap-2 shrink-0">
-            <button
-              onClick={handleToggleActive}
-              disabled={isToggling}
-              className="inline-flex items-center gap-1.5 text-[12px] font-bold border border-[#E5E7EB] rounded-lg px-3 py-2 hover:bg-[#F9FAFB] transition-colors text-[#374151] disabled:opacity-50"
-            >
-              {resume.isActive ? <PowerOff size={13} /> : <Power size={13} />}
-              {resume.isActive ? "비활성화" : "활성화"}
-            </button>
             <button
               onClick={handleDelete}
               className="inline-flex items-center gap-1.5 text-[12px] font-bold border border-[#FECACA] text-[#DC2626] rounded-lg px-3 py-2 hover:bg-[#FEF2F2] transition-colors"

--- a/src/pages/resume-detail/ui/__tests__/ResumeDetailPage.test.tsx
+++ b/src/pages/resume-detail/ui/__tests__/ResumeDetailPage.test.tsx
@@ -11,8 +11,6 @@ jest.mock("@/shared/api/client", () => ({
 jest.mock("@/features/resume/api/resumeApi", () => ({
   resumeApi: {
     retrieve: jest.fn(),
-    activate: jest.fn(),
-    deactivate: jest.fn(),
     remove: jest.fn(),
     finalize: jest.fn(),
   },
@@ -30,7 +28,6 @@ const fakeResume: ResumeDetail = {
   type: "text",
   sourceMode: "text",
   title: "백엔드 개발자 이력서",
-  isActive: true,
   isParsed: true,
   isDirty: false,
   lastFinalizedAt: null,

--- a/src/pages/resume-list/ui/ResumeCard.tsx
+++ b/src/pages/resume-list/ui/ResumeCard.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { MoreVertical, Edit2, Trash2, Power, PowerOff } from "lucide-react";
+import { MoreVertical, Edit2, Trash2 } from "lucide-react";
 import {
   AnalysisProgress,
   ResumeStatusBadge,
@@ -13,10 +13,9 @@ interface ResumeCardProps {
   onDetail: () => void;
   onEdit: () => void;
   onDelete: () => void;
-  onToggleActive: () => void;
 }
 
-export function ResumeCard({ resume, onDetail, onEdit, onDelete, onToggleActive }: ResumeCardProps) {
+export function ResumeCard({ resume, onDetail, onEdit, onDelete }: ResumeCardProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -43,7 +42,7 @@ export function ResumeCard({ resume, onDetail, onEdit, onDelete, onToggleActive 
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap mb-1">
             <h3 className="text-[14px] font-bold text-[#0A0A0A] truncate">{resume.title}</h3>
-            <ResumeStatusBadge status={resume.analysisStatus} isActive={resume.isActive} />
+            <ResumeStatusBadge status={resume.analysisStatus} />
           </div>
           <div className="text-[11px] text-[#6B7280]">
             {formatDateTime(resume.createdAt)}
@@ -63,11 +62,6 @@ export function ResumeCard({ resume, onDetail, onEdit, onDelete, onToggleActive 
           {menuOpen && (
             <div className="absolute right-0 top-[calc(100%+4px)] bg-white border border-[#E5E7EB] rounded-lg shadow-[0_8px_24px_rgba(0,0,0,0.1)] min-w-[150px] overflow-hidden z-10">
               <MenuItem icon={<Edit2 size={13} />} label="수정하기" onClick={() => { setMenuOpen(false); onEdit(); }} />
-              <MenuItem
-                icon={resume.isActive ? <PowerOff size={13} /> : <Power size={13} />}
-                label={resume.isActive ? "비활성화" : "활성화"}
-                onClick={() => { setMenuOpen(false); onToggleActive(); }}
-              />
               <MenuItem icon={<Trash2 size={13} />} label="삭제하기" danger onClick={() => { setMenuOpen(false); onDelete(); }} />
             </div>
           )}

--- a/src/pages/resume-list/ui/ResumeListPage.tsx
+++ b/src/pages/resume-list/ui/ResumeListPage.tsx
@@ -141,13 +141,6 @@ export function ResumeListPage() {
     refreshAll();
   };
 
-  const handleToggleActive = async (item: ResumeListItem) => {
-    const updated = item.isActive
-      ? await resumeApi.deactivate(item.uuid)
-      : await resumeApi.activate(item.uuid);
-    setItems((prev) => prev.map((r) => (r.uuid === item.uuid ? updated : r)));
-  };
-
   return (
     <div className="min-h-screen bg-white">
       <div className="max-w-container-lg mx-auto px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
@@ -193,7 +186,6 @@ export function ResumeListPage() {
                 onDetail={() => navigate(`/resume/${item.uuid}`)}
                 onEdit={() => navigate(`/resume/${item.uuid}`)}
                 onDelete={() => handleDelete(item.uuid)}
-                onToggleActive={() => handleToggleActive(item)}
               />
             ))}
           {items.filter((item) =>

--- a/src/pages/resume-list/ui/ResumeStatsStrip.tsx
+++ b/src/pages/resume-list/ui/ResumeStatsStrip.tsx
@@ -10,15 +10,15 @@ export function ResumeStatsStrip({ count }: ResumeStatsStripProps) {
 
   const statItems = [
     { value: count.total,     label: "전체 이력서" },
-    { value: count.active,    label: "활성 이력서" },
     { value: count.completed, label: "분석 완료" },
     { value: analyzing,       label: "분석 중" },
+    { value: count.failed,    label: "분석 실패" },
   ];
 
   const badges = [
     { dot: "#10B981", text: `분석 완료 ${count.completed}개` },
     { dot: "#0EA5E9", text: `분석 중 ${analyzing}개` },
-    { dot: "#F59E0B", text: `활성 이력서 ${count.active}개` },
+    { dot: "#DC2626", text: `분석 실패 ${count.failed}개` },
   ];
 
   return (

--- a/src/pages/resume-list/ui/__tests__/ResumeStatsStrip.test.tsx
+++ b/src/pages/resume-list/ui/__tests__/ResumeStatsStrip.test.tsx
@@ -9,21 +9,17 @@ describe("ResumeStatsStrip", () => {
     pending: 1,
     completed: 5,
     failed: 2,
-    active: 7,
-    inactive: 3,
   };
 
-  it("전체 이력서 / 활성 이력서 / 분석 완료 / 분석 중 항목을 렌더한다", () => {
+  it("전체 이력서 / 분석 완료 / 분석 중 / 분석 실패 항목을 렌더한다", () => {
     render(<ResumeStatsStrip count={count} />);
     expect(screen.getByText("전체 이력서")).toBeInTheDocument();
     expect(screen.getByText("10")).toBeInTheDocument();
-    expect(screen.getByText("활성 이력서")).toBeInTheDocument();
-    expect(screen.getByText("7")).toBeInTheDocument();
     expect(screen.getByText("분석 완료")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("분석 중")).toBeInTheDocument();
-    expect(screen.queryByText("파일")).not.toBeInTheDocument();
-    expect(screen.queryByText("텍스트")).not.toBeInTheDocument();
+    expect(screen.getByText("분석 실패")).toBeInTheDocument();
+    expect(screen.queryByText("활성 이력서")).not.toBeInTheDocument();
   });
 
   it("'분석 중' 수치는 processing + pending 합계이다", () => {

--- a/src/pages/resume-list/ui/__tests__/ResumeStatsStrip.test.tsx
+++ b/src/pages/resume-list/ui/__tests__/ResumeStatsStrip.test.tsx
@@ -3,22 +3,30 @@ import { ResumeStatsStrip } from "../ResumeStatsStrip";
 import type { ResumeCountStats } from "@/features/resume";
 
 describe("ResumeStatsStrip", () => {
+  // 각 카운트가 화면에서 unique 한 숫자로 매칭되도록 의도적으로 서로 다른 값을 사용한다.
   const count: ResumeCountStats = {
     total: 10,
     processing: 2,
     pending: 1,
     completed: 5,
-    failed: 2,
+    failed: 4,
   };
 
-  it("전체 이력서 / 분석 완료 / 분석 중 / 분석 실패 항목을 렌더한다", () => {
+  it("전체 이력서 / 분석 완료 / 분석 중 / 분석 실패 항목과 값을 렌더한다", () => {
     render(<ResumeStatsStrip count={count} />);
+
     expect(screen.getByText("전체 이력서")).toBeInTheDocument();
     expect(screen.getByText("10")).toBeInTheDocument();
+
     expect(screen.getByText("분석 완료")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
+
     expect(screen.getByText("분석 중")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument(); // processing + pending
+
     expect(screen.getByText("분석 실패")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+
     expect(screen.queryByText("활성 이력서")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## 관련 이슈
Closes #71 

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- 이력서 활성화 및 비활성화 관련 API 호출을 제거했습니다.
- ResumeStatusBadge 컴포넌트에서 활성 상태 표시를 위한 isActive 프로퍼티를 제거했습니다.
- ResumeDetailPage 및 ResumeCard에서 isActive 관련 프로퍼티 사용을 제거했습니다.
- ResumeStatsStrip에서 활성 이력서 통계 및 관련 배지를 제거했습니다.

## 변경 유형
해당하는 항목에 체크해주세요.

- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [ ] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 이력서 목록에서 항목을 클릭하여 상세 페이지로 이동합니다.
2. 배지 상태가 올바르게 표시되는지 확인합니다.
3. 모든 이력서와 관련된 활성화/비활성화 버튼이 사라졌는지 확인합니다.

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
<img width="2472" height="1298" alt="image" src="https://github.com/user-attachments/assets/77d293e7-a071-4982-86bf-04dd6a6c1393" />



## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.