### PR TITLE
feat: 도전과제 페이지 및 사이드바 추가 (#103)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -24,6 +24,7 @@ import { InterviewReportPage } from "@/pages/interview-report";
 import { InterviewResultsPage } from "@/pages/interview-results";
 import { SettingsPage } from "@/pages/settings";
 import { StreakPage } from "@/pages/streak";
+import { AchievementsPage } from "@/pages/achievements";
 import { SubscriptionPage } from "@/pages/subscription";
 import { NotificationsPage } from "@/pages/notifications";
 import { NotFoundPage } from "@/pages/not-found";
@@ -74,6 +75,7 @@ function App() {
         <Route path="/interview/results" element={<ProtectedRoute><InterviewResultsPage /></ProtectedRoute>} />
         <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
         <Route path="/streak" element={<ProtectedRoute><StreakPage /></ProtectedRoute>} />
+        <Route path="/achievements" element={<ProtectedRoute><AchievementsPage /></ProtectedRoute>} />
         <Route path="/subscription" element={<ProtectedRoute><SubscriptionPage /></ProtectedRoute>} />
         <Route path="/notifications" element={<ProtectedRoute><NotificationsPage /></ProtectedRoute>} />
 

--- a/src/features/achievements/api/achievementsApi.ts
+++ b/src/features/achievements/api/achievementsApi.ts
@@ -1,0 +1,54 @@
+import { apiRequest } from "@/shared/api/client";
+import type { Achievement, ClaimResponse, RefreshResponse } from "../model/types";
+
+export async function fetchAchievementsApi(): Promise<{
+  success: boolean;
+  data?: Achievement[];
+  error?: string;
+}> {
+  try {
+    const data = await apiRequest<Achievement[]>("/api/v1/achievements/", { auth: true });
+    return { success: true, data };
+  } catch {
+    return { success: false, error: "도전과제를 불러오지 못했습니다." };
+  }
+}
+
+export async function claimAchievementApi(code: string): Promise<{
+  success: boolean;
+  data?: ClaimResponse;
+  error?: string;
+}> {
+  try {
+    const data = await apiRequest<ClaimResponse>(`/api/v1/achievements/${code}/claim/`, {
+      auth: true,
+      method: "POST",
+    });
+    return { success: true, data };
+  } catch {
+    return { success: false, error: "보상 수령에 실패했습니다." };
+  }
+}
+
+export async function refreshAchievementsApi(): Promise<{
+  success: boolean;
+  data?: RefreshResponse;
+  error?: string;
+  retryAfter?: number;
+}> {
+  try {
+    const data = await apiRequest<RefreshResponse>("/api/v1/achievements/refresh/", {
+      auth: true,
+      method: "POST",
+    });
+    return { success: true, data };
+  } catch (err: unknown) {
+    // 429 Too Many Requests
+    if (err && typeof err === "object" && "status" in err && (err as { status: number }).status === 429) {
+      const retryAfter =
+        "retry_after" in err ? (err as { retry_after?: number }).retry_after : undefined;
+      return { success: false, error: "잠시 후 다시 시도해주세요.", retryAfter };
+    }
+    return { success: false, error: "평가 새로고침에 실패했습니다." };
+  }
+}

--- a/src/features/achievements/index.ts
+++ b/src/features/achievements/index.ts
@@ -1,0 +1,3 @@
+export { useAchievementsStore } from "./model/store";
+export { AchievementCard } from "./ui/AchievementCard";
+export type { Achievement, ClaimResponse, RefreshResponse } from "./model/types";

--- a/src/features/achievements/model/store.ts
+++ b/src/features/achievements/model/store.ts
@@ -1,0 +1,58 @@
+import { create } from "zustand";
+import { fetchAchievementsApi, claimAchievementApi } from "../api/achievementsApi";
+import type { Achievement } from "./types";
+
+interface AchievementsState {
+  data: Achievement[] | null;
+  loading: boolean;
+  error: string | null;
+  claimingCodes: Set<string>;
+  fetchAchievements: () => Promise<void>;
+  claimAchievement: (code: string) => Promise<void>;
+}
+
+export const useAchievementsStore = create<AchievementsState>()((set, get) => ({
+  data: null,
+  loading: false,
+  error: null,
+  claimingCodes: new Set(),
+
+  fetchAchievements: async () => {
+    set({ loading: true, error: null });
+    const res = await fetchAchievementsApi();
+    if (res.success && res.data) {
+      set({ data: res.data, loading: false });
+    } else {
+      set({ error: res.error ?? "도전과제를 불러오지 못했습니다.", loading: false });
+    }
+  },
+
+  claimAchievement: async (code: string) => {
+    const { claimingCodes, data } = get();
+    if (claimingCodes.has(code)) return; // 더블클릭 방지
+
+    set({ claimingCodes: new Set([...claimingCodes, code]) });
+
+    const res = await claimAchievementApi(code);
+
+    if (res.success && res.data && data) {
+      // 로컬 상태 업데이트: 해당 achievement의 reward_claimed_at 갱신
+      const updated = data.map((a) =>
+        a.code === code
+          ? { ...a, reward_claimed_at: res.data!.reward_claimed_at, can_claim_reward: false }
+          : a
+      );
+      set((state) => {
+        const next = new Set(state.claimingCodes);
+        next.delete(code);
+        return { data: updated, claimingCodes: next };
+      });
+    } else {
+      set((state) => {
+        const next = new Set(state.claimingCodes);
+        next.delete(code);
+        return { claimingCodes: next };
+      });
+    }
+  },
+}));

--- a/src/features/achievements/model/store.ts
+++ b/src/features/achievements/model/store.ts
@@ -6,6 +6,7 @@ interface AchievementsState {
   data: Achievement[] | null;
   loading: boolean;
   error: string | null;
+  claimError: string | null;
   claimingCodes: Set<string>;
   fetchAchievements: () => Promise<void>;
   claimAchievement: (code: string) => Promise<void>;
@@ -15,6 +16,7 @@ export const useAchievementsStore = create<AchievementsState>()((set, get) => ({
   data: null,
   loading: false,
   error: null,
+  claimError: null,
   claimingCodes: new Set(),
 
   fetchAchievements: async () => {
@@ -28,31 +30,33 @@ export const useAchievementsStore = create<AchievementsState>()((set, get) => ({
   },
 
   claimAchievement: async (code: string) => {
-    const { claimingCodes, data } = get();
-    if (claimingCodes.has(code)) return; // 더블클릭 방지
+    if (get().claimingCodes.has(code)) return; // 더블클릭 방지
 
-    set({ claimingCodes: new Set([...claimingCodes, code]) });
+    set((state) => ({
+      claimingCodes: new Set(state.claimingCodes).add(code),
+      claimError: null,
+    }));
 
     const res = await claimAchievementApi(code);
 
-    if (res.success && res.data && data) {
-      // 로컬 상태 업데이트: 해당 achievement의 reward_claimed_at 갱신
-      const updated = data.map((a) =>
-        a.code === code
-          ? { ...a, reward_claimed_at: res.data!.reward_claimed_at, can_claim_reward: false }
-          : a
-      );
-      set((state) => {
-        const next = new Set(state.claimingCodes);
-        next.delete(code);
-        return { data: updated, claimingCodes: next };
-      });
-    } else {
-      set((state) => {
-        const next = new Set(state.claimingCodes);
-        next.delete(code);
-        return { claimingCodes: next };
-      });
-    }
+    set((state) => {
+      const nextClaiming = new Set(state.claimingCodes);
+      nextClaiming.delete(code);
+
+      if (res.success && res.data && state.data) {
+        // 로컬 상태 업데이트: 해당 achievement의 reward_claimed_at 갱신
+        const updatedData = state.data.map((a) =>
+          a.code === code
+            ? { ...a, reward_claimed_at: res.data!.reward_claimed_at, can_claim_reward: false }
+            : a
+        );
+        return { data: updatedData, claimingCodes: nextClaiming };
+      }
+
+      return {
+        claimingCodes: nextClaiming,
+        claimError: res.error ?? "보상 수령에 실패했습니다.",
+      };
+    });
   },
 }));

--- a/src/features/achievements/model/store.ts
+++ b/src/features/achievements/model/store.ts
@@ -43,13 +43,13 @@ export const useAchievementsStore = create<AchievementsState>()((set, get) => ({
       const nextClaiming = new Set(state.claimingCodes);
       nextClaiming.delete(code);
 
-      if (res.success && res.data && state.data) {
-        // 로컬 상태 업데이트: 해당 achievement의 reward_claimed_at 갱신
-        const updatedData = state.data.map((a) =>
-          a.code === code
-            ? { ...a, reward_claimed_at: res.data!.reward_claimed_at, can_claim_reward: false }
-            : a
-        );
+        if (res.success && res.data && state.data) {
+          // 로컬 상태 업데이트: 해당 achievement의 rewardClaimedAt 갱신
+          const updatedData = state.data.map((a) =>
+            a.code === code
+              ? { ...a, rewardClaimedAt: res.data!.rewardClaimedAt, canClaimReward: false }
+              : a
+          );
         return { data: updatedData, claimingCodes: nextClaiming };
       }
 

--- a/src/features/achievements/model/types.ts
+++ b/src/features/achievements/model/types.ts
@@ -3,20 +3,20 @@ export interface Achievement {
   name: string;
   description: string;
   category: "streak" | "activity" | "profile" | "interview" | "other";
-  is_active: boolean;
-  starts_at: string | null;
-  ends_at: string | null;
-  is_achieved: boolean;
-  achieved_at: string | null;
-  reward_claimed_at: string | null;
-  can_claim_reward: boolean;
+  isActive: boolean;
+  startsAt: string | null;
+  endsAt: string | null;
+  isAchieved: boolean;
+  achievedAt: string | null;
+  rewardClaimedAt: string | null;
+  canClaimReward: boolean;
 }
 
 export interface ClaimResponse {
-  achievement_code: string;
-  reward_claimed_at: string;
+  achievementCode: string;
+  rewardClaimedAt: string;
 }
 
 export interface RefreshResponse {
-  created_achievements_count: number;
+  createdAchievementsCount: number;
 }

--- a/src/features/achievements/model/types.ts
+++ b/src/features/achievements/model/types.ts
@@ -1,0 +1,22 @@
+export interface Achievement {
+  code: string;
+  name: string;
+  description: string;
+  category: "streak" | "activity" | "profile" | "interview" | "other";
+  is_active: boolean;
+  starts_at: string | null;
+  ends_at: string | null;
+  is_achieved: boolean;
+  achieved_at: string | null;
+  reward_claimed_at: string | null;
+  can_claim_reward: boolean;
+}
+
+export interface ClaimResponse {
+  achievement_code: string;
+  reward_claimed_at: string;
+}
+
+export interface RefreshResponse {
+  created_achievements_count: number;
+}

--- a/src/features/achievements/ui/AchievementCard.tsx
+++ b/src/features/achievements/ui/AchievementCard.tsx
@@ -36,25 +36,25 @@ export function AchievementCard({ achievement, isClaiming, onClaim }: Achievemen
     name,
     description,
     category,
-    is_achieved,
-    achieved_at,
-    reward_claimed_at,
-    can_claim_reward,
+    isAchieved,
+    achievedAt,
+    rewardClaimedAt,
+    canClaimReward,
   } = achievement;
 
   return (
     <div
-      className={`p-7 bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] flex flex-col gap-3 transition-opacity ${!is_achieved ? "opacity-60" : ""}`}
+      className={`p-7 bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] flex flex-col gap-3 transition-opacity ${!isAchieved ? "opacity-60" : ""}`}
     >
       {/* Header: name + category badge */}
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2 flex-1 min-w-0">
-          {is_achieved ? (
+          {isAchieved ? (
             <CheckCircle2 size={18} className="text-[#10B981] shrink-0" />
           ) : (
             <div className="w-[18px] h-[18px] rounded-full border-2 border-[#D1D5DB] shrink-0" />
           )}
-          <span className={`font-bold text-[14px] truncate ${is_achieved ? "text-[#0A0A0A]" : "text-[#9CA3AF]"}`}>
+          <span className={`font-bold text-[14px] truncate ${isAchieved ? "text-[#0A0A0A]" : "text-[#9CA3AF]"}`}>
             {name}
           </span>
         </div>
@@ -68,11 +68,11 @@ export function AchievementCard({ achievement, isClaiming, onClaim }: Achievemen
 
       {/* Footer */}
       <div className="mt-auto pt-3 border-t border-[#F3F4F6]">
-        {is_achieved && achieved_at && !reward_claimed_at && !can_claim_reward && (
-          <p className="text-[12px] text-[#9CA3AF]">달성일: {formatDate(achieved_at)}</p>
+        {isAchieved && achievedAt && !rewardClaimedAt && !canClaimReward && (
+          <p className="text-[12px] text-[#9CA3AF]">달성일: {formatDate(achievedAt)}</p>
         )}
 
-        {can_claim_reward && (
+        {canClaimReward && (
           <Button
             variant="primary"
             size="sm"
@@ -85,14 +85,14 @@ export function AchievementCard({ achievement, isClaiming, onClaim }: Achievemen
           </Button>
         )}
 
-        {reward_claimed_at && (
+        {rewardClaimedAt && (
           <div className="flex items-center gap-1.5 text-[12px] text-[#9CA3AF]">
             <Ticket size={14} className="text-[#0991B2] shrink-0" />
-            <span>수령 완료 · {formatDate(reward_claimed_at)}</span>
+            <span>수령 완료 · {formatDate(rewardClaimedAt)}</span>
           </div>
         )}
 
-        {!is_achieved && !can_claim_reward && !reward_claimed_at && (
+        {!isAchieved && !canClaimReward && !rewardClaimedAt && (
           <p className="text-[12px] text-[#9CA3AF]">아직 달성하지 못한 도전과제입니다</p>
         )}
       </div>

--- a/src/features/achievements/ui/AchievementCard.tsx
+++ b/src/features/achievements/ui/AchievementCard.tsx
@@ -1,0 +1,100 @@
+import { CheckCircle2, Ticket } from "lucide-react";
+import { Card } from "@/shared/ui/Card";
+import { Badge } from "@/shared/ui/Badge";
+import { Button } from "@/shared/ui/Button";
+import type { Achievement } from "../model/types";
+
+interface AchievementCardProps {
+  achievement: Achievement;
+  isClaiming: boolean;
+  onClaim: (code: string) => void;
+}
+
+const categoryLabels: Record<Achievement["category"], string> = {
+  streak: "스트릭",
+  activity: "활동",
+  profile: "프로필",
+  interview: "면접",
+  other: "기타",
+};
+
+const categoryVariants: Record<Achievement["category"], "primary" | "success" | "info" | "warning" | "default"> = {
+  streak: "primary",
+  activity: "success",
+  profile: "info",
+  interview: "warning",
+  other: "default",
+};
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export function AchievementCard({ achievement, isClaiming, onClaim }: AchievementCardProps) {
+  const {
+    code,
+    name,
+    description,
+    category,
+    is_achieved,
+    achieved_at,
+    reward_claimed_at,
+    can_claim_reward,
+  } = achievement;
+
+  return (
+    <Card
+      padding="sm"
+      className={`flex flex-col gap-3 transition-opacity ${!is_achieved ? "opacity-60" : ""}`}
+    >
+      {/* Header: name + category badge */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          {is_achieved && (
+            <CheckCircle2 size={18} className="text-mefit-success shrink-0" />
+          )}
+          {!is_achieved && (
+            <div className="w-[18px] h-[18px] rounded-full border-2 border-mefit-gray-300 shrink-0" />
+          )}
+          <span className={`font-bold text-sm truncate ${is_achieved ? "text-mefit-black" : "text-mefit-gray-400"}`}>
+            {name}
+          </span>
+        </div>
+        <Badge variant={categoryVariants[category]} size="sm" className="shrink-0">
+          {categoryLabels[category]}
+        </Badge>
+      </div>
+
+      {/* Description */}
+      <p className="text-xs text-mefit-gray-500 leading-relaxed">{description}</p>
+
+      {/* Footer: achieved date / claim button / claimed status */}
+      <div className="mt-auto pt-1">
+        {is_achieved && achieved_at && !reward_claimed_at && !can_claim_reward && (
+          <p className="text-xs text-mefit-gray-400">달성일: {formatDate(achieved_at)}</p>
+        )}
+
+        {can_claim_reward && (
+          <Button
+            variant="primary"
+            size="sm"
+            fullWidth
+            loading={isClaiming}
+            disabled={isClaiming}
+            onClick={() => onClaim(code)}
+          >
+            보상 수령
+          </Button>
+        )}
+
+        {reward_claimed_at && (
+          <div className="flex items-center gap-1.5 text-xs text-mefit-gray-400">
+            <Ticket size={14} className="text-mefit-primary shrink-0" />
+            <span>수령 완료 · {formatDate(reward_claimed_at)}</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/features/achievements/ui/AchievementCard.tsx
+++ b/src/features/achievements/ui/AchievementCard.tsx
@@ -1,5 +1,4 @@
 import { CheckCircle2, Ticket } from "lucide-react";
-import { Card } from "@/shared/ui/Card";
 import { Badge } from "@/shared/ui/Badge";
 import { Button } from "@/shared/ui/Button";
 import type { Achievement } from "../model/types";
@@ -44,20 +43,18 @@ export function AchievementCard({ achievement, isClaiming, onClaim }: Achievemen
   } = achievement;
 
   return (
-    <Card
-      padding="sm"
-      className={`flex flex-col gap-3 transition-opacity ${!is_achieved ? "opacity-60" : ""}`}
+    <div
+      className={`p-7 bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] flex flex-col gap-3 transition-opacity ${!is_achieved ? "opacity-60" : ""}`}
     >
       {/* Header: name + category badge */}
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2 flex-1 min-w-0">
-          {is_achieved && (
-            <CheckCircle2 size={18} className="text-mefit-success shrink-0" />
+          {is_achieved ? (
+            <CheckCircle2 size={18} className="text-[#10B981] shrink-0" />
+          ) : (
+            <div className="w-[18px] h-[18px] rounded-full border-2 border-[#D1D5DB] shrink-0" />
           )}
-          {!is_achieved && (
-            <div className="w-[18px] h-[18px] rounded-full border-2 border-mefit-gray-300 shrink-0" />
-          )}
-          <span className={`font-bold text-sm truncate ${is_achieved ? "text-mefit-black" : "text-mefit-gray-400"}`}>
+          <span className={`font-bold text-[14px] truncate ${is_achieved ? "text-[#0A0A0A]" : "text-[#9CA3AF]"}`}>
             {name}
           </span>
         </div>
@@ -67,12 +64,12 @@ export function AchievementCard({ achievement, isClaiming, onClaim }: Achievemen
       </div>
 
       {/* Description */}
-      <p className="text-xs text-mefit-gray-500 leading-relaxed">{description}</p>
+      <p className="text-[13px] text-[#6B7280] leading-relaxed">{description}</p>
 
-      {/* Footer: achieved date / claim button / claimed status */}
-      <div className="mt-auto pt-1">
+      {/* Footer */}
+      <div className="mt-auto pt-3 border-t border-[#F3F4F6]">
         {is_achieved && achieved_at && !reward_claimed_at && !can_claim_reward && (
-          <p className="text-xs text-mefit-gray-400">달성일: {formatDate(achieved_at)}</p>
+          <p className="text-[12px] text-[#9CA3AF]">달성일: {formatDate(achieved_at)}</p>
         )}
 
         {can_claim_reward && (
@@ -89,12 +86,16 @@ export function AchievementCard({ achievement, isClaiming, onClaim }: Achievemen
         )}
 
         {reward_claimed_at && (
-          <div className="flex items-center gap-1.5 text-xs text-mefit-gray-400">
-            <Ticket size={14} className="text-mefit-primary shrink-0" />
+          <div className="flex items-center gap-1.5 text-[12px] text-[#9CA3AF]">
+            <Ticket size={14} className="text-[#0991B2] shrink-0" />
             <span>수령 완료 · {formatDate(reward_claimed_at)}</span>
           </div>
         )}
+
+        {!is_achieved && !can_claim_reward && !reward_claimed_at && (
+          <p className="text-[12px] text-[#9CA3AF]">아직 달성하지 못한 도전과제입니다</p>
+        )}
       </div>
-    </Card>
+    </div>
   );
 }

--- a/src/pages/achievements/index.ts
+++ b/src/pages/achievements/index.ts
@@ -1,0 +1,1 @@
+export { AchievementsPage } from "./ui/AchievementsPage";

--- a/src/pages/achievements/ui/AchievementsPage.tsx
+++ b/src/pages/achievements/ui/AchievementsPage.tsx
@@ -5,7 +5,7 @@ import { AchievementCard } from "@/features/achievements";
 import { refreshAchievementsApi } from "@/features/achievements/api/achievementsApi";
 
 export function AchievementsPage() {
-  const { data, loading, error, fetchAchievements, claimAchievement, claimingCodes } =
+  const { data, loading, error, claimError, fetchAchievements, claimAchievement, claimingCodes } =
     useAchievementsStore();
 
   const [refreshing, setRefreshing] = useState(false);
@@ -70,33 +70,42 @@ export function AchievementsPage() {
           <div className="flex justify-center py-20">
             <Loader2 className="w-6 h-6 animate-spin text-[#0991B2]" />
           </div>
-        ) : error ? (
+        ) : !data && error ? (
           <div className="flex flex-col items-center justify-center py-20 text-center">
             <span className="text-5xl mb-5">⚠️</span>
             <p className="text-[15px] font-extrabold text-[#0A0A0A] mb-2">불러오기 실패</p>
             <p className="text-sm text-[#9CA3AF]">{error}</p>
           </div>
-        ) : data && data.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
-            <span className="text-5xl mb-5">🏆</span>
-            <p className="text-[15px] font-extrabold text-[#0A0A0A] mb-2">아직 달성한 도전과제가 없어요</p>
-            <p className="text-sm text-[#9CA3AF]">면접 연습을 통해 도전과제를 달성해 보세요</p>
-          </div>
-        ) : data ? (
-          <div
-            className="grid gap-[18px]"
-            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))" }}
-          >
-            {data.map((achievement) => (
-              <AchievementCard
-                key={achievement.code}
-                achievement={achievement}
-                isClaiming={claimingCodes.has(achievement.code)}
-                onClaim={claimAchievement}
-              />
-            ))}
-          </div>
-        ) : null}
+        ) : (
+          <>
+            {(error || claimError) && (
+              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+                {error ?? claimError}
+              </div>
+            )}
+            {data && data.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-20 text-center">
+                <span className="text-5xl mb-5">🏆</span>
+                <p className="text-[15px] font-extrabold text-[#0A0A0A] mb-2">아직 달성한 도전과제가 없어요</p>
+                <p className="text-sm text-[#9CA3AF]">면접 연습을 통해 도전과제를 달성해 보세요</p>
+              </div>
+            ) : data ? (
+              <div
+                className="grid gap-[18px]"
+                style={{ gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))" }}
+              >
+                {data.map((achievement) => (
+                  <AchievementCard
+                    key={achievement.code}
+                    achievement={achievement}
+                    isClaiming={claimingCodes.has(achievement.code)}
+                    onClaim={claimAchievement}
+                  />
+                ))}
+              </div>
+            ) : null}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/pages/achievements/ui/AchievementsPage.tsx
+++ b/src/pages/achievements/ui/AchievementsPage.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { useAchievementsStore } from "@/features/achievements";
+import { AchievementCard } from "@/features/achievements";
+import { refreshAchievementsApi } from "@/features/achievements/api/achievementsApi";
+import { SectionHeader } from "@/shared/ui/SectionHeader";
+import { Spinner } from "@/shared/ui/Spinner";
+import { Button } from "@/shared/ui/Button";
+
+export function AchievementsPage() {
+  const { data, loading, error, fetchAchievements, claimAchievement, claimingCodes } =
+    useAchievementsStore();
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshMsg, setRefreshMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchAchievements();
+  }, [fetchAchievements]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    setRefreshMsg(null);
+    const res = await refreshAchievementsApi();
+    if (res.success) {
+      setRefreshMsg(
+        res.data && res.data.created_achievements_count > 0
+          ? `${res.data.created_achievements_count}개의 새 도전과제가 추가됐습니다.`
+          : "이미 최신 상태입니다."
+      );
+      await fetchAchievements();
+    } else {
+      setRefreshMsg(res.error ?? "잠시 후 다시 시도해주세요.");
+    }
+    setRefreshing(false);
+  };
+
+  return (
+    <div className="bg-[#F9FAFB] min-h-[calc(100vh-60px)] p-7 w-full max-sm:p-4">
+      <SectionHeader
+        icon="🏆"
+        title="도전과제"
+        description="달성한 업적을 확인하고 보상을 수령하세요."
+        gradient="linear-gradient(135deg, #fbbf24, #f59e0b)"
+      >
+        <div className="flex items-center gap-3 mt-3">
+          <Button
+            variant="outline"
+            size="sm"
+            loading={refreshing}
+            disabled={refreshing}
+            onClick={handleRefresh}
+          >
+            <RefreshCw size={14} />
+            평가 새로고침
+          </Button>
+          {refreshMsg && (
+            <span className="text-xs text-mefit-gray-500">{refreshMsg}</span>
+          )}
+        </div>
+      </SectionHeader>
+
+      {loading && !data ? (
+        <div className="flex justify-center items-center py-20">
+          <Spinner />
+        </div>
+      ) : error ? (
+        <div className="flex justify-center items-center py-20">
+          <p className="text-sm text-mefit-danger">{error}</p>
+        </div>
+      ) : data && data.length === 0 ? (
+        <div className="flex justify-center items-center py-20">
+          <p className="text-sm text-mefit-gray-400">도전과제가 없습니다.</p>
+        </div>
+      ) : data ? (
+        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+          {data.map((achievement) => (
+            <AchievementCard
+              key={achievement.code}
+              achievement={achievement}
+              isClaiming={claimingCodes.has(achievement.code)}
+              onClaim={claimAchievement}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/pages/achievements/ui/AchievementsPage.tsx
+++ b/src/pages/achievements/ui/AchievementsPage.tsx
@@ -1,11 +1,8 @@
 import { useEffect, useState } from "react";
-import { RefreshCw } from "lucide-react";
+import { Loader2, RefreshCw } from "lucide-react";
 import { useAchievementsStore } from "@/features/achievements";
 import { AchievementCard } from "@/features/achievements";
 import { refreshAchievementsApi } from "@/features/achievements/api/achievementsApi";
-import { SectionHeader } from "@/shared/ui/SectionHeader";
-import { Spinner } from "@/shared/ui/Spinner";
-import { Button } from "@/shared/ui/Button";
 
 export function AchievementsPage() {
   const { data, loading, error, fetchAchievements, claimAchievement, claimingCodes } =
@@ -36,54 +33,71 @@ export function AchievementsPage() {
   };
 
   return (
-    <div className="bg-[#F9FAFB] min-h-[calc(100vh-60px)] p-7 w-full max-sm:p-4">
-      <SectionHeader
-        icon="🏆"
-        title="도전과제"
-        description="달성한 업적을 확인하고 보상을 수령하세요."
-        gradient="linear-gradient(135deg, #fbbf24, #f59e0b)"
-      >
-        <div className="flex items-center gap-3 mt-3">
-          <Button
-            variant="outline"
-            size="sm"
-            loading={refreshing}
-            disabled={refreshing}
-            onClick={handleRefresh}
-          >
-            <RefreshCw size={14} />
-            평가 새로고침
-          </Button>
-          {refreshMsg && (
-            <span className="text-xs text-mefit-gray-500">{refreshMsg}</span>
-          )}
+    <div>
+      <div className="w-full px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
+        {/* 페이지 타이틀 */}
+        <div className="flex items-start justify-between mb-8 gap-4">
+          <div>
+            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">
+              🏆 도전과제
+            </div>
+            <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">
+              내 도전과제
+            </h1>
+            <p className="text-sm text-[#6B7280] mt-1.5">달성한 업적을 확인하고 보상을 수령하세요.</p>
+          </div>
+          <div className="flex flex-col items-end gap-2 shrink-0">
+            <button
+              onClick={handleRefresh}
+              disabled={refreshing}
+              className="inline-flex items-center gap-2 text-sm font-bold text-white bg-[#0A0A0A] border-none cursor-pointer py-3.5 px-6 rounded-lg shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-opacity hover:opacity-85 whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {refreshing ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <RefreshCw size={14} />
+              )}
+              평가 새로고침
+            </button>
+            {refreshMsg && (
+              <span className="text-xs text-[#6B7280]">{refreshMsg}</span>
+            )}
+          </div>
         </div>
-      </SectionHeader>
 
-      {loading && !data ? (
-        <div className="flex justify-center items-center py-20">
-          <Spinner />
-        </div>
-      ) : error ? (
-        <div className="flex justify-center items-center py-20">
-          <p className="text-sm text-mefit-danger">{error}</p>
-        </div>
-      ) : data && data.length === 0 ? (
-        <div className="flex justify-center items-center py-20">
-          <p className="text-sm text-mefit-gray-400">도전과제가 없습니다.</p>
-        </div>
-      ) : data ? (
-        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
-          {data.map((achievement) => (
-            <AchievementCard
-              key={achievement.code}
-              achievement={achievement}
-              isClaiming={claimingCodes.has(achievement.code)}
-              onClaim={claimAchievement}
-            />
-          ))}
-        </div>
-      ) : null}
+        {/* 컨텐츠 */}
+        {loading && !data ? (
+          <div className="flex justify-center py-20">
+            <Loader2 className="w-6 h-6 animate-spin text-[#0991B2]" />
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <span className="text-5xl mb-5">⚠️</span>
+            <p className="text-[15px] font-extrabold text-[#0A0A0A] mb-2">불러오기 실패</p>
+            <p className="text-sm text-[#9CA3AF]">{error}</p>
+          </div>
+        ) : data && data.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <span className="text-5xl mb-5">🏆</span>
+            <p className="text-[15px] font-extrabold text-[#0A0A0A] mb-2">아직 달성한 도전과제가 없어요</p>
+            <p className="text-sm text-[#9CA3AF]">면접 연습을 통해 도전과제를 달성해 보세요</p>
+          </div>
+        ) : data ? (
+          <div
+            className="grid gap-[18px]"
+            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))" }}
+          >
+            {data.map((achievement) => (
+              <AchievementCard
+                key={achievement.code}
+                achievement={achievement}
+                isClaiming={claimingCodes.has(achievement.code)}
+                onClaim={claimAchievement}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/pages/achievements/ui/AchievementsPage.tsx
+++ b/src/pages/achievements/ui/AchievementsPage.tsx
@@ -21,8 +21,8 @@ export function AchievementsPage() {
     const res = await refreshAchievementsApi();
     if (res.success) {
       setRefreshMsg(
-        res.data && res.data.created_achievements_count > 0
-          ? `${res.data.created_achievements_count}개의 새 도전과제가 추가됐습니다.`
+        res.data && res.data.createdAchievementsCount > 0
+          ? `${res.data.createdAchievementsCount}개의 새 도전과제가 추가됐습니다.`
           : "이미 최신 상태입니다."
       );
       await fetchAchievements();

--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "react-router-dom";
-import { Home, Video, FileText, Building2, BarChart2, Flame, CreditCard, Settings } from "lucide-react";
+import { Home, Video, FileText, Building2, BarChart2, Flame, Trophy, CreditCard, Settings } from "lucide-react";
 
 interface HomeSidebarProps {
   menuOpen: boolean;
@@ -43,6 +43,9 @@ export function HomeSidebar({ menuOpen, currentStreak, floating = false, activeI
       </Link>
       <Link to="/streak" className={`hp-sb-item${isActive("/streak") ? " active" : ""}`}>
         <span className="hp-sb-icon"><Flame size={18} /></span>스트릭
+      </Link>
+      <Link to="/achievements" className={`hp-sb-item${isActive("/achievements") ? " active" : ""}`}>
+        <span className="hp-sb-icon"><Trophy size={18} /></span>도전과제
       </Link>
       <div className="hp-sb-sep">설정</div>
       <Link to="/subscription" className={`hp-sb-item${isActive("/subscription") ? " active" : ""}`}>


### PR DESCRIPTION
## 변경 사항

### 신규 파일 (7개)
- `src/features/achievements/model/types.ts` — Achievement, ClaimResponse 타입
- `src/features/achievements/api/achievementsApi.ts` — fetch/claim/refresh API
- `src/features/achievements/model/store.ts` — Zustand store (더블클릭 방지 포함)
- `src/features/achievements/ui/AchievementCard.tsx` — 업적 카드 컴포넌트
- `src/features/achievements/index.ts` — 배럴 export
- `src/pages/achievements/ui/AchievementsPage.tsx` — 도전과제 페이지
- `src/pages/achievements/index.ts` — 배럴 export

### 수정 파일 (2개)
- `src/app/App.tsx`: `/achievements` 라우트 추가 (ProtectedRoute)
- `src/pages/home/ui/components/HomeSidebar.tsx`: 분석 섹션에 도전과제 항목 추가 (Trophy 아이콘)

### 더블클릭 방지
- `claimingCodes: Set<string>` 으로 진행 중인 claim 추적
- 버튼에 `loading`/`disabled` prop 전달
- 백엔드: `select_for_update`로 DB 레벨 이중 방지

### 검증
- 기존 96개 테스트 전체 통과
- 공유 컴포넌트 Card, Button, Badge, Spinner, SectionHeader 재사용

Closes #103