### PR TITLE
feat: .env를 통한 API 엔드포인트 설정 지원 (#101)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,9 @@
+# Backend API endpoint
+# 기본값: https://mefit.xn--hy1by51c.kr (배포 환경)
+# 로컬 개발 시 아래 값으로 오버라이드
+VITE_API_BASE_URL=http://localhost:8000
+
+# Voice API endpoint
+# 기본값: https://mefit-voice.xn--hy1by51c.kr/voice-api/api/v1 (배포 환경)
+# 로컬 개발 시 아래 값으로 오버라이드
+VITE_VOICE_API_BASE_URL=http://localhost:8001/voice-api/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Environment variables (copy .env.sample to .env and fill in values)
+.env
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = "https://mefit.xn--hy1by51c.kr";
+export const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "https://mefit.xn--hy1by51c.kr";
 
 /* ── Token helpers ── */
 export function getAccessToken(): string | null {

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "https://mefit.xn--hy1by51c.kr";
+export const BASE_URL = import.meta.env.VITE_API_BASE_URL || "https://mefit.xn--hy1by51c.kr";
 
 /* ── Token helpers ── */
 export function getAccessToken(): string | null {

--- a/src/shared/lib/tts/useTts.ts
+++ b/src/shared/lib/tts/useTts.ts
@@ -1,7 +1,8 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { getAccessToken } from "@/shared/api/client";
 
-export const VOICE_API_BASE = "https://mefit-voice.xn--hy1by51c.kr/voice-api/api/v1";
+export const VOICE_API_BASE =
+  import.meta.env.VITE_VOICE_API_BASE_URL ?? "https://mefit-voice.xn--hy1by51c.kr/voice-api/api/v1";
 export const TTS_DEFAULT_VOICE = "ko-KR-InJoonNeural";
 
 export interface UseTtsReturn {

--- a/src/shared/lib/tts/useTts.ts
+++ b/src/shared/lib/tts/useTts.ts
@@ -2,7 +2,7 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import { getAccessToken } from "@/shared/api/client";
 
 export const VOICE_API_BASE =
-  import.meta.env.VITE_VOICE_API_BASE_URL ?? "https://mefit-voice.xn--hy1by51c.kr/voice-api/api/v1";
+  import.meta.env.VITE_VOICE_API_BASE_URL || "https://mefit-voice.xn--hy1by51c.kr/voice-api/api/v1";
 export const TTS_DEFAULT_VOICE = "ko-KR-InJoonNeural";
 
 export interface UseTtsReturn {


### PR DESCRIPTION
## 개요
Closes #101

## 변경 사항
- `VITE_API_BASE_URL` 환경변수로 백엔드 엔드포인트 설정 가능
  - 기본값: `https://mefit.xn--hy1by51c.kr` (배포 환경)
- `VITE_VOICE_API_BASE_URL` 환경변수로 Voice API 엔드포인트 설정 가능
  - 기본값: `https://mefit-voice.xn--hy1by51c.kr/voice-api/api/v1` (배포 환경)
- `.env.sample` 추가 (로컬 개발 시 localhost 오버라이드 예시 포함)
- `.gitignore`에 `.env` 추가

## 사용 방법
배포 환경에서는 `.env` 없이 기본값(배포 URL)으로 동작합니다.
로컬 개발 시에는 `.env.sample`을 참고하여 `.env`를 생성하면 됩니다.