### PR TITLE
[093] 사이드바 채용공고 뱃지 제거

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -42,7 +42,6 @@ export function AppLayout({ children }: AppLayoutProps) {
           <HomeSidebar
             menuOpen={menuOpen}
             currentStreak={data?.currentStreak ?? 0}
-            jdCount={data?.jobs.length ?? 0}
           />
         )}
         <main className="hp-page-main">{children}</main>

--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -3,13 +3,12 @@ import { Link, useLocation } from "react-router-dom";
 interface HomeSidebarProps {
   menuOpen: boolean;
   currentStreak: number;
-  jdCount?: number;
   /** grid 밖에서 렌더될 때 항상 fixed position으로 동작 */
   floating?: boolean;
   activeItem?: "home" | "results";
 }
 
-export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = false, activeItem }: HomeSidebarProps) {
+export function HomeSidebar({ menuOpen, currentStreak, floating = false, activeItem }: HomeSidebarProps) {
   const location = useLocation();
   const path = location.pathname;
 
@@ -36,7 +35,6 @@ export function HomeSidebar({ menuOpen, currentStreak, jdCount = 0, floating = f
       </Link>
       <Link to="/jd" className={`hp-sb-item${isActive("/jd") ? " active" : ""}`}>
         <span className="hp-sb-icon">🏢</span>채용공고
-        {jdCount > 0 && <span className="hp-sb-badge">{jdCount}</span>}
       </Link>
       <div className="hp-sb-sep">분석</div>
       <Link to="/interview/results" className={`hp-sb-item${isActive("/interview/results") ? " active" : ""}`}>


### PR DESCRIPTION
## 관련 이슈
Closes #93

## 변경 사항

사이드바의 채용공고 메뉴 옆에 표시되던 숫자 뱃지를 제거했습니다.

기존에는 홈 대시보드 API(`/api/v1/home/dashboard/`)의 `jobs` 배열 길이를 뱃지 숫자로 표시하고 있었으나, 실제 채용공고 목록 데이터와 연동되지 않아 부정확한 값이 노출될 수 있었습니다. 별도 API 호출 없이 뱃지 자체를 제거하는 방향으로 결정했습니다.

---

## 변경 유형

해당하는 항목에 체크해주세요.
- [ ] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

---

## 테스트 방법

변경 사항을 테스트한 방법을 설명해주세요.
- [x] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 사이드바의 채용공고 메뉴 항목에 뱃지가 노출되지 않는지 확인
2. 채용공고 페이지 진입 및 정상 동작 확인
3. 기존 44개 단위 테스트 전체 통과 확인


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

---

## 스크린샷

UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

---

## 추가 정보

- 변경 파일: `src/app/AppLayout.tsx`, `src/pages/home/ui/components/HomeSidebar.tsx`
- `HomeSidebar`의 `jdCount` prop 및 관련 렌더링 로직 완전 제거
- `AppLayout`에서 불필요해진 `useJdListStore` import 및 `useEffect` 제거