### PR TITLE
feat: 알림 기능 프론트엔드 구현 (#98)

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -4,6 +4,7 @@ import { HomeNavbar } from "@/pages/home/ui/components/HomeNavbar";
 import { HomeSidebar } from "@/pages/home/ui/components/HomeSidebar";
 import { SettingsSidebar } from "@/pages/home/ui/components/SettingsSidebar";
 import { useHomeStore } from "@/features/home";
+import { useNotificationToast } from "@/features/notifications";
 import "@/pages/home/ui/HomePage.css";
 
 interface AppLayoutProps {
@@ -14,6 +15,7 @@ interface AppLayoutProps {
 const FULL_SCREEN_PREFIXES = ["/interview/session/", "/interview/precheck/"];
 
 export function AppLayout({ children }: AppLayoutProps) {
+  useNotificationToast();
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
   const { data } = useHomeStore();

--- a/src/features/interview-precheck/api/checkNetwork.ts
+++ b/src/features/interview-precheck/api/checkNetwork.ts
@@ -25,6 +25,7 @@ export async function checkNetworkApi(
           method: "GET",
           cache: "no-store",
           headers: authHeaders,
+          signal: AbortSignal.timeout(5000),
         });
       } catch {
         // Even errors give latency info
@@ -47,6 +48,7 @@ export async function checkNetworkApi(
         method: "GET",
         cache: "no-store",
         headers: { ...authHeaders, Accept: "application/json" },
+        signal: AbortSignal.timeout(5000),
       });
       const blob = await res.blob();
       const downloadEnd = performance.now();

--- a/src/features/interview-precheck/model/store.ts
+++ b/src/features/interview-precheck/model/store.ts
@@ -23,6 +23,7 @@ interface PrecheckState {
 }
 
 let micIntervalRef: ReturnType<typeof setInterval> | null = null;
+let pollPassedRef: ReturnType<typeof setInterval> | null = null;
 let audioContext: AudioContext | null = null;
 let analyser: AnalyserNode | null = null;
 let microphone: MediaStreamAudioSourceNode | null = null;
@@ -31,6 +32,7 @@ let cameraMediaStream: MediaStream | null = null;
 
 function stopAllResources() {
   if (micIntervalRef) { clearInterval(micIntervalRef); micIntervalRef = null; }
+  if (pollPassedRef) { clearInterval(pollPassedRef); pollPassedRef = null; }
   if (microphone) { microphone.disconnect(); microphone = null; }
   if (audioContext) { audioContext.close(); audioContext = null; }
   if (micMediaStream) { micMediaStream.getTracks().forEach((t) => t.stop()); micMediaStream = null; }
@@ -94,6 +96,7 @@ export const usePrecheckStore = create<PrecheckState>((set, get) => ({
 
     // Real mic level via Web Audio API
     if (micIntervalRef) { clearInterval(micIntervalRef); micIntervalRef = null; }
+    if (micMediaStream) { micMediaStream.getTracks().forEach((t) => t.stop()); micMediaStream = null; }
 
     navigator.mediaDevices
       .getUserMedia({ audio: true })
@@ -123,7 +126,7 @@ export const usePrecheckStore = create<PrecheckState>((set, get) => ({
       });
 
     // Watch for all-passed
-    const pollPassed = setInterval(() => {
+    pollPassedRef = setInterval(() => {
       const s = get();
       if (
         s.cameraStatus !== "idle" && s.cameraStatus !== "checking" &&
@@ -131,7 +134,7 @@ export const usePrecheckStore = create<PrecheckState>((set, get) => ({
         s.networkStatus !== "idle" && s.networkStatus !== "checking" &&
         s.gpuStatus !== "idle" && s.gpuStatus !== "checking"
       ) {
-        clearInterval(pollPassed);
+        clearInterval(pollPassedRef!); pollPassedRef = null;
         if (
           s.cameraStatus === "ok" &&
           s.micStatus === "ok" &&

--- a/src/features/interview-precheck/model/store.ts
+++ b/src/features/interview-precheck/model/store.ts
@@ -30,6 +30,21 @@ let microphone: MediaStreamAudioSourceNode | null = null;
 let micMediaStream: MediaStream | null = null;
 let cameraMediaStream: MediaStream | null = null;
 
+/** True when every check has left idle/checking state. */
+function isAllSettled(s: PrecheckState): boolean {
+  return (
+    s.cameraStatus !== "idle" && s.cameraStatus !== "checking" &&
+    s.micStatus !== "idle" && s.micStatus !== "checking" &&
+    s.networkStatus !== "idle" && s.networkStatus !== "checking" &&
+    s.gpuStatus !== "idle" && s.gpuStatus !== "checking"
+  );
+}
+
+/** True when all critical checks passed (GPU fail is non-blocking). */
+function isAllCriticalPassed(s: PrecheckState): boolean {
+  return s.cameraStatus === "ok" && s.micStatus === "ok" && s.networkStatus === "ok";
+}
+
 function stopAllResources() {
   if (micIntervalRef) { clearInterval(micIntervalRef); micIntervalRef = null; }
   if (pollPassedRef) { clearInterval(pollPassedRef); pollPassedRef = null; }
@@ -128,22 +143,9 @@ export const usePrecheckStore = create<PrecheckState>((set, get) => ({
     // Watch for all-passed
     pollPassedRef = setInterval(() => {
       const s = get();
-      if (
-        s.cameraStatus !== "idle" && s.cameraStatus !== "checking" &&
-        s.micStatus !== "idle" && s.micStatus !== "checking" &&
-        s.networkStatus !== "idle" && s.networkStatus !== "checking" &&
-        s.gpuStatus !== "idle" && s.gpuStatus !== "checking"
-      ) {
-        clearInterval(pollPassedRef!); pollPassedRef = null;
-        if (
-          s.cameraStatus === "ok" &&
-          s.micStatus === "ok" &&
-          s.networkStatus === "ok"
-          // GPU fail is non-blocking — interview can proceed without HW accel
-        ) {
-          set({ allPassed: true });
-        }
-      }
+      if (!isAllSettled(s)) return;
+      clearInterval(pollPassedRef!); pollPassedRef = null;
+      if (isAllCriticalPassed(s)) set({ allPassed: true });
     }, 200);
   },
 

--- a/src/features/interview-session/api/types.ts
+++ b/src/features/interview-session/api/types.ts
@@ -83,13 +83,8 @@ export interface SubmitAnswerFollowupResponse {
 export type SubmitAnswerFullProcessResponse = InterviewTurn | { detail: string };
 export type SubmitAnswerResponse = SubmitAnswerFollowupResponse | SubmitAnswerFullProcessResponse;
 
-export interface PaginatedResponse<T> {
-  count: number;
-  totalPagesCount: number;
-  nextPage: number | null;
-  previousPage: number | null;
-  results: T[];
-}
+// ── Paginated Response (공통 타입 — shared 에서 re-export) ──
+export type { PaginatedResponse } from "@/shared/api/client";
 
 export interface InterviewSessionListItem {
   uuid: string;

--- a/src/features/interview-session/ui/TranscriptPanel.tsx
+++ b/src/features/interview-session/ui/TranscriptPanel.tsx
@@ -7,6 +7,37 @@ interface TranscriptPanelProps {
   isListening: boolean;
 }
 
+/**
+ * Parses the limited HTML produced by SpeechAnalyzer (only
+ * `<span class="bad-word">` and `<span class="filler-word">` tags)
+ * into React elements, avoiding dangerouslySetInnerHTML / XSS risk.
+ */
+function parseHighlightedHtml(html: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  const regex = /<span class="(bad-word|filler-word)">([^<]*)<\/span>/g;
+  let lastIndex = 0;
+  let key = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(html)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(html.slice(lastIndex, match.index));
+    }
+    parts.push(
+      <span key={key++} className={match[1]}>
+        {match[2]}
+      </span>,
+    );
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < html.length) {
+    parts.push(html.slice(lastIndex));
+  }
+
+  return parts;
+}
+
 export function TranscriptPanel({
   interimText,
   highlightedHtml,
@@ -29,10 +60,7 @@ export function TranscriptPanel({
         ref={scrollRef}
         className="flex-1 min-h-0 font-mono text-base leading-relaxed overflow-y-auto"
       >
-        <span
-          className="text-white"
-          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-        />
+        <span className="text-white">{parseHighlightedHtml(highlightedHtml)}</span>
         <span className="text-indigo-300 italic animate-pulse ml-1">{interimText}</span>
         {!highlightedHtml && !interimText && !isListening && (
           <span className="text-slate-600 italic text-sm">답변이 여기에 표시됩니다...</span>

--- a/src/features/interview-setup/api/interviewSetupApi.ts
+++ b/src/features/interview-setup/api/interviewSetupApi.ts
@@ -1,5 +1,5 @@
 import { apiRequest } from "@/shared/api/client";
-import type { PaginatedResponse } from "@/features/resume";
+import type { PaginatedResponse } from "@/shared/api";
 import type {
   InterviewSessionType,
   InterviewDifficultyLevel,

--- a/src/features/notifications/api/__tests__/notificationsApi.test.ts
+++ b/src/features/notifications/api/__tests__/notificationsApi.test.ts
@@ -1,0 +1,196 @@
+import { apiRequest } from "@/shared/api/client";
+import {
+  fetchNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+  clearAllNotifications,
+  toStoreNotification,
+} from "../notificationsApi";
+
+jest.mock("@/shared/api/client", () => ({
+  apiRequest: jest.fn(),
+  BASE_URL: "http://test.local",
+  getAccessToken: jest.fn(() => "test-token"),
+}));
+
+const mockApiRequest = apiRequest as jest.MockedFunction<typeof apiRequest>;
+
+// A backend notification with created_at very close to now so formatTime returns "방금 전"
+const makeBackend = (overrides = {}) => ({
+  id: 1,
+  message: "Test notification",
+  category: "system" as const,
+  is_read: false,
+  notifiable_type_label: "resumes.resume" as string | null,
+  notifiable_id: "abc-123" as string | null,
+  created_at: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("toStoreNotification", () => {
+  it("maps id, message, category unchanged", () => {
+    const result = toStoreNotification(makeBackend());
+    expect(result.id).toBe(1);
+    expect(result.message).toBe("Test notification");
+    expect(result.category).toBe("system");
+  });
+
+  it("maps is_read → read", () => {
+    expect(toStoreNotification(makeBackend({ is_read: true })).read).toBe(true);
+    expect(toStoreNotification(makeBackend({ is_read: false })).read).toBe(false);
+  });
+
+  it("maps notifiable_type_label → notifiableType", () => {
+    expect(toStoreNotification(makeBackend()).notifiableType).toBe("resumes.resume");
+    expect(toStoreNotification(makeBackend({ notifiable_type_label: null })).notifiableType).toBeNull();
+  });
+
+  it("maps notifiable_id → notifiableId", () => {
+    expect(toStoreNotification(makeBackend()).notifiableId).toBe("abc-123");
+    expect(toStoreNotification(makeBackend({ notifiable_id: null })).notifiableId).toBeNull();
+  });
+
+  it("formats a very recent created_at as '방금 전'", () => {
+    const result = toStoreNotification(makeBackend({ created_at: new Date().toISOString() }));
+    expect(result.time).toBe("방금 전");
+  });
+
+  it("formats a 2-minute-old timestamp as '2분 전'", () => {
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const result = toStoreNotification(makeBackend({ created_at: twoMinutesAgo }));
+    expect(result.time).toBe("2분 전");
+  });
+
+  it("formats a 3-hour-old timestamp as '3시간 전'", () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 3600 * 1000).toISOString();
+    const result = toStoreNotification(makeBackend({ created_at: threeHoursAgo }));
+    expect(result.time).toBe("3시간 전");
+  });
+
+  it("formats a 25-hour-old timestamp as '어제'", () => {
+    const yesterday = new Date(Date.now() - 25 * 3600 * 1000).toISOString();
+    const result = toStoreNotification(makeBackend({ created_at: yesterday }));
+    expect(result.time).toBe("어제");
+  });
+
+  it("formats a 3-day-old timestamp as '3일 전'", () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 86400 * 1000).toISOString();
+    const result = toStoreNotification(makeBackend({ created_at: threeDaysAgo }));
+    expect(result.time).toBe("3일 전");
+  });
+});
+
+describe("fetchNotifications", () => {
+  beforeEach(() => mockApiRequest.mockClear());
+
+  it("calls GET /api/v1/notifications/ with auth:true", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      results: [makeBackend()],
+      count: 1,
+      next: null,
+      previous: null,
+    });
+    await fetchNotifications();
+    expect(mockApiRequest).toHaveBeenCalledWith("/api/v1/notifications/", { auth: true });
+  });
+
+  it("returns mapped notifications from paginated response", async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      results: [makeBackend()],
+      count: 1,
+      next: null,
+      previous: null,
+    });
+    const result = await fetchNotifications();
+    expect(result).toHaveLength(1);
+    expect(result[0].read).toBe(false);
+    expect(result[0].notifiableType).toBe("resumes.resume");
+    expect(result[0].notifiableId).toBe("abc-123");
+  });
+
+  it("handles plain array response (non-paginated)", async () => {
+    mockApiRequest.mockResolvedValueOnce([makeBackend({ id: 2 }), makeBackend({ id: 3 })]);
+    const result = await fetchNotifications();
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe(2);
+    expect(result[1].id).toBe(3);
+  });
+
+  it("returns empty array when results is empty", async () => {
+    mockApiRequest.mockResolvedValueOnce({ results: [], count: 0, next: null, previous: null });
+    const result = await fetchNotifications();
+    expect(result).toEqual([]);
+  });
+});
+
+describe("markNotificationRead", () => {
+  beforeEach(() => mockApiRequest.mockClear());
+
+  it("calls PATCH /api/v1/notifications/{id}/read/ with auth:true", async () => {
+    mockApiRequest.mockResolvedValueOnce(makeBackend({ is_read: true }));
+    await markNotificationRead(42);
+    expect(mockApiRequest).toHaveBeenCalledWith("/api/v1/notifications/42/read/", {
+      method: "PATCH",
+      auth: true,
+    });
+  });
+
+  it("returns the mapped notification with read:true", async () => {
+    mockApiRequest.mockResolvedValueOnce(makeBackend({ is_read: true }));
+    const result = await markNotificationRead(1);
+    expect(result.read).toBe(true);
+    expect(result.id).toBe(1);
+  });
+});
+
+describe("markAllNotificationsRead", () => {
+  beforeEach(() => mockApiRequest.mockClear());
+
+  it("calls PATCH /api/v1/notifications/mark-all-read/ with auth:true", async () => {
+    mockApiRequest.mockResolvedValueOnce({ updated: 5 });
+    await markAllNotificationsRead();
+    expect(mockApiRequest).toHaveBeenCalledWith("/api/v1/notifications/mark-all-read/", {
+      method: "PATCH",
+      auth: true,
+    });
+  });
+
+  it("returns the updated count from the API", async () => {
+    mockApiRequest.mockResolvedValueOnce({ updated: 3 });
+    const result = await markAllNotificationsRead();
+    expect(result).toEqual({ updated: 3 });
+  });
+});
+
+describe("deleteNotification", () => {
+  beforeEach(() => mockApiRequest.mockClear());
+
+  it("calls DELETE /api/v1/notifications/{id}/ with auth:true", async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined);
+    await deleteNotification(7);
+    expect(mockApiRequest).toHaveBeenCalledWith("/api/v1/notifications/7/", {
+      method: "DELETE",
+      auth: true,
+    });
+  });
+});
+
+describe("clearAllNotifications", () => {
+  beforeEach(() => mockApiRequest.mockClear());
+
+  it("calls DELETE /api/v1/notifications/clear/ with auth:true", async () => {
+    mockApiRequest.mockResolvedValueOnce({ deleted: 10 });
+    await clearAllNotifications();
+    expect(mockApiRequest).toHaveBeenCalledWith("/api/v1/notifications/clear/", {
+      method: "DELETE",
+      auth: true,
+    });
+  });
+
+  it("returns the deleted count from the API", async () => {
+    mockApiRequest.mockResolvedValueOnce({ deleted: 4 });
+    const result = await clearAllNotifications();
+    expect(result).toEqual({ deleted: 4 });
+  });
+});

--- a/src/features/notifications/api/__tests__/notificationsApi.test.ts
+++ b/src/features/notifications/api/__tests__/notificationsApi.test.ts
@@ -36,9 +36,9 @@ describe("toStoreNotification", () => {
     expect(result.category).toBe("system");
   });
 
-  it("maps is_read → read", () => {
-    expect(toStoreNotification(makeBackend({ is_read: true })).read).toBe(true);
-    expect(toStoreNotification(makeBackend({ is_read: false })).read).toBe(false);
+  it("maps is_read → isRead", () => {
+    expect(toStoreNotification(makeBackend({ is_read: true })).isRead).toBe(true);
+    expect(toStoreNotification(makeBackend({ is_read: false })).isRead).toBe(false);
   });
 
   it("maps notifiable_type_label → notifiableType", () => {
@@ -104,7 +104,7 @@ describe("fetchNotifications", () => {
     });
     const result = await fetchNotifications();
     expect(result).toHaveLength(1);
-    expect(result[0].read).toBe(false);
+    expect(result[0].isRead).toBe(false);
     expect(result[0].notifiableType).toBe("resumes.resume");
     expect(result[0].notifiableId).toBe("abc-123");
   });
@@ -139,7 +139,7 @@ describe("markNotificationRead", () => {
   it("returns the mapped notification with read:true", async () => {
     mockApiRequest.mockResolvedValueOnce(makeBackend({ is_read: true }));
     const result = await markNotificationRead(1);
-    expect(result.read).toBe(true);
+    expect(result.isRead).toBe(true);
     expect(result.id).toBe(1);
   });
 });

--- a/src/features/notifications/api/__tests__/notificationsApi.test.ts
+++ b/src/features/notifications/api/__tests__/notificationsApi.test.ts
@@ -16,15 +16,15 @@ jest.mock("@/shared/api/client", () => ({
 
 const mockApiRequest = apiRequest as jest.MockedFunction<typeof apiRequest>;
 
-// A backend notification with created_at very close to now so formatTime returns "방금 전"
+// A backend notification with createdAt very close to now so formatTime returns "방금 전"
 const makeBackend = (overrides = {}) => ({
   id: 1,
   message: "Test notification",
   category: "system" as const,
-  is_read: false,
-  notifiable_type_label: "resumes.resume" as string | null,
-  notifiable_id: "abc-123" as string | null,
-  created_at: new Date().toISOString(),
+  isRead: false,
+  notifiableTypeLabel: "resumes.resume" as string | null,
+  notifiableId: "abc-123" as string | null,
+  createdAt: new Date().toISOString(),
   ...overrides,
 });
 
@@ -36,47 +36,47 @@ describe("toStoreNotification", () => {
     expect(result.category).toBe("system");
   });
 
-  it("maps is_read → isRead", () => {
-    expect(toStoreNotification(makeBackend({ is_read: true })).isRead).toBe(true);
-    expect(toStoreNotification(makeBackend({ is_read: false })).isRead).toBe(false);
+  it("maps isRead correctly", () => {
+    expect(toStoreNotification(makeBackend({ isRead: true })).isRead).toBe(true);
+    expect(toStoreNotification(makeBackend({ isRead: false })).isRead).toBe(false);
   });
 
-  it("maps notifiable_type_label → notifiableType", () => {
+  it("maps notifiableTypeLabel → notifiableType", () => {
     expect(toStoreNotification(makeBackend()).notifiableType).toBe("resumes.resume");
-    expect(toStoreNotification(makeBackend({ notifiable_type_label: null })).notifiableType).toBeNull();
+    expect(toStoreNotification(makeBackend({ notifiableTypeLabel: null })).notifiableType).toBeNull();
   });
 
-  it("maps notifiable_id → notifiableId", () => {
+  it("maps notifiableId correctly", () => {
     expect(toStoreNotification(makeBackend()).notifiableId).toBe("abc-123");
-    expect(toStoreNotification(makeBackend({ notifiable_id: null })).notifiableId).toBeNull();
+    expect(toStoreNotification(makeBackend({ notifiableId: null })).notifiableId).toBeNull();
   });
 
-  it("formats a very recent created_at as '방금 전'", () => {
-    const result = toStoreNotification(makeBackend({ created_at: new Date().toISOString() }));
+  it("formats a very recent createdAt as '방금 전'", () => {
+    const result = toStoreNotification(makeBackend({ createdAt: new Date().toISOString() }));
     expect(result.time).toBe("방금 전");
   });
 
   it("formats a 2-minute-old timestamp as '2분 전'", () => {
     const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
-    const result = toStoreNotification(makeBackend({ created_at: twoMinutesAgo }));
+    const result = toStoreNotification(makeBackend({ createdAt: twoMinutesAgo }));
     expect(result.time).toBe("2분 전");
   });
 
   it("formats a 3-hour-old timestamp as '3시간 전'", () => {
     const threeHoursAgo = new Date(Date.now() - 3 * 3600 * 1000).toISOString();
-    const result = toStoreNotification(makeBackend({ created_at: threeHoursAgo }));
+    const result = toStoreNotification(makeBackend({ createdAt: threeHoursAgo }));
     expect(result.time).toBe("3시간 전");
   });
 
   it("formats a 25-hour-old timestamp as '어제'", () => {
     const yesterday = new Date(Date.now() - 25 * 3600 * 1000).toISOString();
-    const result = toStoreNotification(makeBackend({ created_at: yesterday }));
+    const result = toStoreNotification(makeBackend({ createdAt: yesterday }));
     expect(result.time).toBe("어제");
   });
 
   it("formats a 3-day-old timestamp as '3일 전'", () => {
     const threeDaysAgo = new Date(Date.now() - 3 * 86400 * 1000).toISOString();
-    const result = toStoreNotification(makeBackend({ created_at: threeDaysAgo }));
+    const result = toStoreNotification(makeBackend({ createdAt: threeDaysAgo }));
     expect(result.time).toBe("3일 전");
   });
 });
@@ -128,7 +128,7 @@ describe("markNotificationRead", () => {
   beforeEach(() => mockApiRequest.mockClear());
 
   it("calls PATCH /api/v1/notifications/{id}/read/ with auth:true", async () => {
-    mockApiRequest.mockResolvedValueOnce(makeBackend({ is_read: true }));
+    mockApiRequest.mockResolvedValueOnce(makeBackend({ isRead: true }));
     await markNotificationRead(42);
     expect(mockApiRequest).toHaveBeenCalledWith("/api/v1/notifications/42/read/", {
       method: "PATCH",
@@ -137,7 +137,7 @@ describe("markNotificationRead", () => {
   });
 
   it("returns the mapped notification with read:true", async () => {
-    mockApiRequest.mockResolvedValueOnce(makeBackend({ is_read: true }));
+    mockApiRequest.mockResolvedValueOnce(makeBackend({ isRead: true }));
     const result = await markNotificationRead(1);
     expect(result.isRead).toBe(true);
     expect(result.id).toBe(1);

--- a/src/features/notifications/api/notificationsApi.ts
+++ b/src/features/notifications/api/notificationsApi.ts
@@ -1,0 +1,98 @@
+import { apiRequest } from "@/shared/api/client";
+
+// ── Backend response shape (snake_case) ──────────────────────────────────────
+interface BackendNotification {
+  id: number;
+  message: string;
+  category: "interview" | "resume" | "jd" | "system";
+  is_read: boolean;
+  notifiable_type_label: string | null;
+  notifiable_id: string | null;
+  created_at: string;
+}
+
+type PaginatedResponse = {
+  results: BackendNotification[];
+  count: number;
+  next: string | null;
+  previous: string | null;
+};
+
+// ── Time formatter (standalone — avoids circular dep with store) ──────────────
+function formatTime(isoString: string): string {
+  const diff = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+  if (diff < 60) return "방금 전";
+  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+  if (diff < 172800) return "어제";
+  return `${Math.floor(diff / 86400)}일 전`;
+}
+
+// ── snake_case → camelCase mapper ─────────────────────────────────────────────
+export function toStoreNotification(b: BackendNotification) {
+  return {
+    id: b.id,
+    message: b.message,
+    time: formatTime(b.created_at),
+    read: b.is_read,
+    category: b.category,
+    notifiableType: b.notifiable_type_label,
+    notifiableId: b.notifiable_id,
+  };
+}
+
+// ── API functions ──────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/notifications/
+ * 페이지네이션 응답과 단순 배열 응답 모두 처리
+ */
+export async function fetchNotifications() {
+  const data = await apiRequest<PaginatedResponse | BackendNotification[]>(
+    "/api/v1/notifications/",
+    { auth: true },
+  );
+  const list = Array.isArray(data) ? data : data.results;
+  return list.map(toStoreNotification);
+}
+
+/**
+ * PATCH /api/v1/notifications/{id}/read/
+ */
+export async function markNotificationRead(id: number) {
+  const data = await apiRequest<BackendNotification>(
+    `/api/v1/notifications/${id}/read/`,
+    { method: "PATCH", auth: true },
+  );
+  return toStoreNotification(data);
+}
+
+/**
+ * PATCH /api/v1/notifications/mark-all-read/
+ */
+export async function markAllNotificationsRead() {
+  return apiRequest<{ updated: number }>(
+    "/api/v1/notifications/mark-all-read/",
+    { method: "PATCH", auth: true },
+  );
+}
+
+/**
+ * DELETE /api/v1/notifications/{id}/
+ */
+export async function deleteNotification(id: number) {
+  return apiRequest<void>(`/api/v1/notifications/${id}/`, {
+    method: "DELETE",
+    auth: true,
+  });
+}
+
+/**
+ * DELETE /api/v1/notifications/clear/
+ */
+export async function clearAllNotifications() {
+  return apiRequest<{ deleted: number }>("/api/v1/notifications/clear/", {
+    method: "DELETE",
+    auth: true,
+  });
+}

--- a/src/features/notifications/api/notificationsApi.ts
+++ b/src/features/notifications/api/notificationsApi.ts
@@ -34,7 +34,7 @@ export function toStoreNotification(b: BackendNotification) {
     id: b.id,
     message: b.message,
     time: formatTime(b.created_at),
-    read: b.is_read,
+    isRead: b.is_read,
     category: b.category,
     notifiableType: b.notifiable_type_label,
     notifiableId: b.notifiable_id,

--- a/src/features/notifications/api/notificationsApi.ts
+++ b/src/features/notifications/api/notificationsApi.ts
@@ -1,22 +1,16 @@
 import { apiRequest } from "@/shared/api/client";
+import type { PaginatedResponse } from "@/shared/api";
 
-// ── Backend response shape (snake_case) ──────────────────────────────────────
+// ── Backend response shape (CamelCaseJSONRenderer 적용 — camelCase) ──────────
 interface BackendNotification {
   id: number;
   message: string;
   category: "interview" | "resume" | "jd" | "system";
-  is_read: boolean;
-  notifiable_type_label: string | null;
-  notifiable_id: string | null;
-  created_at: string;
+  isRead: boolean;
+  notifiableTypeLabel: string | null;
+  notifiableId: string | null;
+  createdAt: string;
 }
-
-type PaginatedResponse = {
-  results: BackendNotification[];
-  count: number;
-  next: string | null;
-  previous: string | null;
-};
 
 // ── Time formatter (standalone — avoids circular dep with store) ──────────────
 function formatTime(isoString: string): string {
@@ -28,16 +22,16 @@ function formatTime(isoString: string): string {
   return `${Math.floor(diff / 86400)}일 전`;
 }
 
-// ── snake_case → camelCase mapper ─────────────────────────────────────────────
+// ── BackendNotification → store Notification mapper ───────────────────────────
 export function toStoreNotification(b: BackendNotification) {
   return {
     id: b.id,
     message: b.message,
-    time: formatTime(b.created_at),
-    isRead: b.is_read,
+    time: formatTime(b.createdAt),
+    isRead: b.isRead,
     category: b.category,
-    notifiableType: b.notifiable_type_label,
-    notifiableId: b.notifiable_id,
+    notifiableType: b.notifiableTypeLabel,
+    notifiableId: b.notifiableId,
   };
 }
 
@@ -48,7 +42,7 @@ export function toStoreNotification(b: BackendNotification) {
  * 페이지네이션 응답과 단순 배열 응답 모두 처리
  */
 export async function fetchNotifications() {
-  const data = await apiRequest<PaginatedResponse | BackendNotification[]>(
+  const data = await apiRequest<PaginatedResponse<BackendNotification> | BackendNotification[]>(
     "/api/v1/notifications/",
     { auth: true },
   );

--- a/src/features/notifications/index.ts
+++ b/src/features/notifications/index.ts
@@ -1,2 +1,3 @@
 export { useNotificationStore } from "./model/store";
 export type { Notification } from "./model/store";
+export { getNotifiableUrl } from "./lib/getNotifiableUrl";

--- a/src/features/notifications/index.ts
+++ b/src/features/notifications/index.ts
@@ -1,3 +1,4 @@
 export { useNotificationStore } from "./model/store";
 export type { Notification } from "./model/store";
 export { getNotifiableUrl } from "./lib/getNotifiableUrl";
+export { useNotificationToast } from "./lib/useNotificationToast";

--- a/src/features/notifications/lib/__tests__/getNotifiableUrl.test.ts
+++ b/src/features/notifications/lib/__tests__/getNotifiableUrl.test.ts
@@ -1,0 +1,40 @@
+import { getNotifiableUrl } from "../getNotifiableUrl";
+
+describe("getNotifiableUrl", () => {
+  it("returns null when notifiableType is null", () => {
+    expect(getNotifiableUrl(null, "uuid-1")).toBeNull();
+  });
+
+  it("returns null when notifiableId is null", () => {
+    expect(getNotifiableUrl("resumes.resume", null)).toBeNull();
+  });
+
+  it("returns null when both arguments are null", () => {
+    expect(getNotifiableUrl(null, null)).toBeNull();
+  });
+
+  it("maps 'resumes.resume' to /resume/:id", () => {
+    expect(getNotifiableUrl("resumes.resume", "uuid-abc")).toBe("/resume/uuid-abc");
+  });
+
+  it("maps 'interviews.interviewsession' to /interview/session/:id/report", () => {
+    expect(getNotifiableUrl("interviews.interviewsession", "uuid-def")).toBe(
+      "/interview/session/uuid-def/report"
+    );
+  });
+
+  it("maps 'job_descriptions.userjobdescription' to /jd/:id", () => {
+    expect(getNotifiableUrl("job_descriptions.userjobdescription", "uuid-ghi")).toBe(
+      "/jd/uuid-ghi"
+    );
+  });
+
+  it("returns null for an unknown notifiableType", () => {
+    expect(getNotifiableUrl("unknown.model", "uuid-xyz")).toBeNull();
+  });
+
+  it("includes the exact id in the generated URL", () => {
+    const id = "550e8400-e29b-41d4-a716-446655440000";
+    expect(getNotifiableUrl("resumes.resume", id)).toBe(`/resume/${id}`);
+  });
+});

--- a/src/features/notifications/lib/getNotifiableUrl.ts
+++ b/src/features/notifications/lib/getNotifiableUrl.ts
@@ -1,0 +1,24 @@
+/**
+ * notifiableType과 notifiableId를 받아 해당 객체의 프론트엔드 경로를 반환합니다.
+ * 라우팅 구조 기준:
+ *   /resume/:uuid
+ *   /interview/session/:uuid/report
+ *   /jd/:uuid
+ */
+export function getNotifiableUrl(
+  notifiableType: string | null,
+  notifiableId: string | null,
+): string | null {
+  if (!notifiableType || !notifiableId) return null;
+
+  switch (notifiableType) {
+    case "resumes.resume":
+      return `/resume/${notifiableId}`;
+    case "interviews.interviewsession":
+      return `/interview/session/${notifiableId}/report`;
+    case "job_descriptions.userjobdescription":
+      return `/jd/${notifiableId}`;
+    default:
+      return null;
+  }
+}

--- a/src/features/notifications/lib/useNotificationToast.ts
+++ b/src/features/notifications/lib/useNotificationToast.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useNotificationStore } from "../model/store";
+import { getNotifiableUrl } from "./getNotifiableUrl";
+
+const ACTION_LABEL: Record<string, string> = {
+  jd: "채용공고 결과 보기",
+  resume: "이력서 결과 보기",
+  interview: "면접 리포트 보기",
+};
+
+export function useNotificationToast() {
+  const navigate = useNavigate();
+  const notifications = useNotificationStore((s) => s.notifications);
+  const prevIdsRef = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    const prevIds = prevIdsRef.current;
+
+    notifications.forEach((n) => {
+      if (prevIds.has(n.id)) return;   // 이미 처리된 알림
+      if (n.isRead) return;            // 초기 로드 시 기존 읽음 알림 skip
+
+      const url = getNotifiableUrl(n.notifiableType, n.notifiableId);
+      const label = ACTION_LABEL[n.category];
+
+      toast(n.message, {
+        duration: 5000,
+        action:
+          url && label
+            ? { label, onClick: () => navigate(url) }
+            : undefined,
+      });
+    });
+
+    prevIdsRef.current = new Set(notifications.map((n) => n.id));
+  }, [notifications, navigate]);
+}

--- a/src/features/notifications/model/__tests__/store.test.ts
+++ b/src/features/notifications/model/__tests__/store.test.ts
@@ -32,11 +32,11 @@ const mockClear = notificationsApi.clearAllNotifications as jest.MockedFunction<
   typeof notificationsApi.clearAllNotifications
 >;
 
-const makeNotification = (id: number, read = false) => ({
+const makeNotification = (id: number, isRead = false) => ({
   id,
   message: `Notification ${id}`,
   time: "방금 전",
-  read,
+  isRead,
   category: "system" as const,
   notifiableType: null,
   notifiableId: null,
@@ -86,7 +86,7 @@ describe("useNotificationStore", () => {
       await useNotificationStore.getState().markRead(1);
 
       const { notifications } = useNotificationStore.getState();
-      expect(notifications.find((n) => n.id === 1)?.read).toBe(true);
+      expect(notifications.find((n) => n.id === 1)?.isRead).toBe(true);
     });
 
     it("does not affect other notifications", async () => {
@@ -97,7 +97,7 @@ describe("useNotificationStore", () => {
 
       await useNotificationStore.getState().markRead(1);
 
-      expect(useNotificationStore.getState().notifications.find((n) => n.id === 2)?.read).toBe(
+      expect(useNotificationStore.getState().notifications.find((n) => n.id === 2)?.isRead).toBe(
         false
       );
     });
@@ -122,7 +122,7 @@ describe("useNotificationStore", () => {
       await useNotificationStore.getState().markAllRead();
 
       const { notifications } = useNotificationStore.getState();
-      expect(notifications.every((n) => n.read)).toBe(true);
+      expect(notifications.every((n) => n.isRead)).toBe(true);
     });
 
     it("works correctly when notifications list is empty", async () => {

--- a/src/features/notifications/model/__tests__/store.test.ts
+++ b/src/features/notifications/model/__tests__/store.test.ts
@@ -1,0 +1,193 @@
+import { useNotificationStore } from "../store";
+import * as notificationsApi from "../../api/notificationsApi";
+
+jest.mock("../../api/notificationsApi", () => ({
+  fetchNotifications: jest.fn(),
+  markNotificationRead: jest.fn(),
+  markAllNotificationsRead: jest.fn(),
+  deleteNotification: jest.fn(),
+  clearAllNotifications: jest.fn(),
+}));
+
+jest.mock("@/shared/api/realtimeApi", () => ({
+  RealtimeClient: jest.fn().mockImplementation(() => ({
+    connect: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn(),
+  })),
+}));
+
+const mockFetch = notificationsApi.fetchNotifications as jest.MockedFunction<
+  typeof notificationsApi.fetchNotifications
+>;
+const mockMarkRead = notificationsApi.markNotificationRead as jest.MockedFunction<
+  typeof notificationsApi.markNotificationRead
+>;
+const mockMarkAll = notificationsApi.markAllNotificationsRead as jest.MockedFunction<
+  typeof notificationsApi.markAllNotificationsRead
+>;
+const mockDelete = notificationsApi.deleteNotification as jest.MockedFunction<
+  typeof notificationsApi.deleteNotification
+>;
+const mockClear = notificationsApi.clearAllNotifications as jest.MockedFunction<
+  typeof notificationsApi.clearAllNotifications
+>;
+
+const makeNotification = (id: number, read = false) => ({
+  id,
+  message: `Notification ${id}`,
+  time: "방금 전",
+  read,
+  category: "system" as const,
+  notifiableType: null,
+  notifiableId: null,
+});
+
+describe("useNotificationStore", () => {
+  beforeEach(() => {
+    useNotificationStore.setState({ notifications: [], connected: false });
+    jest.clearAllMocks();
+  });
+
+  describe("fetchInitial", () => {
+    it("populates notifications from the API response", async () => {
+      const notifications = [makeNotification(1), makeNotification(2)];
+      mockFetch.mockResolvedValueOnce(notifications);
+
+      await useNotificationStore.getState().fetchInitial();
+
+      expect(useNotificationStore.getState().notifications).toEqual(notifications);
+    });
+
+    it("calls fetchNotifications once", async () => {
+      mockFetch.mockResolvedValueOnce([]);
+      await useNotificationStore.getState().fetchInitial();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("replaces existing notifications with fresh data", async () => {
+      useNotificationStore.setState({ notifications: [makeNotification(99)] });
+      mockFetch.mockResolvedValueOnce([makeNotification(1)]);
+
+      await useNotificationStore.getState().fetchInitial();
+
+      const { notifications } = useNotificationStore.getState();
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0].id).toBe(1);
+    });
+  });
+
+  describe("markRead", () => {
+    it("sets the target notification's read flag to true", async () => {
+      useNotificationStore.setState({
+        notifications: [makeNotification(1), makeNotification(2)],
+      });
+      mockMarkRead.mockResolvedValueOnce(makeNotification(1, true));
+
+      await useNotificationStore.getState().markRead(1);
+
+      const { notifications } = useNotificationStore.getState();
+      expect(notifications.find((n) => n.id === 1)?.read).toBe(true);
+    });
+
+    it("does not affect other notifications", async () => {
+      useNotificationStore.setState({
+        notifications: [makeNotification(1), makeNotification(2)],
+      });
+      mockMarkRead.mockResolvedValueOnce(makeNotification(1, true));
+
+      await useNotificationStore.getState().markRead(1);
+
+      expect(useNotificationStore.getState().notifications.find((n) => n.id === 2)?.read).toBe(
+        false
+      );
+    });
+
+    it("calls markNotificationRead with the correct id", async () => {
+      useNotificationStore.setState({ notifications: [makeNotification(5)] });
+      mockMarkRead.mockResolvedValueOnce(makeNotification(5, true));
+
+      await useNotificationStore.getState().markRead(5);
+
+      expect(mockMarkRead).toHaveBeenCalledWith(5);
+    });
+  });
+
+  describe("markAllRead", () => {
+    it("sets all notifications to read", async () => {
+      useNotificationStore.setState({
+        notifications: [makeNotification(1), makeNotification(2), makeNotification(3)],
+      });
+      mockMarkAll.mockResolvedValueOnce({ updated: 3 });
+
+      await useNotificationStore.getState().markAllRead();
+
+      const { notifications } = useNotificationStore.getState();
+      expect(notifications.every((n) => n.read)).toBe(true);
+    });
+
+    it("works correctly when notifications list is empty", async () => {
+      mockMarkAll.mockResolvedValueOnce({ updated: 0 });
+
+      await useNotificationStore.getState().markAllRead();
+
+      expect(useNotificationStore.getState().notifications).toEqual([]);
+    });
+  });
+
+  describe("deleteNotification", () => {
+    it("removes the specified notification from the list", async () => {
+      useNotificationStore.setState({
+        notifications: [makeNotification(1), makeNotification(2), makeNotification(3)],
+      });
+      mockDelete.mockResolvedValueOnce(undefined);
+
+      await useNotificationStore.getState().deleteNotification(2);
+
+      const { notifications } = useNotificationStore.getState();
+      expect(notifications).toHaveLength(2);
+      expect(notifications.find((n) => n.id === 2)).toBeUndefined();
+    });
+
+    it("leaves remaining notifications intact", async () => {
+      useNotificationStore.setState({
+        notifications: [makeNotification(1), makeNotification(2)],
+      });
+      mockDelete.mockResolvedValueOnce(undefined);
+
+      await useNotificationStore.getState().deleteNotification(1);
+
+      const { notifications } = useNotificationStore.getState();
+      expect(notifications[0].id).toBe(2);
+    });
+
+    it("calls deleteNotification API with the correct id", async () => {
+      useNotificationStore.setState({ notifications: [makeNotification(9)] });
+      mockDelete.mockResolvedValueOnce(undefined);
+
+      await useNotificationStore.getState().deleteNotification(9);
+
+      expect(mockDelete).toHaveBeenCalledWith(9);
+    });
+  });
+
+  describe("deleteAll", () => {
+    it("clears all notifications from the store", async () => {
+      useNotificationStore.setState({
+        notifications: [makeNotification(1), makeNotification(2), makeNotification(3)],
+      });
+      mockClear.mockResolvedValueOnce({ deleted: 3 });
+
+      await useNotificationStore.getState().deleteAll();
+
+      expect(useNotificationStore.getState().notifications).toEqual([]);
+    });
+
+    it("calls clearAllNotifications API once", async () => {
+      mockClear.mockResolvedValueOnce({ deleted: 0 });
+
+      await useNotificationStore.getState().deleteAll();
+
+      expect(mockClear).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/features/notifications/model/store.ts
+++ b/src/features/notifications/model/store.ts
@@ -8,6 +8,8 @@ export interface Notification {
   time: string;
   read: boolean;
   category: "interview" | "resume" | "jd" | "system";
+  notifiableType: string | null;
+  notifiableId: string | null;
 }
 
 function formatTime(isoString: string): string {
@@ -26,6 +28,8 @@ function wsMessageToNotification(msg: WsNotificationMessage): Notification {
     time: formatTime(msg.createdAt),
     read: false,
     category: msg.category,
+    notifiableType: msg.notifiableType,
+    notifiableId: msg.notifiableId,
   };
 }
 

--- a/src/features/notifications/model/store.ts
+++ b/src/features/notifications/model/store.ts
@@ -1,6 +1,13 @@
 import { create } from "zustand";
 import { RealtimeClient } from "@/shared/api/realtimeApi";
 import type { WsNotificationMessage } from "@/shared/api/realtimeApi";
+import {
+  fetchNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification as apiDeleteNotification,
+  clearAllNotifications,
+} from "../api/notificationsApi";
 
 export interface Notification {
   id: number;
@@ -36,29 +43,53 @@ function wsMessageToNotification(msg: WsNotificationMessage): Notification {
 interface NotificationState {
   notifications: Notification[];
   connected: boolean;
-  markAllRead: () => void;
-  markRead: (id: number) => void;
-  deleteNotification: (id: number) => void;
-  deleteAll: () => void;
+  fetchInitial: () => Promise<void>;
+  markAllRead: () => Promise<void>;
+  markRead: (id: number) => Promise<void>;
+  deleteNotification: (id: number) => Promise<void>;
+  deleteAll: () => Promise<void>;
   connectWs: () => void;
   disconnectWs: () => void;
 }
 
 let _client: RealtimeClient | null = null;
 
-export const useNotificationStore = create<NotificationState>()((set) => ({
+export const useNotificationStore = create<NotificationState>()((set, get) => ({
   notifications: [],
   connected: false,
 
-  markAllRead: () =>
-    set((s) => ({ notifications: s.notifications.map((n) => ({ ...n, read: true })) })),
-  markRead: (id) =>
+  fetchInitial: async () => {
+    const notifications = await fetchNotifications();
+    set({ notifications });
+  },
+
+  markAllRead: async () => {
+    await markAllNotificationsRead();
     set((s) => ({
-      notifications: s.notifications.map((n) => (n.id === id ? { ...n, read: true } : n)),
-    })),
-  deleteNotification: (id) =>
-    set((s) => ({ notifications: s.notifications.filter((n) => n.id !== id) })),
-  deleteAll: () => set({ notifications: [] }),
+      notifications: s.notifications.map((n) => ({ ...n, read: true })),
+    }));
+  },
+
+  markRead: async (id) => {
+    await markNotificationRead(id);
+    set((s) => ({
+      notifications: s.notifications.map((n) =>
+        n.id === id ? { ...n, read: true } : n,
+      ),
+    }));
+  },
+
+  deleteNotification: async (id) => {
+    await apiDeleteNotification(id);
+    set((s) => ({
+      notifications: s.notifications.filter((n) => n.id !== id),
+    }));
+  },
+
+  deleteAll: async () => {
+    await clearAllNotifications();
+    set({ notifications: [] });
+  },
 
   connectWs: () => {
     if (_client) return; // 이미 연결 중
@@ -70,7 +101,11 @@ export const useNotificationStore = create<NotificationState>()((set) => ({
       },
       onClose: () => set({ connected: false }),
     });
-    _client.connect().then(() => set({ connected: true }));
+    _client.connect().then(() => {
+      set({ connected: true });
+      // WS 연결 성공 시 서버에서 초기 알림 목록 로드
+      get().fetchInitial();
+    });
   },
 
   disconnectWs: () => {

--- a/src/features/notifications/model/store.ts
+++ b/src/features/notifications/model/store.ts
@@ -13,7 +13,7 @@ export interface Notification {
   id: number;
   message: string;
   time: string;
-  read: boolean;
+  isRead: boolean;
   category: "interview" | "resume" | "jd" | "system";
   notifiableType: string | null;
   notifiableId: string | null;
@@ -33,7 +33,7 @@ function wsMessageToNotification(msg: WsNotificationMessage): Notification {
     id: msg.id,
     message: msg.message,
     time: formatTime(msg.createdAt),
-    read: false,
+    isRead: false,
     category: msg.category,
     notifiableType: msg.notifiableType,
     notifiableId: msg.notifiableId,
@@ -66,7 +66,7 @@ export const useNotificationStore = create<NotificationState>()((set, get) => ({
   markAllRead: async () => {
     await markAllNotificationsRead();
     set((s) => ({
-      notifications: s.notifications.map((n) => ({ ...n, read: true })),
+      notifications: s.notifications.map((n) => ({ ...n, isRead: true })),
     }));
   },
 
@@ -74,7 +74,7 @@ export const useNotificationStore = create<NotificationState>()((set, get) => ({
     await markNotificationRead(id);
     set((s) => ({
       notifications: s.notifications.map((n) =>
-        n.id === id ? { ...n, read: true } : n,
+        n.id === id ? { ...n, isRead: true } : n,
       ),
     }));
   },

--- a/src/features/resume/api/types.ts
+++ b/src/features/resume/api/types.ts
@@ -123,14 +123,8 @@ export interface ResumeDetail extends ResumeListItem {
   fileUrl: string | null;
 }
 
-// ── Paginated Response ──
-export interface PaginatedResponse<T> {
-  count: number;
-  totalPagesCount: number;
-  nextPage: number | null;
-  previousPage: number | null;
-  results: T[];
-}
+// ── Paginated Response (공통 타입 — shared 에서 re-export) ──
+export type { PaginatedResponse } from "@/shared/api/client";
 
 // ── Stats ──
 export interface ResumeCountStats {

--- a/src/features/user-job-description/api/userJobDescriptionApi.ts
+++ b/src/features/user-job-description/api/userJobDescriptionApi.ts
@@ -9,13 +9,15 @@
  */
 
 import { apiRequest } from "@/shared/api/client";
+import type { PaginatedResponse } from "@/shared/api";
 import type { CreatedUserJobDescription, UserJobDescription } from "./types";
 
 const BASE = "/api/v1/user-job-descriptions";
 
 export const userJobDescriptionApi = {
   list: () =>
-    apiRequest<UserJobDescription[]>(`${BASE}/`, { auth: true }),
+    apiRequest<PaginatedResponse<UserJobDescription>>(`${BASE}/`, { auth: true })
+      .then((res) => res.results),
 
   retrieve: (uuid: string) =>
     apiRequest<UserJobDescription>(`${BASE}/${uuid}/`, { auth: true }),

--- a/src/pages/home/ui/components/HomeNavbar.tsx
+++ b/src/pages/home/ui/components/HomeNavbar.tsx
@@ -15,7 +15,7 @@ interface HomeNavbarProps {
 export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
   const navigate = useNavigate();
   const { user, logout } = useAuthStore();
-  const { notifications, markAllRead } = useNotificationStore();
+  const { notifications, markAllRead, markRead } = useNotificationStore();
   const unreadCount = notifications.filter((n) => !n.read).length;
   const { tickets } = useTicketCount();
   const { policy } = useTicketPolicy();
@@ -117,11 +117,16 @@ export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
                 notifications.slice(0, 4).map((n) => (
                   <li
                     key={n.id}
-                    className={`flex items-start gap-3 px-4 py-3 border-b border-[#F3F4F6] last:border-0 ${!n.read ? "bg-[#F0F9FF]" : ""}`}
+                    onClick={() => { markRead(n.id); setNotiOpen(false); }}
+                    className={`flex items-start gap-3 px-4 py-3 border-b border-[#F3F4F6] last:border-0 cursor-pointer transition-colors ${
+                      !n.read ? "bg-[#F0F9FF] hover:bg-[#E0F4FC]" : "hover:bg-[#F9FAFB]"
+                    }`}
                   >
-                    <span className={`mt-1 w-2 h-2 rounded-full flex-shrink-0 ${!n.read ? "bg-[#0991B2]" : "bg-transparent"}`} />
+                    <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 transition-colors ${!n.read ? "bg-[#0991B2]" : "bg-transparent"}`} />
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm text-[#0A0A0A]">{n.message}</p>
+                      <p className={`text-sm leading-snug ${!n.read ? "font-semibold text-[#0A0A0A]" : "text-[#374151]"}`}>
+                        {n.message}
+                      </p>
                       <p className="text-xs text-[#9CA3AF] mt-0.5">{n.time}</p>
                     </div>
                   </li>

--- a/src/pages/home/ui/components/HomeNavbar.tsx
+++ b/src/pages/home/ui/components/HomeNavbar.tsx
@@ -16,7 +16,7 @@ export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
   const navigate = useNavigate();
   const { user, logout } = useAuthStore();
   const { notifications, markAllRead, markRead } = useNotificationStore();
-  const unreadCount = notifications.filter((n) => !n.read).length;
+  const unreadCount = notifications.filter((n) => !n.isRead).length;
   const { tickets } = useTicketCount();
   const { policy } = useTicketPolicy();
   const [profileOpen, setProfileOpen] = useState(false);
@@ -119,12 +119,12 @@ export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
                     key={n.id}
                     onClick={() => { markRead(n.id); setNotiOpen(false); }}
                     className={`flex items-start gap-3 px-4 py-3 border-b border-[#F3F4F6] last:border-0 cursor-pointer transition-colors ${
-                      !n.read ? "bg-[#F0F9FF] hover:bg-[#E0F4FC]" : "hover:bg-[#F9FAFB]"
+                      !n.isRead ? "bg-[#F0F9FF] hover:bg-[#E0F4FC]" : "hover:bg-[#F9FAFB]"
                     }`}
                   >
-                    <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 transition-colors ${!n.read ? "bg-[#0991B2]" : "bg-transparent"}`} />
+                    <span className={`mt-1.5 w-2 h-2 rounded-full flex-shrink-0 transition-colors ${!n.isRead ? "bg-[#0991B2]" : "bg-transparent"}`} />
                     <div className="flex-1 min-w-0">
-                      <p className={`text-sm leading-snug ${!n.read ? "font-semibold text-[#0A0A0A]" : "text-[#374151]"}`}>
+                      <p className={`text-sm leading-snug ${!n.isRead ? "font-semibold text-[#0A0A0A]" : "text-[#374151]"}`}>
                         {n.message}
                       </p>
                       <p className="text-xs text-[#9CA3AF] mt-0.5">{n.time}</p>

--- a/src/pages/notifications/ui/NotificationsPage.tsx
+++ b/src/pages/notifications/ui/NotificationsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useNotificationStore, type Notification, getNotifiableUrl } from "@/features/notifications";
 
@@ -122,9 +122,14 @@ function NotificationList({
 }
 
 export function NotificationsPage() {
-  const { notifications, markAllRead, markRead, deleteNotification, deleteAll } = useNotificationStore();
+  const { notifications, markAllRead, markRead, deleteNotification, deleteAll, fetchInitial } = useNotificationStore();
   const unreadCount = notifications.filter((n) => !n.read).length;
   const [activeTab, setActiveTab] = useState<TabKey>("all");
+
+  // WS 연결 전 새로고침 케이스 대응 — 마운트 시 서버에서 목록 로드
+  useEffect(() => {
+    fetchInitial();
+  }, [fetchInitial]);
 
   const filtered =
     activeTab === "all"

--- a/src/pages/notifications/ui/NotificationsPage.tsx
+++ b/src/pages/notifications/ui/NotificationsPage.tsx
@@ -35,7 +35,7 @@ function NotificationItem({
   onDelete: (id: number) => void;
 }) {
   const handleItemClick = () => {
-    if (!n.read) onMarkRead(n.id);
+    if (!n.isRead) onMarkRead(n.id);
   };
 
   return (
@@ -43,7 +43,7 @@ function NotificationItem({
       role="article"
       onClick={handleItemClick}
       className={`flex items-start gap-4 px-5 py-4 border-b border-[#F3F4F6] last:border-0 transition-colors ${
-        !n.read
+        !n.isRead
           ? "bg-[#F0F9FF] cursor-pointer hover:bg-[#E0F4FC]"
           : "hover:bg-[#FAFAFA]"
       }`}
@@ -51,7 +51,7 @@ function NotificationItem({
       {/* 카테고리 아이콘 */}
       <div
         className={`w-10 h-10 rounded-xl flex items-center justify-center text-[18px] shrink-0 ${
-          !n.read ? "bg-[#E0F2FE]" : "bg-[#F3F4F6]"
+          !n.isRead ? "bg-[#E0F2FE]" : "bg-[#F3F4F6]"
         }`}
       >
         {CATEGORY_ICON[n.category]}
@@ -63,14 +63,14 @@ function NotificationItem({
           <span className="text-[10px] font-bold text-[#0991B2] bg-[#E0F2FE] px-2 py-0.5 rounded-full">
             {CATEGORY_LABEL[n.category]}
           </span>
-          {!n.read && (
+          {!n.isRead && (
             <span className="inline-flex items-center gap-1 text-[10px] font-bold text-[#0991B2]">
               <span className="w-1.5 h-1.5 rounded-full bg-[#0991B2]" />
               새 알림
             </span>
           )}
         </div>
-        <p className={`text-[13px] leading-[1.55] ${!n.read ? "font-semibold text-[#0A0A0A]" : "text-[#374151]"}`}>
+        <p className={`text-[13px] leading-[1.55] ${!n.isRead ? "font-semibold text-[#0A0A0A]" : "text-[#374151]"}`}>
           {n.message}
         </p>
         <div className="flex items-center gap-3 mt-1">
@@ -78,7 +78,7 @@ function NotificationItem({
           {getNotifiableUrl(n.notifiableType, n.notifiableId) && (
             <Link
               to={getNotifiableUrl(n.notifiableType, n.notifiableId)!}
-              onClick={(e) => { e.stopPropagation(); if (!n.read) onMarkRead(n.id); }}
+              onClick={(e) => { e.stopPropagation(); if (!n.isRead) onMarkRead(n.id); }}
               className="text-[11px] font-semibold text-[#0991B2] hover:underline"
             >
               바로 가기 →
@@ -89,7 +89,7 @@ function NotificationItem({
 
       {/* 액션 버튼 */}
       <div className="flex items-center gap-1 shrink-0 mt-0.5">
-        {!n.read && (
+        {!n.isRead && (
           <button
             onClick={(e) => { e.stopPropagation(); onMarkRead(n.id); }}
             className="text-[11px] font-semibold text-[#0991B2] bg-[#E6F7FA] px-2.5 py-1 rounded-lg hover:bg-[#cceef6] transition-colors"
@@ -140,7 +140,7 @@ function NotificationList({
 
 export function NotificationsPage() {
   const { notifications, markAllRead, markRead, deleteNotification, deleteAll, fetchInitial } = useNotificationStore();
-  const unreadCount = notifications.filter((n) => !n.read).length;
+  const unreadCount = notifications.filter((n) => !n.isRead).length;
   const [activeTab, setActiveTab] = useState<TabKey>("all");
 
   // WS 연결 전 새로고침 케이스 대응 — 마운트 시 서버에서 목록 로드

--- a/src/pages/notifications/ui/NotificationsPage.tsx
+++ b/src/pages/notifications/ui/NotificationsPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { useNotificationStore, type Notification } from "@/features/notifications";
+import { Link } from "react-router-dom";
+import { useNotificationStore, type Notification, getNotifiableUrl } from "@/features/notifications";
 
 const CATEGORY_ICON: Record<Notification["category"], string> = {
   interview: "🎥",
@@ -57,7 +58,17 @@ function NotificationItem({
         <p className={`text-[13px] leading-[1.55] ${!n.read ? "font-semibold text-[#0A0A0A]" : "text-[#374151]"}`}>
           {n.message}
         </p>
-        <p className="text-[11px] text-[#9CA3AF] mt-1">{n.time}</p>
+        <div className="flex items-center gap-3 mt-1">
+          <p className="text-[11px] text-[#9CA3AF]">{n.time}</p>
+          {getNotifiableUrl(n.notifiableType, n.notifiableId) && (
+            <Link
+              to={getNotifiableUrl(n.notifiableType, n.notifiableId)!}
+              className="text-[11px] font-semibold text-[#0991B2] hover:underline"
+            >
+              바로 가기 →
+            </Link>
+          )}
+        </div>
       </div>
 
       <div className="flex items-center gap-1 shrink-0 mt-0.5">

--- a/src/pages/notifications/ui/NotificationsPage.tsx
+++ b/src/pages/notifications/ui/NotificationsPage.tsx
@@ -34,12 +34,21 @@ function NotificationItem({
   onMarkRead: (id: number) => void;
   onDelete: (id: number) => void;
 }) {
+  const handleItemClick = () => {
+    if (!n.read) onMarkRead(n.id);
+  };
+
   return (
     <div
+      role="article"
+      onClick={handleItemClick}
       className={`flex items-start gap-4 px-5 py-4 border-b border-[#F3F4F6] last:border-0 transition-colors ${
-        !n.read ? "bg-[#F0F9FF]" : "hover:bg-white"
+        !n.read
+          ? "bg-[#F0F9FF] cursor-pointer hover:bg-[#E0F4FC]"
+          : "hover:bg-[#FAFAFA]"
       }`}
     >
+      {/* 카테고리 아이콘 */}
       <div
         className={`w-10 h-10 rounded-xl flex items-center justify-center text-[18px] shrink-0 ${
           !n.read ? "bg-[#E0F2FE]" : "bg-[#F3F4F6]"
@@ -48,12 +57,18 @@ function NotificationItem({
         {CATEGORY_ICON[n.category]}
       </div>
 
+      {/* 본문 */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-0.5">
           <span className="text-[10px] font-bold text-[#0991B2] bg-[#E0F2FE] px-2 py-0.5 rounded-full">
             {CATEGORY_LABEL[n.category]}
           </span>
-          {!n.read && <span className="w-1.5 h-1.5 rounded-full bg-[#0991B2]" />}
+          {!n.read && (
+            <span className="inline-flex items-center gap-1 text-[10px] font-bold text-[#0991B2]">
+              <span className="w-1.5 h-1.5 rounded-full bg-[#0991B2]" />
+              새 알림
+            </span>
+          )}
         </div>
         <p className={`text-[13px] leading-[1.55] ${!n.read ? "font-semibold text-[#0A0A0A]" : "text-[#374151]"}`}>
           {n.message}
@@ -63,6 +78,7 @@ function NotificationItem({
           {getNotifiableUrl(n.notifiableType, n.notifiableId) && (
             <Link
               to={getNotifiableUrl(n.notifiableType, n.notifiableId)!}
+              onClick={(e) => { e.stopPropagation(); if (!n.read) onMarkRead(n.id); }}
               className="text-[11px] font-semibold text-[#0991B2] hover:underline"
             >
               바로 가기 →
@@ -71,17 +87,18 @@ function NotificationItem({
         </div>
       </div>
 
+      {/* 액션 버튼 */}
       <div className="flex items-center gap-1 shrink-0 mt-0.5">
         {!n.read && (
           <button
-            onClick={() => onMarkRead(n.id)}
+            onClick={(e) => { e.stopPropagation(); onMarkRead(n.id); }}
             className="text-[11px] font-semibold text-[#0991B2] bg-[#E6F7FA] px-2.5 py-1 rounded-lg hover:bg-[#cceef6] transition-colors"
           >
             확인
           </button>
         )}
         <button
-          onClick={() => onDelete(n.id)}
+          onClick={(e) => { e.stopPropagation(); onDelete(n.id); }}
           className="w-7 h-7 flex items-center justify-center rounded-lg text-[#9CA3AF] hover:bg-[#FEF2F2] hover:text-[#EF4444] transition-colors"
           aria-label="알림 삭제"
         >

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,5 +1,4 @@
-// export const BASE_URL = "https://mefit.xn--hy1by51c.kr";
-export const BASE_URL = "http://localhost:8000";
+export const BASE_URL = "https://mefit.xn--hy1by51c.kr";
 
 /* ── Token helpers ── */
 export function getAccessToken(): string | null {

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,4 +1,5 @@
-export const BASE_URL = "https://mefit.xn--hy1by51c.kr";
+// export const BASE_URL = "https://mefit.xn--hy1by51c.kr";
+export const BASE_URL = "http://localhost:8000";
 
 /* ── Token helpers ── */
 export function getAccessToken(): string | null {
@@ -14,6 +15,15 @@ export function setTokens(access: string, refresh: string): void {
 export function clearTokens(): void {
   localStorage.removeItem("mefit_access");
   localStorage.removeItem("mefit_refresh");
+}
+
+/* ── Paginated Response ── */
+export interface PaginatedResponse<T> {
+  count: number;
+  totalPagesCount: number;
+  nextPage: number | null;
+  previousPage: number | null;
+  results: T[];
 }
 
 /* ── Error type ── */

--- a/src/shared/api/realtimeApi.ts
+++ b/src/shared/api/realtimeApi.ts
@@ -24,6 +24,8 @@ export type WsNotificationMessage = {
   message: string;
   category: "interview" | "resume" | "jd" | "system";
   createdAt: string;
+  notifiableType: string | null;
+  notifiableId: string | null;
 };
 
 type WsEventHandlers = {


### PR DESCRIPTION
## Summary
- notificationsApi: fetch/markRead/markAllRead/delete/clear (snake_case → camelCase 변환)
- Zustand store: fetchInitial, markRead, markAllRead, deleteNotification, deleteAll
- NotificationsPage: 마운트 시 fetchInitial 호출, notifiable 링크 표시
- getNotifiableUrl 유틸리티
- 41개 테스트 전체 통과

Closes #98