### PR TITLE
feat: 면접 과정 중 영상 녹화 과정 연결

### DIFF
--- a/src/features/interview-session/api/interviewApi.ts
+++ b/src/features/interview-session/api/interviewApi.ts
@@ -7,6 +7,7 @@ import type {
   SubmitAnswerResponse,
   PaginatedResponse,
   InterviewSessionListItem,
+  BehaviorAnalysis,
 } from "./types";
 
 const BASE = "/api/v1/interviews/interview-sessions";
@@ -31,10 +32,15 @@ export const interviewApi = {
   getInterviewTurns: (interviewSessionUuid: string) =>
     apiRequest<InterviewTurn[]>(`${BASE}/${interviewSessionUuid}/turns/`, { auth: true }),
 
-  submitAnswer: (interviewSessionUuid: string, turnPk: number, answer: string) =>
+  submitAnswer: (
+    interviewSessionUuid: string,
+    turnPk: number,
+    answer: string,
+    speechSegments?: { text: string; startMs: number; endMs: number }[],
+  ) =>
     apiRequest<SubmitAnswerResponse>(
       `${BASE}/${interviewSessionUuid}/turns/${turnPk}/answer/`,
-      { method: "POST", body: JSON.stringify({ answer }), auth: true },
+      { method: "POST", body: JSON.stringify({ answer, speech_segments: speechSegments ?? [] }), auth: true },
     ),
 
   finishInterview: (interviewSessionUuid: string) =>
@@ -56,4 +62,8 @@ export const interviewApi = {
       method: "POST",
       auth: true,
     }),
+
+  getBehaviorAnalyses: (interviewSessionUuid: string) =>
+    apiRequest<{ results: BehaviorAnalysis[] }>(`${BASE}/${interviewSessionUuid}/behavior-analyses/`, { auth: true })
+      .then((res) => res.results),
 };

--- a/src/features/interview-session/api/recordingApi.ts
+++ b/src/features/interview-session/api/recordingApi.ts
@@ -1,0 +1,63 @@
+import { apiRequest } from "@/shared/api/client";
+
+export interface InitiateRecordingResponse {
+  recordingId: string;
+  uploadId: string;
+  s3Key: string;
+  presignedUrls: { partNumber: number; url: string }[];
+}
+
+export interface CompleteRecordingResponse {
+  recordingId: string;
+  status: string;
+}
+
+export interface RecordingItem {
+  recordingId: string;
+  turnId: number;
+  mediaType: "video" | "audio";
+  status: string;
+  durationMs: number | null;
+  createdAt: string;
+}
+
+export interface PlaybackUrlResponse {
+  url: string;
+  scaledUrl: string | null;
+  audioUrl: string | null;
+  expiresIn: number;
+  mediaType: string;
+}
+
+const BASE = "/api/v1/interviews";
+
+export const recordingApi = {
+  initiate: (sessionUuid: string, turnId: number, mediaType: "video" | "audio") =>
+    apiRequest<InitiateRecordingResponse>(
+      `${BASE}/interview-sessions/${sessionUuid}/recordings/initiate/`,
+      {
+        method: "POST",
+        body: JSON.stringify({ turnId, mediaType }),
+        auth: true,
+      },
+    ),
+
+  complete: (recordingId: string, parts: { partNumber: number; etag: string }[], endTimestamp: string, durationMs: number) =>
+    apiRequest<CompleteRecordingResponse>(
+      `${BASE}/recordings/${recordingId}/complete/`,
+      {
+        method: "POST",
+        body: JSON.stringify({ parts, endTimestamp, durationMs }),
+        auth: true,
+      },
+    ),
+
+  abort: (recordingId: string) =>
+    apiRequest<void>(`${BASE}/recordings/${recordingId}/abort/`, { method: "POST", auth: true }),
+
+  list: (sessionUuid: string) =>
+    apiRequest<RecordingItem[]>(`${BASE}/interview-sessions/${sessionUuid}/recordings/`, { auth: true }),
+
+  playbackUrl: (recordingId: string) =>
+    apiRequest<PlaybackUrlResponse>(`${BASE}/recordings/${recordingId}/playback-url/`, { auth: true }),
+};

--- a/src/features/interview-session/api/recordingApi.ts
+++ b/src/features/interview-session/api/recordingApi.ts
@@ -1,10 +1,11 @@
-import { apiRequest } from "@/shared/api/client";
+import { apiRequest, BASE_URL, getAccessToken } from "@/shared/api/client";
 
 export interface InitiateRecordingResponse {
   recordingId: string;
   uploadId: string;
   s3Key: string;
   presignedUrls: { partNumber: number; url: string }[];
+  singleUploadUrl: string;
 }
 
 export interface CompleteRecordingResponse {
@@ -42,18 +43,33 @@ export const recordingApi = {
       },
     ),
 
-  complete: (recordingId: string, parts: { partNumber: number; etag: string }[], endTimestamp: string, durationMs: number) =>
+  complete: (recordingId: string, parts: { partNumber: number; etag: string }[], endTimestamp: string, durationMs: number, singleUpload = false) =>
     apiRequest<CompleteRecordingResponse>(
       `${BASE}/recordings/${recordingId}/complete/`,
       {
         method: "POST",
-        body: JSON.stringify({ parts, endTimestamp, durationMs }),
+        body: JSON.stringify({ parts, endTimestamp, durationMs, singleUpload }),
         auth: true,
       },
     ),
 
   abort: (recordingId: string) =>
     apiRequest<void>(`${BASE}/recordings/${recordingId}/abort/`, { method: "POST", auth: true }),
+
+  upload: (recordingId: string, blob: Blob) => {
+    const formData = new FormData();
+    formData.append("file", blob, "recording.webm");
+    return fetch(`${BASE_URL}${BASE}/recordings/${recordingId}/upload/`, {
+      method: "PUT",
+      body: formData,
+      headers: {
+        Authorization: `Bearer ${getAccessToken() ?? ""}`,
+      },
+    }).then((res) => {
+      if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
+      return res.json();
+    });
+  },
 
   list: (sessionUuid: string) =>
     apiRequest<RecordingItem[]>(`${BASE}/interview-sessions/${sessionUuid}/recordings/`, { auth: true }),

--- a/src/features/interview-session/api/recordingApi.ts
+++ b/src/features/interview-session/api/recordingApi.ts
@@ -1,4 +1,4 @@
-import { apiRequest, BASE_URL, getAccessToken } from "@/shared/api/client";
+import { apiRequest, BASE_URL, fetchWithAuth } from "@/shared/api/client";
 
 export interface InitiateRecordingResponse {
   recordingId: string;
@@ -59,12 +59,9 @@ export const recordingApi = {
   upload: (recordingId: string, blob: Blob) => {
     const formData = new FormData();
     formData.append("file", blob, "recording.webm");
-    return fetch(`${BASE_URL}${BASE}/recordings/${recordingId}/upload/`, {
+    return fetchWithAuth(`${BASE_URL}${BASE}/recordings/${recordingId}/upload/`, {
       method: "PUT",
       body: formData,
-      headers: {
-        Authorization: `Bearer ${getAccessToken() ?? ""}`,
-      },
     }).then((res) => {
       if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
       return res.json();

--- a/src/features/interview-session/api/types.ts
+++ b/src/features/interview-session/api/types.ts
@@ -20,12 +20,19 @@ export interface InterviewSession {
   updatedAt: string;
 }
 
+export interface SpeechSegment {
+  text: string;
+  startMs: number;
+  endMs: number;
+}
+
 export interface InterviewTurn {
   id: number;
   turnType: InterviewTurnType;
   questionSource: string;
   question: string;
   answer: string;
+  speechSegments: SpeechSegment[];
   turnNumber: number;
   followupOrder: number | null;
   createdAt: string;
@@ -99,3 +106,34 @@ export interface InterviewSessionListItem {
   anchorQuestions: { id: number; question: string }[];
   reportStatus: InterviewAnalysisReportStatus | null;
 }
+
+export interface SpeechTimelineSegment {
+  startMs: number;
+  endMs: number;
+  type: "speech" | "silence";
+  dbfs: number | null;
+}
+
+export interface VoiceSummary {
+  totalDurationMs: number;
+  speechDurationMs: number;
+  silenceDurationMs: number;
+  silenceRatio: number;
+  speechRatio: number;
+  avgDbfsOverall: number | null;
+  avgDbfsSpeech: number | null;
+  silenceSegmentCount: number;
+  speechSegmentCount: number;
+}
+
+export interface BehaviorAnalysis {
+  uuid: string;
+  interviewTurn: number;
+  status: string;
+  speechData: {
+    summary: VoiceSummary;
+    timeline: SpeechTimelineSegment[];
+  } | null;
+  expressionData: Record<string, unknown>;
+}
+

--- a/src/features/interview-session/index.ts
+++ b/src/features/interview-session/index.ts
@@ -21,6 +21,7 @@ export type {
   SubmitAnswerFollowupResponse,
   SubmitAnswerFullProcessResponse,
   SubmitAnswerResponse,
+  BehaviorAnalysis,
 } from "./api/types";
 
 export { SESSION_TYPE_LABEL, DIFFICULTY_LABEL, REPORT_STATUS_BADGE } from "./constants/labels";

--- a/src/features/interview-session/index.ts
+++ b/src/features/interview-session/index.ts
@@ -29,3 +29,15 @@ export { AvatarSection } from "./ui/AvatarSection";
 export { QuestionPanel } from "./ui/QuestionPanel";
 export { TranscriptPanel } from "./ui/TranscriptPanel";
 export { BehaviorMetrics } from "./ui/BehaviorMetrics";
+
+export { recordingApi } from "./api/recordingApi";
+export { useMediaRecorder } from "./lib/useMediaRecorder";
+export { useChunkUploader } from "./lib/useChunkUploader";
+export { useRecordingManager } from "./lib/useRecordingManager";
+
+export { VideoPreview } from "./ui/VideoPreview";
+export { RecordingIndicator } from "./ui/RecordingIndicator";
+export { MediaPlayer } from "./ui/MediaPlayer";
+export type { RecordingItem } from "./api/recordingApi";
+
+

--- a/src/features/interview-session/lib/__tests__/useChunkUploader.test.ts
+++ b/src/features/interview-session/lib/__tests__/useChunkUploader.test.ts
@@ -1,0 +1,106 @@
+import { renderHook, act } from "@testing-library/react";
+import { useChunkUploader } from "../useChunkUploader";
+
+const URLS = [
+  { partNumber: 1, url: "https://s3.example.com/part1" },
+  { partNumber: 2, url: "https://s3.example.com/part2" },
+  { partNumber: 3, url: "https://s3.example.com/part3" },
+];
+
+const makeBlob = (size = 1024) => new Blob([new ArrayBuffer(size)]);
+
+describe("useChunkUploader", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("init 후 urlsRef에 즉시 반영되어 uploadChunk가 URL을 찾을 수 있다", async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ ETag: '"abc123"' }),
+    }) as jest.Mock;
+
+    const { result } = renderHook(() => useChunkUploader());
+
+    act(() => { result.current.init(URLS); });
+
+    let part: unknown;
+    await act(async () => {
+      part = await result.current.uploadChunk(makeBlob());
+    });
+
+    expect(part).toEqual({ partNumber: 1, etag: "abc123" });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://s3.example.com/part1",
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+
+  it("연속 uploadChunk 호출 시 partNumber가 순차 증가한다", async () => {
+    globalThis.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: true, headers: new Headers({ ETag: '"e1"' }) })
+      .mockResolvedValueOnce({ ok: true, headers: new Headers({ ETag: '"e2"' }) })
+      .mockResolvedValueOnce({ ok: true, headers: new Headers({ ETag: '"e3"' }) }) as jest.Mock;
+
+    const { result } = renderHook(() => useChunkUploader());
+    act(() => { result.current.init(URLS); });
+
+    const parts = [];
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        parts.push(await result.current.uploadChunk(makeBlob()));
+      });
+    }
+
+    expect(parts).toEqual([
+      { partNumber: 1, etag: "e1" },
+      { partNumber: 2, etag: "e2" },
+      { partNumber: 3, etag: "e3" },
+    ]);
+  });
+
+  it("init 전에 uploadChunk를 호출하면 null을 반환한다", async () => {
+    const { result } = renderHook(() => useChunkUploader());
+
+    let part: unknown;
+    await act(async () => {
+      part = await result.current.uploadChunk(makeBlob());
+    });
+
+    expect(part).toBeNull();
+    expect(result.current.error).toBe("No presigned URL found for current part.");
+  });
+
+  it("fetch 실패 시 재시도 후 null 반환", async () => {
+    globalThis.fetch = jest.fn().mockRejectedValue(new Error("Network error")) as jest.Mock;
+
+    const { result } = renderHook(() => useChunkUploader({ maxRetries: 1, retryBaseDelay: 10 }));
+    act(() => { result.current.init(URLS); });
+
+    let part: unknown;
+    await act(async () => {
+      part = await result.current.uploadChunk(makeBlob());
+    });
+
+    expect(part).toBeNull();
+    expect(result.current.error).toContain("Network error");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("reset 후 상태가 초기화된다", async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ ETag: '"e1"' }),
+    }) as jest.Mock;
+
+    const { result } = renderHook(() => useChunkUploader());
+    act(() => { result.current.init(URLS); });
+
+    await act(async () => { await result.current.uploadChunk(makeBlob()); });
+    expect(result.current.uploadedParts).toHaveLength(1);
+
+    act(() => { result.current.reset(); });
+    expect(result.current.uploadedParts).toHaveLength(0);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/features/interview-session/lib/__tests__/useMediaRecorder.test.ts
+++ b/src/features/interview-session/lib/__tests__/useMediaRecorder.test.ts
@@ -36,8 +36,11 @@ class MockMediaRecorder {
   removeEventListener() { /* noop */ }
 }
 
-const mockTrack = { stop: jest.fn(), kind: "video" as const, enabled: true };
-const mockStream = { getTracks: () => [mockTrack] } as unknown as MediaStream;
+const mockTrack = { stop: jest.fn(), kind: "video" as const, enabled: true, readyState: "live" as const };
+const mockStream = {
+  getTracks: () => [mockTrack],
+  clone: () => ({ getTracks: () => [{ ...mockTrack, stop: jest.fn() }], clone: () => mockStream }),
+} as unknown as MediaStream;
 
 beforeAll(() => {
   Object.defineProperty(globalThis, "MediaRecorder", { value: MockMediaRecorder, writable: true });

--- a/src/features/interview-session/lib/__tests__/useMediaRecorder.test.ts
+++ b/src/features/interview-session/lib/__tests__/useMediaRecorder.test.ts
@@ -1,0 +1,123 @@
+import { renderHook, act } from "@testing-library/react";
+import { useMediaRecorder } from "../useMediaRecorder";
+
+class MockMediaRecorder {
+  state: string = "inactive";
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  private timeslice = 0;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  static isTypeSupported = jest.fn(() => true);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_stream: MediaStream, _options?: { mimeType?: string }) {
+    /* noop */
+  }
+
+  start(timeslice?: number) {
+    this.state = "recording";
+    this.timeslice = timeslice ?? 0;
+    if (this.timeslice > 0) {
+      this.intervalId = setInterval(() => {
+        this.ondataavailable?.({ data: new Blob([new ArrayBuffer(100)]) });
+      }, this.timeslice);
+    }
+  }
+
+  stop() {
+    if (this.intervalId) clearInterval(this.intervalId);
+    this.state = "inactive";
+    this.ondataavailable?.({ data: new Blob([new ArrayBuffer(50)]) });
+    this.onstop?.();
+  }
+
+  addEventListener() { /* noop */ }
+  removeEventListener() { /* noop */ }
+}
+
+const mockTrack = { stop: jest.fn(), kind: "video" as const, enabled: true };
+const mockStream = { getTracks: () => [mockTrack] } as unknown as MediaStream;
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, "MediaRecorder", { value: MockMediaRecorder, writable: true });
+  Object.defineProperty(globalThis.navigator, "mediaDevices", {
+    value: { getUserMedia: jest.fn().mockResolvedValue(mockStream) },
+    writable: true,
+  });
+});
+
+describe("useMediaRecorder", () => {
+  const onChunk = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("externalStream으로 start 시 MediaRecorder가 시작된다", async () => {
+    const { result } = renderHook(() =>
+      useMediaRecorder({ onChunk, externalStream: mockStream, timeslice: 100 }),
+    );
+
+    await act(async () => { await result.current.start(); });
+
+    expect(result.current.isRecording).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("start → stop 시 isRecording=false로 전환된다", async () => {
+    const { result } = renderHook(() =>
+      useMediaRecorder({ onChunk, externalStream: mockStream, timeslice: 50000 }),
+    );
+
+    await act(async () => { await result.current.start(); });
+    expect(result.current.isRecording).toBe(true);
+
+    await act(async () => { await result.current.stop(); });
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it("이미 recording 중이면 start()가 skip된다", async () => {
+    const { result } = renderHook(() =>
+      useMediaRecorder({ onChunk, externalStream: mockStream }),
+    );
+
+    await act(async () => { await result.current.start(); });
+    expect(result.current.isRecording).toBe(true);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    await act(async () => { await result.current.start(); });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("skipped"));
+    warnSpy.mockRestore();
+  });
+
+  it("stop → start → stop 순서가 정상 작동한다 (ref 기반)", async () => {
+    const { result } = renderHook(() =>
+      useMediaRecorder({ onChunk, externalStream: mockStream }),
+    );
+
+    await act(async () => { await result.current.start(); });
+    await act(async () => { await result.current.stop(); });
+    expect(result.current.isRecording).toBe(false);
+
+    await act(async () => { await result.current.start(); });
+    expect(result.current.isRecording).toBe(true);
+
+    await act(async () => { await result.current.stop(); });
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it("시작 실패 시 throw한다", async () => {
+    Object.defineProperty(globalThis, "MediaRecorder", { value: undefined, writable: true });
+
+    const { result } = renderHook(() =>
+      useMediaRecorder({ onChunk, externalStream: mockStream }),
+    );
+
+    await expect(
+      act(async () => { await result.current.start(); }),
+    ).rejects.toThrow();
+
+    Object.defineProperty(globalThis, "MediaRecorder", { value: MockMediaRecorder, writable: true });
+  });
+});

--- a/src/features/interview-session/lib/__tests__/useRecordingManager.test.ts
+++ b/src/features/interview-session/lib/__tests__/useRecordingManager.test.ts
@@ -1,0 +1,158 @@
+import { renderHook, act } from "@testing-library/react";
+
+jest.mock("../../api/recordingApi", () => ({
+  recordingApi: {
+    initiate: jest.fn(),
+    complete: jest.fn(),
+    abort: jest.fn(),
+  },
+}));
+
+import { recordingApi } from "../../api/recordingApi";
+
+const mockInitiate = recordingApi.initiate as jest.Mock;
+const mockComplete = recordingApi.complete as jest.Mock;
+const mockAbort = recordingApi.abort as jest.Mock;
+
+jest.mock("../useMediaRecorder", () => ({
+  useMediaRecorder: () => ({
+    start: mockMediaStart,
+    stop: mockMediaStop,
+    stream: null,
+    isRecording: false,
+    error: null,
+  }),
+}));
+
+jest.mock("../useChunkUploader", () => ({
+  useChunkUploader: () => ({
+    uploadedParts: [],
+    currentPartNumber: 1,
+    isUploading: false,
+    progress: 0,
+    error: null,
+    init: mockUploaderInit,
+    uploadChunk: mockUploadChunk,
+    reset: mockUploaderReset,
+  }),
+}));
+
+const mockMediaStart = jest.fn().mockResolvedValue(undefined);
+const mockMediaStop = jest.fn();
+const mockUploaderInit = jest.fn();
+const mockUploadChunk = jest.fn();
+const mockUploaderReset = jest.fn();
+
+import { useRecordingManager } from "../useRecordingManager";
+
+const INIT_RESPONSE = {
+  recordingId: "rec-123",
+  uploadId: "upload-456",
+  s3Key: "session/turn/test.webm",
+  presignedUrls: [{ partNumber: 1, url: "https://s3/part1" }],
+  singleUploadUrl: "https://s3/single-put",
+};
+
+describe("useRecordingManager", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInitiate.mockResolvedValue(INIT_RESPONSE);
+    mockComplete.mockResolvedValue({ recordingId: "rec-123", status: "completed" });
+    mockAbort.mockResolvedValue(undefined);
+    mockMediaStop.mockResolvedValue(new Blob([new ArrayBuffer(1024)]));
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: true }) as jest.Mock;
+  });
+
+  it("startRecording: initiate API → chunkUploader.init → mediaRecorder.start", async () => {
+    const { result } = renderHook(() =>
+      useRecordingManager({ sessionUuid: "sess-1" }),
+    );
+
+    await act(async () => { await result.current.startRecording(10); });
+
+    expect(mockInitiate).toHaveBeenCalledWith("sess-1", 10, "video");
+    expect(mockUploaderInit).toHaveBeenCalledWith(INIT_RESPONSE.presignedUrls);
+    expect(mockMediaStart).toHaveBeenCalled();
+  });
+
+  it("stopRecording (단일 업로드): parts=0이면 recordingApi.upload 후 complete(singleUpload=true)", async () => {
+    const mockUpload = jest.fn().mockResolvedValue({ status: "uploaded" });
+    (recordingApi as Record<string, unknown>).upload = mockUpload;
+
+    const finalBlob = new Blob([new ArrayBuffer(2048)]);
+    mockMediaStop.mockResolvedValue(finalBlob);
+    mockUploadChunk.mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useRecordingManager({ sessionUuid: "sess-1" }),
+    );
+
+    await act(async () => { await result.current.startRecording(10); });
+    await act(async () => { await result.current.stopRecording(); });
+
+    expect(mockUpload).toHaveBeenCalledWith("rec-123", finalBlob);
+    expect(mockComplete).toHaveBeenCalledWith(
+      "rec-123",
+      [],
+      expect.any(String),
+      expect.any(Number),
+      true,
+    );
+  });
+
+  it("stopRecording: complete API에 올바른 타임스탬프와 duration을 전달한다", async () => {
+    const mockUpload = jest.fn().mockResolvedValue({ status: "uploaded" });
+    (recordingApi as Record<string, unknown>).upload = mockUpload;
+
+    const finalBlob = new Blob([new ArrayBuffer(2048)]);
+    mockMediaStop.mockResolvedValue(finalBlob);
+
+    const { result } = renderHook(() =>
+      useRecordingManager({ sessionUuid: "sess-1" }),
+    );
+
+    await act(async () => { await result.current.startRecording(10); });
+    await act(async () => { await result.current.stopRecording(); });
+
+    expect(mockComplete).toHaveBeenCalled();
+    const [, , endTimestamp, durationMs] = mockComplete.mock.calls[0];
+    expect(new Date(endTimestamp).getTime()).toBeGreaterThan(0);
+    expect(durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("abortRecording: abort API 호출 + 상태 초기화", async () => {
+    const { result } = renderHook(() =>
+      useRecordingManager({ sessionUuid: "sess-1" }),
+    );
+
+    await act(async () => { await result.current.startRecording(10); });
+    await act(async () => { await result.current.abortRecording(); });
+
+    expect(mockAbort).toHaveBeenCalledWith("rec-123");
+    expect(mockUploaderReset).toHaveBeenCalled();
+  });
+
+  it("enabled=false이면 startRecording이 무시된다", async () => {
+    const { result } = renderHook(() =>
+      useRecordingManager({ sessionUuid: "sess-1", enabled: false }),
+    );
+
+    await act(async () => { await result.current.startRecording(10); });
+
+    expect(mockInitiate).not.toHaveBeenCalled();
+  });
+
+  it("stopRecording: finalBlob=null + parts=0 → abort", async () => {
+    mockMediaStop.mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useRecordingManager({ sessionUuid: "sess-1" }),
+    );
+
+    await act(async () => { await result.current.startRecording(10); });
+    await act(async () => { await result.current.stopRecording(); });
+
+    expect(mockAbort).toHaveBeenCalledWith("rec-123");
+    expect(mockComplete).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/interview-session/lib/useChunkUploader.ts
+++ b/src/features/interview-session/lib/useChunkUploader.ts
@@ -79,7 +79,6 @@ export function useChunkUploader({
           const response = await fetch(url, {
             method: "PUT",
             body: blob,
-            headers: { "Content-Type": blob.type },
           });
 
           if (!response.ok) {
@@ -96,6 +95,7 @@ export function useChunkUploader({
           return part;
         } catch (err) {
           attempt++;
+          console.warn(`[ChunkUploader] Part ${partNumber} attempt ${attempt}/${maxRetries} failed:`, err);
           if (attempt > maxRetries) {
             setError(err instanceof Error ? err.message : "Upload failed after retries.");
             setIsUploading(false);

--- a/src/features/interview-session/lib/useChunkUploader.ts
+++ b/src/features/interview-session/lib/useChunkUploader.ts
@@ -39,6 +39,7 @@ export function useChunkUploader({
 
   const urlsRef = useRef<PresignedUrl[]>([]);
   const partCounterRef = useRef<number>(1);
+  const uploadLockRef = useRef<boolean>(false);
 
   const progress = urlsRef.current.length > 0 ? (uploadedParts.length / urlsRef.current.length) * 100 : 0;
 
@@ -60,57 +61,66 @@ export function useChunkUploader({
 
   const uploadChunk = useCallback(
     async (blob: Blob): Promise<UploadedPart | null> => {
-      setIsUploading(true);
-      setError(null);
+      while (uploadLockRef.current) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      uploadLockRef.current = true;
 
-      const currentPart = partCounterRef.current;
-      const targetUrlObj = urlsRef.current.find((u) => u.partNumber === currentPart);
-      if (!targetUrlObj) {
-        console.warn(`[ChunkUploader] No presigned URL for part ${currentPart}, urls count: ${urlsRef.current.length}`);
-        setError("No presigned URL found for current part.");
+      try {
+        setIsUploading(true);
+        setError(null);
+
+        const currentPart = partCounterRef.current;
+        const targetUrlObj = urlsRef.current.find((u) => u.partNumber === currentPart);
+        if (!targetUrlObj) {
+          console.warn(`[ChunkUploader] No presigned URL for part ${currentPart}, urls count: ${urlsRef.current.length}`);
+          setError("No presigned URL found for current part.");
+          setIsUploading(false);
+          return null;
+        }
+
+        const { url, partNumber } = targetUrlObj;
+
+        let attempt = 0;
+
+        while (attempt <= maxRetries) {
+          try {
+            const response = await fetch(url, {
+              method: "PUT",
+              body: blob,
+            });
+
+            if (!response.ok) {
+              throw new Error(`Upload failed with status ${response.status}`);
+            }
+
+            let etag = response.headers.get("ETag") ?? "";
+            etag = etag.replace(/"/g, "");
+
+            const part: UploadedPart = { partNumber, etag };
+            setUploadedParts((prev) => [...prev, part]);
+            partCounterRef.current = currentPart + 1;
+            setIsUploading(false);
+            return part;
+          } catch (err) {
+            attempt++;
+            console.warn(`[ChunkUploader] Part ${partNumber} attempt ${attempt}/${maxRetries} failed:`, err);
+            if (attempt > maxRetries) {
+              setError(err instanceof Error ? err.message : "Upload failed after retries.");
+              setIsUploading(false);
+              return null;
+            }
+            await new Promise((resolve) =>
+              setTimeout(resolve, retryBaseDelay * Math.pow(2, attempt - 1))
+            );
+          }
+        }
+
         setIsUploading(false);
         return null;
+      } finally {
+        uploadLockRef.current = false;
       }
-
-      const { url, partNumber } = targetUrlObj;
-
-      let attempt = 0;
-
-      while (attempt <= maxRetries) {
-        try {
-          const response = await fetch(url, {
-            method: "PUT",
-            body: blob,
-          });
-
-          if (!response.ok) {
-            throw new Error(`Upload failed with status ${response.status}`);
-          }
-
-          let etag = response.headers.get("ETag") ?? "";
-          etag = etag.replace(/"/g, "");
-
-          const part: UploadedPart = { partNumber, etag };
-          setUploadedParts((prev) => [...prev, part]);
-          partCounterRef.current = currentPart + 1;
-          setIsUploading(false);
-          return part;
-        } catch (err) {
-          attempt++;
-          console.warn(`[ChunkUploader] Part ${partNumber} attempt ${attempt}/${maxRetries} failed:`, err);
-          if (attempt > maxRetries) {
-            setError(err instanceof Error ? err.message : "Upload failed after retries.");
-            setIsUploading(false);
-            return null;
-          }
-          await new Promise((resolve) =>
-            setTimeout(resolve, retryBaseDelay * Math.pow(2, attempt - 1))
-          );
-        }
-      }
-
-      setIsUploading(false);
-      return null;
     },
     [maxRetries, retryBaseDelay]
   );

--- a/src/features/interview-session/lib/useChunkUploader.ts
+++ b/src/features/interview-session/lib/useChunkUploader.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 
 interface UseChunkUploaderOptions {
   maxRetries?: number;
@@ -33,27 +33,27 @@ export function useChunkUploader({
   maxRetries = 3,
   retryBaseDelay = 1000,
 }: UseChunkUploaderOptions = {}): UseChunkUploaderReturn {
-  const [urls, setUrls] = useState<PresignedUrl[]>([]);
   const [uploadedParts, setUploadedParts] = useState<{ partNumber: number; etag: string }[]>([]);
-  const [currentPartNumber, setCurrentPartNumber] = useState<number>(1);
   const [isUploading, setIsUploading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  const progress = urls.length > 0 ? (uploadedParts.length / urls.length) * 100 : 0;
+  const urlsRef = useRef<PresignedUrl[]>([]);
+  const partCounterRef = useRef<number>(1);
+
+  const progress = urlsRef.current.length > 0 ? (uploadedParts.length / urlsRef.current.length) * 100 : 0;
 
   const init = useCallback((presignedUrls: PresignedUrl[]) => {
-    setUrls(presignedUrls);
+    urlsRef.current = presignedUrls;
+    partCounterRef.current = presignedUrls.length > 0 ? Math.min(...presignedUrls.map(p => p.partNumber)) : 1;
     setUploadedParts([]);
-    const initialPart = presignedUrls.length > 0 ? Math.min(...presignedUrls.map(p => p.partNumber)) : 1;
-    setCurrentPartNumber(initialPart);
     setIsUploading(false);
     setError(null);
   }, []);
 
   const reset = useCallback(() => {
-    setUrls([]);
+    urlsRef.current = [];
+    partCounterRef.current = 1;
     setUploadedParts([]);
-    setCurrentPartNumber(1);
     setIsUploading(false);
     setError(null);
   }, []);
@@ -63,8 +63,10 @@ export function useChunkUploader({
       setIsUploading(true);
       setError(null);
 
-      const targetUrlObj = urls.find((u) => u.partNumber === currentPartNumber);
+      const currentPart = partCounterRef.current;
+      const targetUrlObj = urlsRef.current.find((u) => u.partNumber === currentPart);
       if (!targetUrlObj) {
+        console.warn(`[ChunkUploader] No presigned URL for part ${currentPart}, urls count: ${urlsRef.current.length}`);
         setError("No presigned URL found for current part.");
         setIsUploading(false);
         return null;
@@ -90,7 +92,7 @@ export function useChunkUploader({
 
           const part: UploadedPart = { partNumber, etag };
           setUploadedParts((prev) => [...prev, part]);
-          setCurrentPartNumber((prev) => prev + 1);
+          partCounterRef.current = currentPart + 1;
           setIsUploading(false);
           return part;
         } catch (err) {
@@ -110,12 +112,12 @@ export function useChunkUploader({
       setIsUploading(false);
       return null;
     },
-    [urls, currentPartNumber, maxRetries, retryBaseDelay]
+    [maxRetries, retryBaseDelay]
   );
 
   return {
     uploadedParts,
-    currentPartNumber,
+    currentPartNumber: partCounterRef.current,
     isUploading,
     progress,
     error,

--- a/src/features/interview-session/lib/useChunkUploader.ts
+++ b/src/features/interview-session/lib/useChunkUploader.ts
@@ -1,0 +1,126 @@
+import { useState, useCallback } from "react";
+
+interface UseChunkUploaderOptions {
+  maxRetries?: number;
+  retryBaseDelay?: number;
+}
+
+interface ChunkUploadState {
+  uploadedParts: { partNumber: number; etag: string }[];
+  currentPartNumber: number;
+  isUploading: boolean;
+  progress: number;
+  error: string | null;
+}
+
+interface PresignedUrl {
+  partNumber: number;
+  url: string;
+}
+
+export interface UploadedPart {
+  partNumber: number;
+  etag: string;
+}
+
+interface UseChunkUploaderReturn extends ChunkUploadState {
+  init: (presignedUrls: PresignedUrl[]) => void;
+  uploadChunk: (blob: Blob) => Promise<UploadedPart | null>;
+  reset: () => void;
+}
+
+export function useChunkUploader({
+  maxRetries = 3,
+  retryBaseDelay = 1000,
+}: UseChunkUploaderOptions = {}): UseChunkUploaderReturn {
+  const [urls, setUrls] = useState<PresignedUrl[]>([]);
+  const [uploadedParts, setUploadedParts] = useState<{ partNumber: number; etag: string }[]>([]);
+  const [currentPartNumber, setCurrentPartNumber] = useState<number>(1);
+  const [isUploading, setIsUploading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const progress = urls.length > 0 ? (uploadedParts.length / urls.length) * 100 : 0;
+
+  const init = useCallback((presignedUrls: PresignedUrl[]) => {
+    setUrls(presignedUrls);
+    setUploadedParts([]);
+    const initialPart = presignedUrls.length > 0 ? Math.min(...presignedUrls.map(p => p.partNumber)) : 1;
+    setCurrentPartNumber(initialPart);
+    setIsUploading(false);
+    setError(null);
+  }, []);
+
+  const reset = useCallback(() => {
+    setUrls([]);
+    setUploadedParts([]);
+    setCurrentPartNumber(1);
+    setIsUploading(false);
+    setError(null);
+  }, []);
+
+  const uploadChunk = useCallback(
+    async (blob: Blob): Promise<UploadedPart | null> => {
+      setIsUploading(true);
+      setError(null);
+
+      const targetUrlObj = urls.find((u) => u.partNumber === currentPartNumber);
+      if (!targetUrlObj) {
+        setError("No presigned URL found for current part.");
+        setIsUploading(false);
+        return null;
+      }
+
+      const { url, partNumber } = targetUrlObj;
+
+      let attempt = 0;
+
+      while (attempt <= maxRetries) {
+        try {
+          const response = await fetch(url, {
+            method: "PUT",
+            body: blob,
+            headers: { "Content-Type": blob.type },
+          });
+
+          if (!response.ok) {
+            throw new Error(`Upload failed with status ${response.status}`);
+          }
+
+          let etag = response.headers.get("ETag") ?? "";
+          etag = etag.replace(/"/g, "");
+
+          const part: UploadedPart = { partNumber, etag };
+          setUploadedParts((prev) => [...prev, part]);
+          setCurrentPartNumber((prev) => prev + 1);
+          setIsUploading(false);
+          return part;
+        } catch (err) {
+          attempt++;
+          if (attempt > maxRetries) {
+            setError(err instanceof Error ? err.message : "Upload failed after retries.");
+            setIsUploading(false);
+            return null;
+          }
+          await new Promise((resolve) =>
+            setTimeout(resolve, retryBaseDelay * Math.pow(2, attempt - 1))
+          );
+        }
+      }
+
+      setIsUploading(false);
+      return null;
+    },
+    [urls, currentPartNumber, maxRetries, retryBaseDelay]
+  );
+
+  return {
+    uploadedParts,
+    currentPartNumber,
+    isUploading,
+    progress,
+    error,
+    init,
+    uploadChunk,
+    reset,
+  };
+}

--- a/src/features/interview-session/lib/useMediaRecorder.ts
+++ b/src/features/interview-session/lib/useMediaRecorder.ts
@@ -1,0 +1,137 @@
+import { useRef, useCallback, useState, useEffect } from "react";
+
+interface UseMediaRecorderOptions {
+  timeslice?: number;
+  onChunk: (blob: Blob) => void;
+  mimeType?: string;
+  externalStream?: MediaStream | null;
+}
+
+interface UseMediaRecorderReturn {
+  start: () => Promise<void>;
+  stop: () => Promise<Blob | null>;
+  stream: MediaStream | null;
+  isRecording: boolean;
+  error: string | null;
+}
+
+export function useMediaRecorder({
+  timeslice = 5000,
+  onChunk,
+  mimeType,
+  externalStream,
+}: UseMediaRecorderOptions): UseMediaRecorderReturn {
+  const [stream, setStream] = useState<MediaStream | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const onChunkRef = useRef(onChunk);
+  const finalChunkResolveRef = useRef<((blob: Blob | null) => void) | null>(null);
+  const isStartingRef = useRef(false);
+
+  useEffect(() => {
+    onChunkRef.current = onChunk;
+  }, [onChunk]);
+
+  const start = useCallback(async () => {
+    if (isStartingRef.current || isRecording) return;
+    if (typeof navigator === "undefined" || !navigator.mediaDevices || typeof MediaRecorder === "undefined") {
+      setError("이 브라우저에서는 녹화를 지원하지 않습니다.");
+      setIsRecording(false);
+      return;
+    }
+
+    isStartingRef.current = true;
+    try {
+      const mediaStream = externalStream ?? await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+      setStream(mediaStream);
+
+      let selectedMimeType = mimeType;
+      if (!selectedMimeType) {
+        const types = ["video/webm;codecs=vp8,opus", "video/webm"];
+        selectedMimeType = types.find((type) => MediaRecorder.isTypeSupported(type)) || "";
+      }
+
+      try {
+        const recorder = new MediaRecorder(mediaStream, {
+          mimeType: selectedMimeType,
+        });
+
+        recorder.ondataavailable = (event) => {
+          if (event.data && event.data.size > 0) {
+            if (recorder.state === "inactive" && finalChunkResolveRef.current) {
+              finalChunkResolveRef.current(event.data);
+              finalChunkResolveRef.current = null;
+            } else {
+              onChunkRef.current(event.data);
+            }
+          } else if (recorder.state === "inactive" && finalChunkResolveRef.current) {
+            finalChunkResolveRef.current(null);
+            finalChunkResolveRef.current = null;
+          }
+        };
+
+        recorder.onstop = () => {
+          if (finalChunkResolveRef.current) {
+            finalChunkResolveRef.current(null);
+            finalChunkResolveRef.current = null;
+          }
+        };
+
+        recorderRef.current = recorder;
+        recorder.start(timeslice);
+        setIsRecording(true);
+        setError(null);
+      } catch {
+        if (!externalStream) {
+          mediaStream.getTracks().forEach((track) => track.stop());
+        }
+        setStream(null);
+        setError("이 브라우저에서는 녹화를 지원하지 않습니다.");
+        setIsRecording(false);
+      }
+    } catch {
+      setError("카메라/마이크 권한이 필요합니다.");
+      setIsRecording(false);
+    } finally {
+      isStartingRef.current = false;
+    }
+  }, [timeslice, mimeType, externalStream, isRecording]);
+
+  const stop = useCallback((): Promise<Blob | null> => {
+    return new Promise((resolve) => {
+      if (!recorderRef.current || recorderRef.current.state === "inactive") {
+        if (stream && !externalStream) {
+          stream.getTracks().forEach((track) => track.stop());
+        }
+        setIsRecording(false);
+        resolve(null);
+        return;
+      }
+
+      finalChunkResolveRef.current = (blob) => {
+        if (stream && !externalStream) {
+          stream.getTracks().forEach((track) => track.stop());
+        }
+        setIsRecording(false);
+        resolve(blob);
+      };
+
+      recorderRef.current.stop();
+    });
+  }, [stream, externalStream]);
+
+  useEffect(() => {
+    return () => {
+      if (recorderRef.current && recorderRef.current.state !== "inactive") {
+        recorderRef.current.stop();
+      }
+      if (stream && !externalStream) {
+        stream.getTracks().forEach((track) => track.stop());
+      }
+    };
+  }, [stream, externalStream]);
+
+  return { start, stop, stream, isRecording, error };
+}

--- a/src/features/interview-session/lib/useMediaRecorder.ts
+++ b/src/features/interview-session/lib/useMediaRecorder.ts
@@ -36,10 +36,14 @@ export function useMediaRecorder({
   }, [onChunk]);
 
   const start = useCallback(async () => {
-    if (isStartingRef.current || isRecordingRef.current) return;
-    if (typeof navigator === "undefined" || !navigator.mediaDevices || typeof MediaRecorder === "undefined") {
-      setError("이 브라우저에서는 녹화를 지원하지 않습니다.");
+    if (isStartingRef.current || isRecordingRef.current) {
+      console.warn("[MediaRecorder] start() skipped: already starting or recording");
       return;
+    }
+    if (typeof navigator === "undefined" || !navigator.mediaDevices || typeof MediaRecorder === "undefined") {
+      const msg = "이 브라우저에서는 녹화를 지원하지 않습니다.";
+      setError(msg);
+      throw new Error(msg);
     }
 
     isStartingRef.current = true;
@@ -53,50 +57,49 @@ export function useMediaRecorder({
         selectedMimeType = types.find((type) => MediaRecorder.isTypeSupported(type)) || "";
       }
 
-      try {
-        const recorder = new MediaRecorder(mediaStream, {
-          mimeType: selectedMimeType,
-        });
+      const recorder = new MediaRecorder(mediaStream, {
+        mimeType: selectedMimeType,
+      });
 
-        recorder.ondataavailable = (event) => {
-          if (event.data && event.data.size > 0) {
-            if (recorder.state === "inactive" && finalChunkResolveRef.current) {
-              finalChunkResolveRef.current(event.data);
-              finalChunkResolveRef.current = null;
-            } else {
-              onChunkRef.current(event.data);
-            }
-          } else if (recorder.state === "inactive" && finalChunkResolveRef.current) {
-            finalChunkResolveRef.current(null);
+      recorder.ondataavailable = (event) => {
+        if (event.data && event.data.size > 0) {
+          if (recorder.state === "inactive" && finalChunkResolveRef.current) {
+            finalChunkResolveRef.current(event.data);
             finalChunkResolveRef.current = null;
+          } else {
+            onChunkRef.current(event.data);
           }
-        };
-
-        recorder.onstop = () => {
-          if (finalChunkResolveRef.current) {
-            finalChunkResolveRef.current(null);
-            finalChunkResolveRef.current = null;
-          }
-        };
-
-        recorderRef.current = recorder;
-        recorder.start(timeslice);
-        isRecordingRef.current = true;
-        setIsRecording(true);
-        setError(null);
-      } catch {
-        if (!externalStream) {
-          mediaStream.getTracks().forEach((track) => track.stop());
+        } else if (recorder.state === "inactive" && finalChunkResolveRef.current) {
+          finalChunkResolveRef.current(null);
+          finalChunkResolveRef.current = null;
         }
-        setStream(null);
-        setError("이 브라우저에서는 녹화를 지원하지 않습니다.");
+      };
+
+      recorder.onstop = () => {
+        if (finalChunkResolveRef.current) {
+          finalChunkResolveRef.current(null);
+          finalChunkResolveRef.current = null;
+        }
+      };
+
+      recorderRef.current = recorder;
+      recorder.start(timeslice);
+      isRecordingRef.current = true;
+      setIsRecording(true);
+      setError(null);
+      console.info("[MediaRecorder] started, timeslice=%dms, mimeType=%s", timeslice, selectedMimeType);
+    } catch (err) {
+      if (!externalStream && stream) {
+        stream.getTracks().forEach((track) => track.stop());
       }
-    } catch {
-      setError("카메라/마이크 권한이 필요합니다.");
+      setStream(null);
+      const msg = err instanceof Error ? err.message : "녹화 시작 실패";
+      setError(msg);
+      throw err;
     } finally {
       isStartingRef.current = false;
     }
-  }, [timeslice, mimeType, externalStream]);
+  }, [timeslice, mimeType, externalStream, stream]);
 
   const stop = useCallback((): Promise<Blob | null> => {
     return new Promise((resolve) => {

--- a/src/features/interview-session/lib/useMediaRecorder.ts
+++ b/src/features/interview-session/lib/useMediaRecorder.ts
@@ -29,16 +29,16 @@ export function useMediaRecorder({
   const onChunkRef = useRef(onChunk);
   const finalChunkResolveRef = useRef<((blob: Blob | null) => void) | null>(null);
   const isStartingRef = useRef(false);
+  const isRecordingRef = useRef(false);
 
   useEffect(() => {
     onChunkRef.current = onChunk;
   }, [onChunk]);
 
   const start = useCallback(async () => {
-    if (isStartingRef.current || isRecording) return;
+    if (isStartingRef.current || isRecordingRef.current) return;
     if (typeof navigator === "undefined" || !navigator.mediaDevices || typeof MediaRecorder === "undefined") {
       setError("이 브라우저에서는 녹화를 지원하지 않습니다.");
-      setIsRecording(false);
       return;
     }
 
@@ -81,6 +81,7 @@ export function useMediaRecorder({
 
         recorderRef.current = recorder;
         recorder.start(timeslice);
+        isRecordingRef.current = true;
         setIsRecording(true);
         setError(null);
       } catch {
@@ -89,15 +90,13 @@ export function useMediaRecorder({
         }
         setStream(null);
         setError("이 브라우저에서는 녹화를 지원하지 않습니다.");
-        setIsRecording(false);
       }
     } catch {
       setError("카메라/마이크 권한이 필요합니다.");
-      setIsRecording(false);
     } finally {
       isStartingRef.current = false;
     }
-  }, [timeslice, mimeType, externalStream, isRecording]);
+  }, [timeslice, mimeType, externalStream]);
 
   const stop = useCallback((): Promise<Blob | null> => {
     return new Promise((resolve) => {
@@ -105,6 +104,7 @@ export function useMediaRecorder({
         if (stream && !externalStream) {
           stream.getTracks().forEach((track) => track.stop());
         }
+        isRecordingRef.current = false;
         setIsRecording(false);
         resolve(null);
         return;
@@ -114,6 +114,7 @@ export function useMediaRecorder({
         if (stream && !externalStream) {
           stream.getTracks().forEach((track) => track.stop());
         }
+        isRecordingRef.current = false;
         setIsRecording(false);
         resolve(blob);
       };

--- a/src/features/interview-session/lib/useMediaRecorder.ts
+++ b/src/features/interview-session/lib/useMediaRecorder.ts
@@ -135,7 +135,7 @@ export function useMediaRecorder({
     } finally {
       isStartingRef.current = false;
     }
-  }, [timeslice, mimeType, externalStream, stream]);
+  }, [timeslice, mimeType, externalStream]);
 
   const stop = useCallback((): Promise<Blob | null> => {
     console.info("[MediaRecorder] stop() called, recorderState=%s", recorderRef.current?.state ?? "null");
@@ -171,7 +171,7 @@ export function useMediaRecorder({
 
       recorderRef.current.stop();
     });
-  }, [stream, externalStream]);
+  }, [externalStream]);
 
   useEffect(() => {
     return () => {

--- a/src/features/interview-session/lib/useMediaRecorder.ts
+++ b/src/features/interview-session/lib/useMediaRecorder.ts
@@ -15,6 +15,8 @@ interface UseMediaRecorderReturn {
   error: string | null;
 }
 
+const MIN_S3_PART_SIZE = 5 * 1024 * 1024;
+
 export function useMediaRecorder({
   timeslice = 5000,
   onChunk,
@@ -30,6 +32,7 @@ export function useMediaRecorder({
   const finalChunkResolveRef = useRef<((blob: Blob | null) => void) | null>(null);
   const isStartingRef = useRef(false);
   const isRecordingRef = useRef(false);
+  const bufferRef = useRef<Blob[]>([]);
 
   useEffect(() => {
     onChunkRef.current = onChunk;
@@ -48,7 +51,8 @@ export function useMediaRecorder({
 
     isStartingRef.current = true;
     try {
-      const mediaStream = externalStream ?? await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+      const sourceStream = externalStream ?? await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+      const mediaStream = sourceStream.clone();
       setStream(mediaStream);
 
       let selectedMimeType = mimeType;
@@ -62,15 +66,33 @@ export function useMediaRecorder({
       });
 
       recorder.ondataavailable = (event) => {
+        console.info("[MediaRecorder] ondataavailable size=%d state=%s", event.data?.size ?? 0, recorder.state);
         if (event.data && event.data.size > 0) {
           if (recorder.state === "inactive" && finalChunkResolveRef.current) {
-            finalChunkResolveRef.current(event.data);
+            const allChunks = [...bufferRef.current, event.data];
+            bufferRef.current = [];
+            const merged = new Blob(allChunks, { type: event.data.type });
+            finalChunkResolveRef.current(merged);
             finalChunkResolveRef.current = null;
           } else {
-            onChunkRef.current(event.data);
+            bufferRef.current.push(event.data);
+            const bufferSize = bufferRef.current.reduce((sum, b) => sum + b.size, 0);
+            if (bufferSize >= MIN_S3_PART_SIZE) {
+              const merged = new Blob(bufferRef.current, { type: event.data.type });
+              bufferRef.current = [];
+              console.info("[MediaRecorder] flushing buffer, size=%d", merged.size);
+              onChunkRef.current(merged);
+            }
           }
         } else if (recorder.state === "inactive" && finalChunkResolveRef.current) {
-          finalChunkResolveRef.current(null);
+          const allChunks = bufferRef.current;
+          bufferRef.current = [];
+          if (allChunks.length > 0) {
+            const merged = new Blob(allChunks);
+            finalChunkResolveRef.current(merged);
+          } else {
+            finalChunkResolveRef.current(null);
+          }
           finalChunkResolveRef.current = null;
         }
       };
@@ -83,11 +105,14 @@ export function useMediaRecorder({
       };
 
       recorderRef.current = recorder;
+      bufferRef.current = [];
       recorder.start(timeslice);
       isRecordingRef.current = true;
       setIsRecording(true);
       setError(null);
-      console.info("[MediaRecorder] started, timeslice=%dms, mimeType=%s", timeslice, selectedMimeType);
+      console.info("[MediaRecorder] started, timeslice=%dms, mimeType=%s, tracks=%o",
+        timeslice, selectedMimeType,
+        mediaStream.getTracks().map(t => ({ kind: t.kind, readyState: t.readyState, enabled: t.enabled })));
     } catch (err) {
       if (!externalStream && stream) {
         stream.getTracks().forEach((track) => track.stop());
@@ -102,6 +127,7 @@ export function useMediaRecorder({
   }, [timeslice, mimeType, externalStream, stream]);
 
   const stop = useCallback((): Promise<Blob | null> => {
+    console.info("[MediaRecorder] stop() called, recorderState=%s", recorderRef.current?.state ?? "null");
     return new Promise((resolve) => {
       if (!recorderRef.current || recorderRef.current.state === "inactive") {
         if (stream && !externalStream) {
@@ -131,11 +157,8 @@ export function useMediaRecorder({
       if (recorderRef.current && recorderRef.current.state !== "inactive") {
         recorderRef.current.stop();
       }
-      if (stream && !externalStream) {
-        stream.getTracks().forEach((track) => track.stop());
-      }
     };
-  }, [stream, externalStream]);
+  }, []);
 
   return { start, stop, stream, isRecording, error };
 }

--- a/src/features/interview-session/lib/useMediaRecorder.ts
+++ b/src/features/interview-session/lib/useMediaRecorder.ts
@@ -33,6 +33,8 @@ export function useMediaRecorder({
   const isStartingRef = useRef(false);
   const isRecordingRef = useRef(false);
   const bufferRef = useRef<Blob[]>([]);
+  const sourceStreamRef = useRef<MediaStream | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
 
   useEffect(() => {
     onChunkRef.current = onChunk;
@@ -52,8 +54,12 @@ export function useMediaRecorder({
     isStartingRef.current = true;
     try {
       const sourceStream = externalStream ?? await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+      if (!externalStream) {
+        sourceStreamRef.current = sourceStream;
+      }
       const mediaStream = sourceStream.clone();
       setStream(mediaStream);
+      streamRef.current = mediaStream;
 
       let selectedMimeType = mimeType;
       if (!selectedMimeType) {
@@ -114,9 +120,14 @@ export function useMediaRecorder({
         timeslice, selectedMimeType,
         mediaStream.getTracks().map(t => ({ kind: t.kind, readyState: t.readyState, enabled: t.enabled })));
     } catch (err) {
-      if (!externalStream && stream) {
-        stream.getTracks().forEach((track) => track.stop());
+      if (!externalStream && streamRef.current) {
+        streamRef.current.getTracks().forEach((track) => track.stop());
       }
+      if (sourceStreamRef.current) {
+        sourceStreamRef.current.getTracks().forEach((t) => t.stop());
+        sourceStreamRef.current = null;
+      }
+      streamRef.current = null;
       setStream(null);
       const msg = err instanceof Error ? err.message : "녹화 시작 실패";
       setError(msg);
@@ -130,9 +141,14 @@ export function useMediaRecorder({
     console.info("[MediaRecorder] stop() called, recorderState=%s", recorderRef.current?.state ?? "null");
     return new Promise((resolve) => {
       if (!recorderRef.current || recorderRef.current.state === "inactive") {
-        if (stream && !externalStream) {
-          stream.getTracks().forEach((track) => track.stop());
+        if (streamRef.current && !externalStream) {
+          streamRef.current.getTracks().forEach((track) => track.stop());
         }
+        if (sourceStreamRef.current) {
+          sourceStreamRef.current.getTracks().forEach((t) => t.stop());
+          sourceStreamRef.current = null;
+        }
+        streamRef.current = null;
         isRecordingRef.current = false;
         setIsRecording(false);
         resolve(null);
@@ -140,9 +156,14 @@ export function useMediaRecorder({
       }
 
       finalChunkResolveRef.current = (blob) => {
-        if (stream && !externalStream) {
-          stream.getTracks().forEach((track) => track.stop());
+        if (streamRef.current && !externalStream) {
+          streamRef.current.getTracks().forEach((track) => track.stop());
         }
+        if (sourceStreamRef.current) {
+          sourceStreamRef.current.getTracks().forEach((t) => t.stop());
+          sourceStreamRef.current = null;
+        }
+        streamRef.current = null;
         isRecordingRef.current = false;
         setIsRecording(false);
         resolve(blob);
@@ -156,6 +177,14 @@ export function useMediaRecorder({
     return () => {
       if (recorderRef.current && recorderRef.current.state !== "inactive") {
         recorderRef.current.stop();
+      }
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((t) => t.stop());
+        streamRef.current = null;
+      }
+      if (sourceStreamRef.current) {
+        sourceStreamRef.current.getTracks().forEach((t) => t.stop());
+        sourceStreamRef.current = null;
       }
     };
   }, []);

--- a/src/features/interview-session/lib/useRecordingManager.ts
+++ b/src/features/interview-session/lib/useRecordingManager.ts
@@ -29,6 +29,7 @@ export function useRecordingManager({
   const [managerError, setManagerError] = useState<string | null>(null);
 
   const recordingIdRef = useRef<string | null>(null);
+  const singleUploadUrlRef = useRef<string | null>(null);
   const startTimeRef = useRef<number | null>(null);
   const isInitializedRef = useRef(false);
   const collectedPartsRef = useRef<UploadedPart[]>([]);
@@ -63,6 +64,15 @@ export function useRecordingManager({
     }
   }, [mediaRecorder.error]);
 
+  const resetRefs = useCallback(() => {
+    recordingIdRef.current = null;
+    singleUploadUrlRef.current = null;
+    startTimeRef.current = null;
+    isInitializedRef.current = false;
+    collectedPartsRef.current = [];
+    chunkUploader.reset();
+  }, [chunkUploader]);
+
   const abortRecording = useCallback(async () => {
     if (recordingIdRef.current) {
       await recordingApi.abort(recordingIdRef.current).catch(() => {});
@@ -70,12 +80,8 @@ export function useRecordingManager({
     if (mediaRecorder.isRecording) {
       await mediaRecorder.stop();
     }
-    recordingIdRef.current = null;
-    startTimeRef.current = null;
-    isInitializedRef.current = false;
-    collectedPartsRef.current = [];
-    chunkUploader.reset();
-  }, [mediaRecorder, chunkUploader]);
+    resetRefs();
+  }, [mediaRecorder, resetRefs]);
 
   const startRecording = useCallback(
     async (turnId: number) => {
@@ -87,6 +93,7 @@ export function useRecordingManager({
       try {
         const initRes = await recordingApi.initiate(sessionUuid, turnId, "video");
         recordingIdRef.current = initRes.recordingId;
+        singleUploadUrlRef.current = initRes.singleUploadUrl;
 
         try {
           chunkUploader.init(initRes.presignedUrls);
@@ -99,6 +106,7 @@ export function useRecordingManager({
           setRecordingEnabled(false);
           await recordingApi.abort(recordingIdRef.current).catch(() => {});
           recordingIdRef.current = null;
+          singleUploadUrlRef.current = null;
           throw innerErr;
         }
       } catch (err) {
@@ -123,7 +131,9 @@ export function useRecordingManager({
     try {
       const finalBlob = await mediaRecorder.stop();
 
-      if (finalBlob && finalBlob.size > 0) {
+      const hasParts = collectedPartsRef.current.length > 0;
+
+      if (hasParts && finalBlob && finalBlob.size > 0) {
         const finalPart = await chunkUploader.uploadChunk(finalBlob);
         if (finalPart) {
           collectedPartsRef.current = [...collectedPartsRef.current, finalPart];
@@ -131,14 +141,21 @@ export function useRecordingManager({
       }
 
       const parts = collectedPartsRef.current;
-      if (parts.length === 0) {
+      const useSingleUpload = parts.length === 0 && finalBlob && finalBlob.size > 0;
+
+      if (parts.length === 0 && !useSingleUpload) {
         setManagerError("업로드된 청크가 없습니다.");
         await recordingApi.abort(recordingIdRef.current).catch(() => {});
-        recordingIdRef.current = null;
-        startTimeRef.current = null;
-        collectedPartsRef.current = [];
-        chunkUploader.reset();
+        resetRefs();
         return;
+      }
+
+      console.info("[RecordingManager] decision: hasParts=%s useSingleUpload=%s", hasParts, useSingleUpload);
+
+      if (useSingleUpload) {
+        console.info("[RecordingManager] proxy upload via backend, blob size=%d", finalBlob.size);
+        await recordingApi.upload(recordingIdRef.current, finalBlob);
+        console.info("[RecordingManager] proxy upload complete");
       }
 
       const endTime = Date.now();
@@ -150,24 +167,22 @@ export function useRecordingManager({
         parts,
         endTimestamp,
         durationMs,
+        useSingleUpload ?? false,
       );
 
-      chunkUploader.reset();
-      recordingIdRef.current = null;
-      startTimeRef.current = null;
-      collectedPartsRef.current = [];
+      console.info("[RecordingManager] recording completed, mode=%s, parts=%d",
+        useSingleUpload ? "single" : "multipart", parts.length);
+
+      resetRefs();
       isInitializedRef.current = false;
     } catch (err) {
       setManagerError(
         err instanceof Error ? err.message : "녹화 완료 실패",
       );
-      recordingIdRef.current = null;
-      startTimeRef.current = null;
-      collectedPartsRef.current = [];
+      resetRefs();
       isInitializedRef.current = false;
-      chunkUploader.reset();
     }
-  }, [recordingEnabled, mediaRecorder, chunkUploader]);
+  }, [recordingEnabled, mediaRecorder, chunkUploader, resetRefs]);
 
   const combinedError = managerError || chunkUploader.error || mediaRecorder.error;
 

--- a/src/features/interview-session/lib/useRecordingManager.ts
+++ b/src/features/interview-session/lib/useRecordingManager.ts
@@ -162,9 +162,10 @@ export function useRecordingManager({
       const durationMs = endTime - startTimeRef.current;
       const endTimestamp = new Date(endTime).toISOString();
 
+      const sortedParts = [...parts].sort((a, b) => a.partNumber - b.partNumber);
       await recordingApi.complete(
         recordingIdRef.current,
-        parts,
+        sortedParts,
         endTimestamp,
         durationMs,
         useSingleUpload ?? false,

--- a/src/features/interview-session/lib/useRecordingManager.ts
+++ b/src/features/interview-session/lib/useRecordingManager.ts
@@ -91,15 +91,12 @@ export function useRecordingManager({
         try {
           chunkUploader.init(initRes.presignedUrls);
           await mediaRecorder.start();
-
-          if (mediaRecorder.error) {
-            setRecordingEnabled(false);
-            throw new Error(mediaRecorder.error);
-          }
-
           startTimeRef.current = Date.now();
           isInitializedRef.current = true;
+          console.info("[RecordingManager] recording started, turnId=%d", turnId);
         } catch (innerErr) {
+          console.warn("[RecordingManager] start failed, aborting:", innerErr);
+          setRecordingEnabled(false);
           await recordingApi.abort(recordingIdRef.current).catch(() => {});
           recordingIdRef.current = null;
           throw innerErr;

--- a/src/features/interview-session/lib/useRecordingManager.ts
+++ b/src/features/interview-session/lib/useRecordingManager.ts
@@ -14,6 +14,7 @@ export interface UseRecordingManagerReturn {
   isRecording: boolean;
   uploadProgress: number;
   error: string | null;
+  prepareRecording: (turnId: number) => Promise<void>;
   startRecording: (turnId: number) => Promise<void>;
   stopRecording: () => Promise<void>;
   abortRecording: () => Promise<void>;
@@ -33,6 +34,7 @@ export function useRecordingManager({
   const startTimeRef = useRef<number | null>(null);
   const isInitializedRef = useRef(false);
   const collectedPartsRef = useRef<UploadedPart[]>([]);
+  const preparedTurnIdRef = useRef<number | null>(null);
 
   const chunkUploader = useChunkUploader();
 
@@ -83,6 +85,24 @@ export function useRecordingManager({
     resetRefs();
   }, [mediaRecorder, resetRefs]);
 
+  const prepareRecording = useCallback(
+    async (turnId: number) => {
+      if (!recordingEnabled || preparedTurnIdRef.current === turnId) return;
+      try {
+        const initRes = await recordingApi.initiate(sessionUuid, turnId, "video");
+        recordingIdRef.current = initRes.recordingId;
+        singleUploadUrlRef.current = initRes.singleUploadUrl;
+        chunkUploader.init(initRes.presignedUrls);
+        preparedTurnIdRef.current = turnId;
+        console.info("[RecordingManager] prepared for turnId=%d", turnId);
+      } catch (err) {
+        console.warn("[RecordingManager] prepare failed, will init on startRecording:", err);
+        preparedTurnIdRef.current = null;
+      }
+    },
+    [sessionUuid, recordingEnabled, chunkUploader],
+  );
+
   const startRecording = useCallback(
     async (turnId: number) => {
       if (!recordingEnabled) return;
@@ -91,12 +111,15 @@ export function useRecordingManager({
       collectedPartsRef.current = [];
 
       try {
-        const initRes = await recordingApi.initiate(sessionUuid, turnId, "video");
-        recordingIdRef.current = initRes.recordingId;
-        singleUploadUrlRef.current = initRes.singleUploadUrl;
+        if (preparedTurnIdRef.current !== turnId || !recordingIdRef.current) {
+          const initRes = await recordingApi.initiate(sessionUuid, turnId, "video");
+          recordingIdRef.current = initRes.recordingId;
+          singleUploadUrlRef.current = initRes.singleUploadUrl;
+          chunkUploader.init(initRes.presignedUrls);
+        }
+        preparedTurnIdRef.current = null;
 
         try {
-          chunkUploader.init(initRes.presignedUrls);
           await mediaRecorder.start();
           startTimeRef.current = Date.now();
           isInitializedRef.current = true;
@@ -192,6 +215,7 @@ export function useRecordingManager({
     isRecording: mediaRecorder.isRecording,
     uploadProgress: chunkUploader.progress,
     error: combinedError,
+    prepareRecording,
     startRecording,
     stopRecording,
     abortRecording,

--- a/src/features/interview-session/lib/useRecordingManager.ts
+++ b/src/features/interview-session/lib/useRecordingManager.ts
@@ -1,0 +1,182 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useMediaRecorder } from "./useMediaRecorder";
+import { useChunkUploader, type UploadedPart } from "./useChunkUploader";
+import { recordingApi } from "../api/recordingApi";
+
+export interface UseRecordingManagerOptions {
+  sessionUuid: string;
+  enabled?: boolean;
+  externalStream?: MediaStream | null;
+}
+
+export interface UseRecordingManagerReturn {
+  stream: MediaStream | null;
+  isRecording: boolean;
+  uploadProgress: number;
+  error: string | null;
+  startRecording: (turnId: number) => Promise<void>;
+  stopRecording: () => Promise<void>;
+  abortRecording: () => Promise<void>;
+  recordingEnabled: boolean;
+}
+
+export function useRecordingManager({
+  sessionUuid,
+  enabled = true,
+  externalStream,
+}: UseRecordingManagerOptions): UseRecordingManagerReturn {
+  const [recordingEnabled, setRecordingEnabled] = useState(enabled);
+  const [managerError, setManagerError] = useState<string | null>(null);
+
+  const recordingIdRef = useRef<string | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const isInitializedRef = useRef(false);
+  const collectedPartsRef = useRef<UploadedPart[]>([]);
+
+  const chunkUploader = useChunkUploader();
+
+  const handleChunk = useCallback(
+    (blob: Blob) => {
+      chunkUploader.uploadChunk(blob).then((part) => {
+        if (part) {
+          collectedPartsRef.current = [...collectedPartsRef.current, part];
+        }
+      }).catch((err) => {
+        setManagerError(err instanceof Error ? err.message : "청크 업로드 실패");
+      });
+    },
+    [chunkUploader],
+  );
+
+  const mediaRecorder = useMediaRecorder({
+    onChunk: handleChunk,
+    externalStream,
+  });
+
+  useEffect(() => {
+    setRecordingEnabled(enabled);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (mediaRecorder.error) {
+      setRecordingEnabled(false);
+    }
+  }, [mediaRecorder.error]);
+
+  const abortRecording = useCallback(async () => {
+    if (recordingIdRef.current) {
+      await recordingApi.abort(recordingIdRef.current).catch(() => {});
+    }
+    if (mediaRecorder.isRecording) {
+      await mediaRecorder.stop();
+    }
+    recordingIdRef.current = null;
+    startTimeRef.current = null;
+    isInitializedRef.current = false;
+    collectedPartsRef.current = [];
+    chunkUploader.reset();
+  }, [mediaRecorder, chunkUploader]);
+
+  const startRecording = useCallback(
+    async (turnId: number) => {
+      if (!recordingEnabled) return;
+      setManagerError(null);
+      isInitializedRef.current = false;
+      collectedPartsRef.current = [];
+
+      try {
+        const initRes = await recordingApi.initiate(sessionUuid, turnId, "video");
+        recordingIdRef.current = initRes.recordingId;
+
+        try {
+          chunkUploader.init(initRes.presignedUrls);
+          await mediaRecorder.start();
+
+          if (mediaRecorder.error) {
+            setRecordingEnabled(false);
+            throw new Error(mediaRecorder.error);
+          }
+
+          startTimeRef.current = Date.now();
+          isInitializedRef.current = true;
+        } catch (innerErr) {
+          await recordingApi.abort(recordingIdRef.current).catch(() => {});
+          recordingIdRef.current = null;
+          throw innerErr;
+        }
+      } catch (err) {
+        setManagerError(
+          err instanceof Error ? err.message : "녹화 시작 실패",
+        );
+      }
+    },
+    [sessionUuid, recordingEnabled, chunkUploader, mediaRecorder],
+  );
+
+  const stopRecording = useCallback(async () => {
+    if (!recordingEnabled || !recordingIdRef.current || !startTimeRef.current) {
+      return;
+    }
+
+    if (!isInitializedRef.current) {
+      await mediaRecorder.stop();
+      return;
+    }
+
+    try {
+      const finalBlob = await mediaRecorder.stop();
+
+      if (finalBlob && finalBlob.size > 0) {
+        const finalPart = await chunkUploader.uploadChunk(finalBlob);
+        if (finalPart) {
+          collectedPartsRef.current = [...collectedPartsRef.current, finalPart];
+        }
+      }
+
+      const parts = collectedPartsRef.current;
+      if (parts.length === 0) {
+        setManagerError("업로드된 청크가 없습니다.");
+        await recordingApi.abort(recordingIdRef.current).catch(() => {});
+        recordingIdRef.current = null;
+        startTimeRef.current = null;
+        collectedPartsRef.current = [];
+        chunkUploader.reset();
+        return;
+      }
+
+      const endTime = Date.now();
+      const durationMs = endTime - startTimeRef.current;
+      const endTimestamp = new Date(endTime).toISOString();
+
+      await recordingApi.complete(
+        recordingIdRef.current,
+        parts,
+        endTimestamp,
+        durationMs,
+      );
+
+      chunkUploader.reset();
+      recordingIdRef.current = null;
+      startTimeRef.current = null;
+      collectedPartsRef.current = [];
+      isInitializedRef.current = false;
+    } catch (err) {
+      setManagerError(
+        err instanceof Error ? err.message : "녹화 완료 실패",
+      );
+    }
+  }, [recordingEnabled, mediaRecorder, chunkUploader]);
+
+  const combinedError = managerError || chunkUploader.error || mediaRecorder.error;
+
+  return {
+    stream: mediaRecorder.stream,
+    isRecording: mediaRecorder.isRecording,
+    uploadProgress: chunkUploader.progress,
+    error: combinedError,
+    startRecording,
+    stopRecording,
+    abortRecording,
+    recordingEnabled,
+  };
+}

--- a/src/features/interview-session/lib/useRecordingManager.ts
+++ b/src/features/interview-session/lib/useRecordingManager.ts
@@ -164,6 +164,11 @@ export function useRecordingManager({
       setManagerError(
         err instanceof Error ? err.message : "녹화 완료 실패",
       );
+      recordingIdRef.current = null;
+      startTimeRef.current = null;
+      collectedPartsRef.current = [];
+      isInitializedRef.current = false;
+      chunkUploader.reset();
     }
   }, [recordingEnabled, mediaRecorder, chunkUploader]);
 

--- a/src/features/interview-session/model/actions/submitAnswer.ts
+++ b/src/features/interview-session/model/actions/submitAnswer.ts
@@ -12,6 +12,7 @@ export async function submitInterviewAnswer(
   interviewSessionUuid: string,
   turnPk: number,
   answer: string,
+  speechSegments?: { text: string; startMs: number; endMs: number }[],
 ) {
   const { interviewSession, interviewTurns, currentInterviewTurnIndex } = get();
   if (!interviewSession) return;
@@ -25,7 +26,7 @@ export async function submitInterviewAnswer(
   );
 
   try {
-    const response = await interviewApi.submitAnswer(interviewSessionUuid, turnPk, answer);
+    const response = await interviewApi.submitAnswer(interviewSessionUuid, turnPk, answer, speechSegments);
 
     if (isFollowup) {
       await handleFollowupResponse(set, interviewSessionUuid, response as SubmitAnswerFollowupResponse, turnsWithAnswer, currentInterviewTurnIndex);

--- a/src/features/interview-session/model/store.ts
+++ b/src/features/interview-session/model/store.ts
@@ -17,7 +17,7 @@ export const useInterviewSessionStore = create<InterviewSessionStore>((set, get)
   loadInterviewTurns: (uuid) => loadInterviewTurns(set, uuid),
   startInterview: (uuid) => startInterview(set, uuid),
   finishInterview: (uuid) => finishInterview(set, uuid),
-  submitInterviewAnswer: (uuid, turnPk, answer) => submitInterviewAnswer(set, get, uuid, turnPk, answer),
+  submitInterviewAnswer: (uuid, turnPk, answer, speechSegments) => submitInterviewAnswer(set, get, uuid, turnPk, answer, speechSegments),
   startReportPolling: (uuid) => startReportPolling(set, uuid),
 
   resetInterviewSession: () => {

--- a/src/features/interview-session/model/types.ts
+++ b/src/features/interview-session/model/types.ts
@@ -31,7 +31,7 @@ export interface InterviewSessionActions {
   loadInterviewSession: (uuid: string) => Promise<void>;
   loadInterviewTurns: (uuid: string) => Promise<void>;
   startInterview: (uuid: string) => Promise<void>;
-  submitInterviewAnswer: (uuid: string, turnPk: number, answer: string) => Promise<void>;
+  submitInterviewAnswer: (uuid: string, turnPk: number, answer: string, speechSegments?: { text: string; startMs: number; endMs: number }[]) => Promise<void>;
   finishInterview: (uuid: string) => Promise<void>;
   startReportPolling: (uuid: string) => void;
   resetInterviewSession: () => void;

--- a/src/features/interview-session/ui/MediaPlayer.tsx
+++ b/src/features/interview-session/ui/MediaPlayer.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from "react";
+import { Download, Video, Mic, AlertCircle } from "lucide-react";
+import { recordingApi } from "../api/recordingApi";
+import type { PlaybackUrlResponse } from "../api/recordingApi";
+
+interface MediaPlayerProps {
+  recordingId: string;
+  mediaType: "video" | "audio";
+  className?: string;
+}
+
+export function MediaPlayer({ recordingId, mediaType, className = "" }: MediaPlayerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [playbackData, setPlaybackData] = useState<PlaybackUrlResponse | null>(null);
+  const [error, setError] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+        }
+      },
+      { rootMargin: "200px" }
+    );
+
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  const loadMedia = async () => {
+    try {
+      setIsLoading(true);
+      setError(false);
+      const data = await recordingApi.playbackUrl(recordingId);
+      setPlaybackData(data);
+    } catch {
+      setError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isVisible && !playbackData && !error) {
+      loadMedia();
+    }
+  }, [isVisible, recordingId, playbackData, error]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const renderContent = () => {
+    if (error) {
+      return (
+        <div className="flex flex-col items-center justify-center w-full aspect-video sm:aspect-[21/9] bg-[#F3F4F6] text-[#6B7280]">
+          <AlertCircle className="w-8 h-8 mb-2 text-[#9CA3AF]" />
+          <p className="text-sm font-medium">재생할 수 없습니다</p>
+          <button
+            onClick={loadMedia}
+            className="mt-3 text-[12px] font-bold px-3 py-1.5 bg-white border border-[#E5E7EB] rounded-md hover:bg-[#F9FAFB] transition-colors"
+          >
+            다시 시도
+          </button>
+        </div>
+      );
+    }
+
+    if (isLoading || !playbackData) {
+      return (
+        <div className="flex items-center justify-center w-full aspect-video sm:aspect-[21/9] bg-[#F3F4F6] animate-pulse">
+          {mediaType === "video" ? (
+            <Video className="w-8 h-8 text-[#D1D5DB]" />
+          ) : (
+            <Mic className="w-8 h-8 text-[#D1D5DB]" />
+          )}
+        </div>
+      );
+    }
+
+    const { url, scaledUrl, audioUrl } = playbackData;
+
+    if (mediaType === "video") {
+      const src = scaledUrl || url;
+      return (
+        <video
+          src={src}
+          controls
+          playsInline
+          preload="metadata"
+          className="w-full aspect-video object-contain bg-black"
+        />
+      );
+    }
+
+    const src = audioUrl || url;
+    return (
+      <div className="w-full p-4 flex items-center justify-center bg-white border-b border-[#E5E7EB]">
+        <audio src={src} controls className="w-full max-w-md h-[40px]" />
+      </div>
+    );
+  };
+
+  const downloadUrl = playbackData?.url;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`rounded-xl overflow-hidden bg-[#F9FAFB] border border-[#E5E7EB] ${className}`}
+    >
+      {renderContent()}
+
+      <div className="h-10 px-4 flex items-center justify-between bg-[#F9FAFB] border-t border-[#E5E7EB]">
+        <div className="flex items-center gap-2 text-[12px] font-semibold text-[#6B7280]">
+          {mediaType === "video" ? (
+            <><Video className="w-4 h-4" /> 비디오 답변</>
+          ) : (
+            <><Mic className="w-4 h-4" /> 오디오 답변</>
+          )}
+        </div>
+        
+        {downloadUrl && (
+          <a
+            href={downloadUrl}
+            download
+            className="flex items-center gap-1 text-[12px] font-medium text-[#6B7280] hover:text-[#0991B2] transition-colors"
+          >
+            <Download className="w-3.5 h-3.5" />
+            <span>다운로드</span>
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/interview-session/ui/MediaPlayer.tsx
+++ b/src/features/interview-session/ui/MediaPlayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { Download, Video, Mic, AlertCircle } from "lucide-react";
 import { recordingApi } from "../api/recordingApi";
 import type { PlaybackUrlResponse } from "../api/recordingApi";
@@ -36,7 +36,7 @@ export function MediaPlayer({ recordingId, mediaType, className = "" }: MediaPla
     };
   }, []);
 
-  const loadMedia = async () => {
+  const loadMedia = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(false);
@@ -47,13 +47,13 @@ export function MediaPlayer({ recordingId, mediaType, className = "" }: MediaPla
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [recordingId]);
 
   useEffect(() => {
     if (isVisible && !playbackData && !error) {
       loadMedia();
     }
-  }, [isVisible, recordingId, playbackData, error]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isVisible, playbackData, error, loadMedia]);
 
   const renderContent = () => {
     if (error) {

--- a/src/features/interview-session/ui/RecordingIndicator.tsx
+++ b/src/features/interview-session/ui/RecordingIndicator.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface RecordingIndicatorProps {
+  isRecording: boolean;
+  className?: string;
+}
+
+export function RecordingIndicator({ isRecording, className = "" }: RecordingIndicatorProps) {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const startTimeRef = useRef(0);
+
+  useEffect(() => {
+    if (!isRecording) {
+      setElapsedSeconds(0); // eslint-disable-line react-hooks/set-state-in-effect -- reset on stop
+      return;
+    }
+    startTimeRef.current = Date.now();
+    setElapsedSeconds(0);  
+    const interval = setInterval(() => {
+      setElapsedSeconds(Math.floor((Date.now() - startTimeRef.current) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isRecording]);
+
+  if (!isRecording) return null;
+
+  const minutes = Math.floor(elapsedSeconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = (elapsedSeconds % 60).toString().padStart(2, "0");
+
+  return (
+    <div
+      className={`flex items-center gap-2 px-3 py-1.5 rounded-full bg-[rgba(220,38,38,0.1)] ${className}`}
+    >
+      <div className="w-2.5 h-2.5 rounded-full bg-[#DC2626] animate-pulse" />
+      <span className="text-[11px] font-extrabold text-[#DC2626] tracking-wider">REC</span>
+      <span className="text-[11px] font-mono font-bold text-[#DC2626]">
+        {minutes}:{seconds}
+      </span>
+    </div>
+  );
+}

--- a/src/features/interview-session/ui/VideoPreview.tsx
+++ b/src/features/interview-session/ui/VideoPreview.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+import { Camera } from "lucide-react";
+
+export interface VideoPreviewProps {
+  stream: MediaStream | null;
+  isRecording: boolean;
+  className?: string;
+}
+
+export function VideoPreview({ stream, isRecording, className = "" }: VideoPreviewProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (videoRef.current && stream) {
+      videoRef.current.srcObject = stream;
+    }
+  }, [stream]);
+
+  return (
+    <div
+      className={`relative rounded-xl overflow-hidden bg-[#1a1a2e] aspect-video ${
+        isRecording ? "ring-2 ring-green-500/50" : ""
+      } ${className}`}
+    >
+      {stream ? (
+        <video
+          ref={videoRef}
+          autoPlay
+          muted
+          playsInline
+          className="w-full h-full object-cover transform scale-x-[-1]"
+        />
+      ) : (
+        <div className="absolute inset-0 flex flex-col items-center justify-center text-[#6B7280]">
+          <Camera className="w-8 h-8 mb-2 opacity-50" />
+          <span className="text-[11px] font-medium">카메라 준비 중...</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/interview-report/ui/InteractiveTimeline.tsx
+++ b/src/pages/interview-report/ui/InteractiveTimeline.tsx
@@ -115,7 +115,7 @@ export function InteractiveTimeline({
     recordingApi.playbackUrl(recordingId).then(data => {
       setVideoUrl(data.scaledUrl || data.url);
       setAudioUrl(data.audioUrl || data.url);
-    }).catch(() => {});
+    }).catch((err) => { console.error("Failed to load playback URL:", err); });
   }, [recordingId]);
 
   if (!speechData?.summary || !speechData?.timeline) return null;

--- a/src/pages/interview-report/ui/InteractiveTimeline.tsx
+++ b/src/pages/interview-report/ui/InteractiveTimeline.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useRef, useState } from "react";
+import { recordingApi } from "@/features/interview-session/api/recordingApi";
+import type { BehaviorAnalysis } from "@/features/interview-session";
+import type { SpeechSegment } from "@/features/interview-session/api/types";
+
+const DBFS_MIN = -60;
+const DBFS_MAX = 0;
+const CHART_H = 48;
+const CHART_PADDING_TOP = 4;
+
+function dbfsToY(dbfs: number): number {
+  const clamped = Math.max(DBFS_MIN, Math.min(DBFS_MAX, dbfs));
+  return CHART_PADDING_TOP + ((DBFS_MAX - clamped) / (DBFS_MAX - DBFS_MIN)) * (CHART_H - CHART_PADDING_TOP);
+}
+
+function DbfsAreaChart({
+  timeline,
+  totalDurationMs,
+}: {
+  timeline: NonNullable<BehaviorAnalysis["speechData"]>["timeline"];
+  totalDurationMs: number;
+}) {
+  if (totalDurationMs === 0) return null;
+
+  const toX = (ms: number) => (ms / totalDurationMs) * 100;
+
+  const points: string[] = [];
+  const fillPoints: string[] = [];
+
+  for (const seg of timeline) {
+    const x1 = toX(seg.startMs);
+    const x2 = toX(seg.endMs);
+
+    if (seg.type === "silence") {
+      const yBottom = CHART_H;
+      points.push(`${x1},${yBottom}`, `${x2},${yBottom}`);
+      fillPoints.push(`${x1},${yBottom}`, `${x2},${yBottom}`);
+    } else {
+      const y = dbfsToY(seg.dbfs ?? DBFS_MIN);
+      points.push(`${x1},${y}`, `${x2},${y}`);
+      fillPoints.push(`${x1},${y}`, `${x2},${y}`);
+    }
+  }
+
+  const polylineStr = points.join(" ");
+  const lastX = toX(totalDurationMs);
+  const fillStr = `0,${CHART_H} ${fillPoints.join(" ")} ${lastX},${CHART_H}`;
+
+  const gridLines = [-10, -20, -30, -40, -50];
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] text-[#6B7280]">음량 (dBFS)</span>
+      <svg viewBox={`0 0 100 ${CHART_H}`} preserveAspectRatio="none" className="w-full h-12">
+        {gridLines.map((db) => (
+          <line
+            key={db}
+            x1={0} y1={dbfsToY(db)} x2={100} y2={dbfsToY(db)}
+            stroke="#F3F4F6" strokeWidth={0.3}
+          />
+        ))}
+
+        <defs>
+          <linearGradient id="dbfs-fill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#059669" stopOpacity={0.4} />
+            <stop offset="50%" stopColor="#D97706" stopOpacity={0.3} />
+            <stop offset="100%" stopColor="#DC2626" stopOpacity={0.1} />
+          </linearGradient>
+        </defs>
+
+        <polygon points={fillStr} fill="url(#dbfs-fill)" />
+        <polyline points={polylineStr} fill="none" stroke="#059669" strokeWidth={0.5} vectorEffect="non-scaling-stroke" />
+
+        {gridLines.map((db) => (
+          <text
+            key={`label-${db}`}
+            x={1} y={dbfsToY(db) - 1}
+            className="fill-[#9CA3AF]" fontSize={2.5}
+          >
+            {db}
+          </text>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+interface InteractiveTimelineProps {
+  recordingId?: string;
+  mediaType?: string;
+  speechData: NonNullable<BehaviorAnalysis["speechData"]>;
+  speechSegments: SpeechSegment[];
+}
+
+function formatDuration(ms: number) {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+}
+
+export function InteractiveTimeline({
+  recordingId,
+  mediaType,
+  speechData,
+  speechSegments,
+}: InteractiveTimelineProps) {
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [currentTimeMs, setCurrentTimeMs] = useState(0);
+  const mediaRef = useRef<HTMLVideoElement | HTMLAudioElement>(null);
+
+  useEffect(() => {
+    if (!recordingId) return;
+    recordingApi.playbackUrl(recordingId).then(data => {
+      setVideoUrl(data.scaledUrl || data.url);
+      setAudioUrl(data.audioUrl || data.url);
+    }).catch(() => {});
+  }, [recordingId]);
+
+  const { summary, timeline } = speechData;
+  const { totalDurationMs } = summary;
+
+  const handleTimeUpdate = () => {
+    if (mediaRef.current) {
+      setCurrentTimeMs(mediaRef.current.currentTime * 1000);
+    }
+  };
+
+  const handleTimelineClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!mediaRef.current) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const clickX = Math.max(0, Math.min(e.clientX - rect.left, rect.width));
+    const percentage = clickX / rect.width;
+    const seekTimeMs = percentage * totalDurationMs;
+    mediaRef.current.currentTime = seekTimeMs / 1000;
+    setCurrentTimeMs(seekTimeMs);
+  };
+
+  const currentSegment = speechSegments.find(
+    (seg) => currentTimeMs >= seg.startMs && currentTimeMs <= seg.endMs
+  );
+
+  const getSilenceColor = (ratio: number) => {
+    if (ratio < 0.15) return "text-[#059669]";
+    if (ratio <= 0.3) return "text-[#D97706]";
+    return "text-[#DC2626]";
+  };
+
+  const silenceRatioPct = Math.round(summary.silenceRatio * 100);
+  const cursorLeftPct = totalDurationMs > 0 ? (currentTimeMs / totalDurationMs) * 100 : 0;
+
+  return (
+    <div className="bg-white border border-[#E5E7EB] rounded-xl p-4 flex flex-col gap-4 mt-4">
+      {/* 1. Header & Stats (Always visible in both modes) */}
+      <div className="flex justify-between items-start">
+        <h4 className="text-[10px] font-bold uppercase tracking-wide text-[#0991B2]">음성 및 행동 분석</h4>
+        <div className="flex gap-4 text-[10px] text-[#6B7280]">
+          <div className="flex flex-col items-end">
+            <span>총 시간</span>
+            <span className="text-[11px] font-bold text-gray-900">{formatDuration(summary.totalDurationMs)}</span>
+          </div>
+          <div className="flex flex-col items-end">
+            <span>발화 시간</span>
+            <span className="text-[11px] font-bold text-gray-900">{formatDuration(summary.speechDurationMs)}</span>
+          </div>
+          <div className="flex flex-col items-end">
+            <span>침묵 횟수</span>
+            <span className="text-[11px] font-bold text-gray-900">{summary.silenceSegmentCount}회</span>
+          </div>
+          <div className="flex flex-col items-end">
+            <span>평균 음량</span>
+            <span className="text-[11px] font-bold text-gray-900">
+              {summary.avgDbfsSpeech !== null ? `${summary.avgDbfsSpeech.toFixed(1)} dBFS` : "N/A"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* 2. Video Player (Interactive mode only) */}
+      {recordingId && (videoUrl || audioUrl) && (
+        <div className="w-full aspect-video sm:aspect-[21/9] bg-black rounded-xl overflow-hidden print:hidden shrink-0 flex items-center justify-center">
+          {mediaType === "video" ? (
+            <video
+              ref={mediaRef as React.RefObject<HTMLVideoElement>}
+              src={videoUrl || undefined}
+              controls
+              playsInline
+              className="w-full h-full object-contain"
+              onTimeUpdate={handleTimeUpdate}
+            />
+          ) : (
+            <audio
+              ref={mediaRef as React.RefObject<HTMLAudioElement>}
+              src={audioUrl || videoUrl || undefined}
+              controls
+              className="w-full h-[40px]"
+              onTimeUpdate={handleTimeUpdate}
+            />
+          )}
+        </div>
+      )}
+
+      {/* 3. Waveform and Silence Bars */}
+      <div className="flex gap-6 items-center">
+        {/* Gauge (Always visible) */}
+        <div className="flex flex-col items-center gap-1 shrink-0">
+          <span className="text-[10px] text-[#6B7280]">침묵 비율</span>
+          <div className="relative w-12 h-12 flex items-center justify-center rounded-full bg-gray-100">
+            <svg viewBox="0 0 36 36" className="absolute w-full h-full -rotate-90">
+              <path
+                className="text-gray-200"
+                d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className={getSilenceColor(summary.silenceRatio)}
+                d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="4"
+                strokeDasharray={`${silenceRatioPct}, 100`}
+              />
+            </svg>
+            <span className={`text-[11px] font-bold ${getSilenceColor(summary.silenceRatio)}`}>
+              {silenceRatioPct}%
+            </span>
+          </div>
+        </div>
+
+        {/* Timelines */}
+        <div className="flex-1 flex flex-col gap-3 overflow-hidden relative">
+          
+          {/* Interactive Playback Cursor (Interactive mode only) */}
+          <div
+            className="absolute top-0 bottom-0 w-[2px] bg-[#DC2626] z-10 print:hidden transition-all duration-75 pointer-events-none"
+            style={{ left: `${cursorLeftPct}%` }}
+          />
+
+          {/* Interactive Click Overlay (Interactive mode only) */}
+          <div 
+            className="absolute inset-0 z-20 cursor-pointer print:hidden"
+            onClick={handleTimelineClick}
+          />
+
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-[#6B7280]">발화/침묵 구간</span>
+            <div className="h-4 flex rounded-full overflow-hidden bg-gray-100 w-full group">
+              {timeline.map((seg, idx) => {
+                const widthPct = ((seg.endMs - seg.startMs) / totalDurationMs) * 100;
+                const label = seg.type === "speech" ? "발화" : "침묵";
+                return (
+                  <div
+                    key={idx}
+                    className={`h-full relative ${seg.type === "speech" ? "bg-[#059669]" : "bg-gray-300"}`}
+                    style={{ width: `${widthPct}%` }}
+                    title={`${label}: ${formatDuration(seg.startMs)} - ${formatDuration(seg.endMs)}`}
+                  />
+                );
+              })}
+            </div>
+          </div>
+
+          <DbfsAreaChart timeline={timeline} totalDurationMs={totalDurationMs} />
+        </div>
+      </div>
+
+      {/* 4. STT Text Display (Interactive mode only) */}
+      <div className="bg-[#F9FAFB] rounded-lg p-3 border border-[#E5E7EB] min-h-[60px] flex items-center justify-center print:hidden">
+        {currentSegment ? (
+          <p className="text-[13px] text-gray-900 leading-relaxed text-center font-medium">
+            "{currentSegment.text}"
+          </p>
+        ) : (
+          <p className="text-[13px] text-gray-400 italic text-center">
+            (침묵)
+          </p>
+        )}
+      </div>
+
+    </div>
+  );
+}

--- a/src/pages/interview-report/ui/InteractiveTimeline.tsx
+++ b/src/pages/interview-report/ui/InteractiveTimeline.tsx
@@ -88,7 +88,7 @@ function DbfsAreaChart({
 interface InteractiveTimelineProps {
   recordingId?: string;
   mediaType?: string;
-  speechData: NonNullable<BehaviorAnalysis["speechData"]>;
+  speechData: BehaviorAnalysis["speechData"] | null;
   speechSegments: SpeechSegment[];
 }
 
@@ -118,8 +118,12 @@ export function InteractiveTimeline({
     }).catch(() => {});
   }, [recordingId]);
 
+  if (!speechData?.summary || !speechData?.timeline) return null;
+
   const { summary, timeline } = speechData;
   const { totalDurationMs } = summary;
+
+  if (totalDurationMs <= 0 || timeline.length === 0) return null;
 
   const handleTimeUpdate = () => {
     if (mediaRef.current) {

--- a/src/pages/interview-report/ui/InterviewReportPage.tsx
+++ b/src/pages/interview-report/ui/InterviewReportPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Loader2, ArrowLeft } from "lucide-react";
-import { useInterviewSessionStore, recordingApi } from "@/features/interview-session";
-import type { RecordingItem } from "@/features/interview-session";
+import { useInterviewSessionStore, recordingApi, interviewApi } from "@/features/interview-session";
+import type { RecordingItem, BehaviorAnalysis } from "@/features/interview-session";
 import { RadarChart } from "./RadarChart";
 import { ScoreGauge } from "./ScoreGauge";
 import { StrengthsImprovements } from "./StrengthsImprovements";
@@ -20,6 +20,7 @@ const GRADE_KO: Record<string, string> = {
 export function InterviewReportPage() {
   const { interviewSessionUuid } = useParams<{ interviewSessionUuid: string }>();
   const [recordings, setRecordings] = useState<RecordingItem[]>([]);
+  const [behaviorAnalyses, setBehaviorAnalyses] = useState<BehaviorAnalysis[]>([]);
 
   const {
     interviewSession, interviewTurns, interviewAnalysisReport, isReportPolling,
@@ -33,6 +34,7 @@ export function InterviewReportPage() {
     loadInterviewTurns(interviewSessionUuid);
     startReportPolling(interviewSessionUuid);
     recordingApi.list(interviewSessionUuid).then(setRecordings).catch(() => {});
+    interviewApi.getBehaviorAnalyses(interviewSessionUuid).then(setBehaviorAnalyses).catch(() => {});
   }, [interviewSessionUuid]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const turnAnswerMap = Object.fromEntries(interviewTurns.map((t) => [t.id, t.answer]));
@@ -43,7 +45,6 @@ export function InterviewReportPage() {
 
   return (
     <div className="min-h-screen bg-[#F9FAFB]">
-      {/* Nav */}
       <nav className="sticky top-0 z-[200] bg-white/[.92] backdrop-blur-[20px] border-b border-[#E5E7EB] h-[60px] flex items-center px-6 gap-3">
         <Link to="/interview/results" className="flex items-center gap-1.5 text-sm font-medium text-[#6B7280] hover:text-[#0A0A0A] no-underline">
           <ArrowLeft size={16} /> 면접 결과
@@ -55,7 +56,6 @@ export function InterviewReportPage() {
       </nav>
 
       <div className="max-w-3xl mx-auto px-6 pt-8 pb-16">
-        {/* Header */}
         <div className="mb-6">
           <div className="text-[11px] font-bold tracking-[.1em] uppercase text-[#0991B2] mb-2">AI 면접 분석 리포트</div>
           <h1 className="text-[clamp(22px,3vw,32px)] font-black tracking-[-0.5px]">면접 분석 리포트</h1>
@@ -68,7 +68,6 @@ export function InterviewReportPage() {
           )}
         </div>
 
-        {/* Pending */}
         {isPending && (
           <div className="bg-white border border-[#E5E7EB] rounded-2xl p-10 text-center shadow-sm mb-6">
             <Loader2 className="w-12 h-12 animate-spin text-[#0991B2] mx-auto mb-4" />
@@ -78,7 +77,6 @@ export function InterviewReportPage() {
           </div>
         )}
 
-        {/* Failed */}
         {isFailed && (
           <div className="bg-red-50 border border-red-200 rounded-2xl p-8 text-center mb-6">
             <p className="text-red-600 font-bold mb-2">리포트 생성에 실패했습니다</p>
@@ -86,10 +84,8 @@ export function InterviewReportPage() {
           </div>
         )}
 
-        {/* Completed */}
         {isCompleted && report && (
           <>
-            {/* Overall score */}
             <div className="bg-white border border-[#E5E7EB] rounded-2xl p-6 shadow-sm mb-4 flex flex-col sm:flex-row items-center gap-6">
               <div className="shrink-0 w-40"><ScoreGauge score={report.overallScore ?? 0} /></div>
               <div className="flex-1 text-center sm:text-left">
@@ -100,7 +96,6 @@ export function InterviewReportPage() {
               </div>
             </div>
 
-            {/* Category scores */}
             {report.categoryScores.length > 0 && (
               <div className="bg-white border border-[#E5E7EB] rounded-2xl p-6 shadow-sm mb-4">
                 <h2 className="text-[13px] font-bold mb-4">카테고리별 점수</h2>
@@ -126,9 +121,14 @@ export function InterviewReportPage() {
             )}
 
             <StrengthsImprovements strengths={report.strengths} improvements={report.improvementAreas} />
-            <QuestionFeedbackList feedbacks={report.questionFeedbacks} turnAnswerMap={turnAnswerMap} recordings={recordings} />
+            <QuestionFeedbackList 
+              feedbacks={report.questionFeedbacks} 
+              turnAnswerMap={turnAnswerMap} 
+              recordings={recordings} 
+              behaviorAnalyses={behaviorAnalyses}
+              interviewTurns={interviewTurns}
+            />
 
-            {/* CTA */}
             <div className="flex gap-3 justify-center flex-wrap">
               <Link to="/interview/setup" className="inline-flex items-center gap-2 text-sm font-bold text-white bg-[#0A0A0A] rounded-xl py-3 px-8 no-underline hover:opacity-85">다시 면접하기 →</Link>
               <Link to="/interview/results" className="inline-flex items-center gap-2 text-sm font-bold text-[#374151] border border-[#E5E7EB] bg-white rounded-xl py-3 px-8 no-underline hover:bg-[#F9FAFB]">← 면접 결과 목록</Link>
@@ -139,3 +139,4 @@ export function InterviewReportPage() {
     </div>
   );
 }
+

--- a/src/pages/interview-report/ui/InterviewReportPage.tsx
+++ b/src/pages/interview-report/ui/InterviewReportPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Loader2, ArrowLeft } from "lucide-react";
-import { useInterviewSessionStore } from "@/features/interview-session";
+import { useInterviewSessionStore, recordingApi } from "@/features/interview-session";
+import type { RecordingItem } from "@/features/interview-session";
 import { RadarChart } from "./RadarChart";
 import { ScoreGauge } from "./ScoreGauge";
 import { StrengthsImprovements } from "./StrengthsImprovements";
@@ -18,6 +19,7 @@ const GRADE_KO: Record<string, string> = {
 
 export function InterviewReportPage() {
   const { interviewSessionUuid } = useParams<{ interviewSessionUuid: string }>();
+  const [recordings, setRecordings] = useState<RecordingItem[]>([]);
 
   const {
     interviewSession, interviewTurns, interviewAnalysisReport, isReportPolling,
@@ -30,6 +32,7 @@ export function InterviewReportPage() {
     loadInterviewSession(interviewSessionUuid);
     loadInterviewTurns(interviewSessionUuid);
     startReportPolling(interviewSessionUuid);
+    recordingApi.list(interviewSessionUuid).then(setRecordings).catch(() => {});
   }, [interviewSessionUuid]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const turnAnswerMap = Object.fromEntries(interviewTurns.map((t) => [t.id, t.answer]));
@@ -123,7 +126,7 @@ export function InterviewReportPage() {
             )}
 
             <StrengthsImprovements strengths={report.strengths} improvements={report.improvementAreas} />
-            <QuestionFeedbackList feedbacks={report.questionFeedbacks} turnAnswerMap={turnAnswerMap} />
+            <QuestionFeedbackList feedbacks={report.questionFeedbacks} turnAnswerMap={turnAnswerMap} recordings={recordings} />
 
             {/* CTA */}
             <div className="flex gap-3 justify-center flex-wrap">

--- a/src/pages/interview-report/ui/QuestionFeedbackList.tsx
+++ b/src/pages/interview-report/ui/QuestionFeedbackList.tsx
@@ -1,16 +1,26 @@
-import type { InterviewQuestionFeedback, RecordingItem } from "@/features/interview-session";
-import { MediaPlayer } from "@/features/interview-session";
+import type { InterviewQuestionFeedback, RecordingItem, BehaviorAnalysis, InterviewTurn } from "@/features/interview-session";
+import { InteractiveTimeline } from "./InteractiveTimeline";
 
 interface QuestionFeedbackListProps {
   feedbacks: InterviewQuestionFeedback[];
   turnAnswerMap: Record<number, string>;
   recordings?: RecordingItem[];
+  behaviorAnalyses?: BehaviorAnalysis[];
+  interviewTurns?: InterviewTurn[];
 }
 
-export function QuestionFeedbackList({ feedbacks, turnAnswerMap, recordings = [] }: QuestionFeedbackListProps) {
+export function QuestionFeedbackList({
+  feedbacks,
+  turnAnswerMap,
+  recordings = [],
+  behaviorAnalyses = [],
+  interviewTurns = [],
+}: QuestionFeedbackListProps) {
   if (feedbacks.length === 0) return null;
 
   const recordingsByTurnId = Object.fromEntries(recordings.map((r) => [r.turnId, r]));
+  const behaviorByTurnId = Object.fromEntries(behaviorAnalyses.map((ba) => [ba.interviewTurn, ba]));
+  const segmentsByTurnId = Object.fromEntries(interviewTurns.map((t) => [t.id, t.speechSegments || []]));
 
   return (
     <div className="bg-white border border-[#E5E7EB] rounded-2xl p-6 shadow-sm mb-6">
@@ -18,6 +28,8 @@ export function QuestionFeedbackList({ feedbacks, turnAnswerMap, recordings = []
       <div className="flex flex-col gap-6">
         {feedbacks.map((qf, i) => {
           const recording = recordingsByTurnId[qf.turnId];
+          const behaviorAnalysis = behaviorByTurnId[qf.turnId];
+          const speechSegments = segmentsByTurnId[qf.turnId] || [];
 
           return (
             <div key={qf.turnId ?? i} className="border-b border-[#F3F4F6] pb-6 last:border-b-0 last:pb-0">
@@ -25,14 +37,21 @@ export function QuestionFeedbackList({ feedbacks, turnAnswerMap, recordings = []
                 <span className="text-[#0991B2] mr-1">Q{i + 1}.</span>{qf.question}
               </p>
 
-              {recording && (
-                <MediaPlayer recordingId={recording.recordingId} mediaType={recording.mediaType} className="mb-3" />
-              )}
-
               {turnAnswerMap[qf.turnId] && (
                 <div className="bg-[#F0F9FF] border border-[#BAE6FD] rounded-xl p-3 mb-3">
                   <p className="text-[10px] font-bold text-[#0369A1] uppercase tracking-wide mb-1">내 답변</p>
                   <p className="text-[12px] text-[#374151] leading-relaxed">{turnAnswerMap[qf.turnId]}</p>
+                </div>
+              )}
+
+              {behaviorAnalysis?.speechData && (
+                <div className="mb-3">
+                  <InteractiveTimeline
+                    recordingId={recording?.recordingId}
+                    mediaType={recording?.mediaType}
+                    speechData={behaviorAnalysis.speechData}
+                    speechSegments={speechSegments}
+                  />
                 </div>
               )}
 
@@ -72,3 +91,5 @@ export function QuestionFeedbackList({ feedbacks, turnAnswerMap, recordings = []
     </div>
   );
 }
+
+

--- a/src/pages/interview-report/ui/QuestionFeedbackList.tsx
+++ b/src/pages/interview-report/ui/QuestionFeedbackList.tsx
@@ -1,61 +1,73 @@
-import type { InterviewQuestionFeedback } from "@/features/interview-session";
+import type { InterviewQuestionFeedback, RecordingItem } from "@/features/interview-session";
+import { MediaPlayer } from "@/features/interview-session";
 
 interface QuestionFeedbackListProps {
   feedbacks: InterviewQuestionFeedback[];
   turnAnswerMap: Record<number, string>;
+  recordings?: RecordingItem[];
 }
 
-export function QuestionFeedbackList({ feedbacks, turnAnswerMap }: QuestionFeedbackListProps) {
+export function QuestionFeedbackList({ feedbacks, turnAnswerMap, recordings = [] }: QuestionFeedbackListProps) {
   if (feedbacks.length === 0) return null;
+
+  const recordingsByTurnId = Object.fromEntries(recordings.map((r) => [r.turnId, r]));
 
   return (
     <div className="bg-white border border-[#E5E7EB] rounded-2xl p-6 shadow-sm mb-6">
       <h2 className="text-[13px] font-bold mb-4">질문별 피드백</h2>
       <div className="flex flex-col gap-6">
-        {feedbacks.map((qf, i) => (
-          <div key={qf.turnId ?? i} className="border-b border-[#F3F4F6] pb-6 last:border-b-0 last:pb-0">
-            <p className="text-[13px] font-bold text-[#0A0A0A] mb-2">
-              <span className="text-[#0991B2] mr-1">Q{i + 1}.</span>{qf.question}
-            </p>
+        {feedbacks.map((qf, i) => {
+          const recording = recordingsByTurnId[qf.turnId];
 
-            {turnAnswerMap[qf.turnId] && (
-              <div className="bg-[#F0F9FF] border border-[#BAE6FD] rounded-xl p-3 mb-3">
-                <p className="text-[10px] font-bold text-[#0369A1] uppercase tracking-wide mb-1">내 답변</p>
-                <p className="text-[12px] text-[#374151] leading-relaxed">{turnAnswerMap[qf.turnId]}</p>
-              </div>
-            )}
+          return (
+            <div key={qf.turnId ?? i} className="border-b border-[#F3F4F6] pb-6 last:border-b-0 last:pb-0">
+              <p className="text-[13px] font-bold text-[#0A0A0A] mb-2">
+                <span className="text-[#0991B2] mr-1">Q{i + 1}.</span>{qf.question}
+              </p>
 
-            <div className="grid grid-cols-2 gap-3 mb-3 max-sm:grid-cols-1">
-              <div className="bg-[#F0FDF4] rounded-xl p-3">
-                <p className="text-[10px] font-bold text-[#059669] uppercase tracking-wide mb-1.5">잘한 점</p>
-                <ul className="flex flex-col gap-1">
-                  {qf.strengths.map((s, j) => (
-                    <li key={j} className="text-[11px] text-[#374151] flex items-start gap-1.5">
-                      <span className="text-[#059669] shrink-0">✓</span>{s}
-                    </li>
-                  ))}
-                </ul>
+              {recording && (
+                <MediaPlayer recordingId={recording.recordingId} mediaType={recording.mediaType} className="mb-3" />
+              )}
+
+              {turnAnswerMap[qf.turnId] && (
+                <div className="bg-[#F0F9FF] border border-[#BAE6FD] rounded-xl p-3 mb-3">
+                  <p className="text-[10px] font-bold text-[#0369A1] uppercase tracking-wide mb-1">내 답변</p>
+                  <p className="text-[12px] text-[#374151] leading-relaxed">{turnAnswerMap[qf.turnId]}</p>
+                </div>
+              )}
+
+              <div className="grid grid-cols-2 gap-3 mb-3 max-sm:grid-cols-1">
+                <div className="bg-[#F0FDF4] rounded-xl p-3">
+                  <p className="text-[10px] font-bold text-[#059669] uppercase tracking-wide mb-1.5">잘한 점</p>
+                  <ul className="flex flex-col gap-1">
+                    {qf.strengths.map((s, j) => (
+                      <li key={j} className="text-[11px] text-[#374151] flex items-start gap-1.5">
+                        <span className="text-[#059669] shrink-0">✓</span>{s}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="bg-[#FFF7ED] rounded-xl p-3">
+                  <p className="text-[10px] font-bold text-[#D97706] uppercase tracking-wide mb-1.5">개선할 점</p>
+                  <ul className="flex flex-col gap-1">
+                    {qf.improvements.map((s, j) => (
+                      <li key={j} className="text-[11px] text-[#374151] flex items-start gap-1.5">
+                        <span className="text-[#D97706] shrink-0">→</span>{s}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </div>
-              <div className="bg-[#FFF7ED] rounded-xl p-3">
-                <p className="text-[10px] font-bold text-[#D97706] uppercase tracking-wide mb-1.5">개선할 점</p>
-                <ul className="flex flex-col gap-1">
-                  {qf.improvements.map((s, j) => (
-                    <li key={j} className="text-[11px] text-[#374151] flex items-start gap-1.5">
-                      <span className="text-[#D97706] shrink-0">→</span>{s}
-                    </li>
-                  ))}
-                </ul>
-              </div>
+
+              {qf.modelAnswer && (
+                <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl p-3">
+                  <p className="text-[10px] font-bold text-[#0991B2] uppercase tracking-wide mb-1">모범 답변</p>
+                  <p className="text-[12px] text-[#374151] leading-relaxed">{qf.modelAnswer}</p>
+                </div>
+              )}
             </div>
-
-            {qf.modelAnswer && (
-              <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl p-3">
-                <p className="text-[10px] font-bold text-[#0991B2] uppercase tracking-wide mb-1">모범 답변</p>
-                <p className="text-[12px] text-[#374151] leading-relaxed">{qf.modelAnswer}</p>
-              </div>
-            )}
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/pages/interview-report/ui/QuestionFeedbackList.tsx
+++ b/src/pages/interview-report/ui/QuestionFeedbackList.tsx
@@ -44,16 +44,12 @@ export function QuestionFeedbackList({
                 </div>
               )}
 
-              {behaviorAnalysis?.speechData && (
-                <div className="mb-3">
-                  <InteractiveTimeline
-                    recordingId={recording?.recordingId}
-                    mediaType={recording?.mediaType}
-                    speechData={behaviorAnalysis.speechData}
-                    speechSegments={speechSegments}
-                  />
-                </div>
-              )}
+              <InteractiveTimeline
+                recordingId={recording?.recordingId}
+                mediaType={recording?.mediaType}
+                speechData={behaviorAnalysis?.speechData ?? null}
+                speechSegments={speechSegments}
+              />
 
               <div className="grid grid-cols-2 gap-3 mb-3 max-sm:grid-cols-1">
                 <div className="bg-[#F0FDF4] rounded-xl p-3">

--- a/src/pages/interview-report/ui/VoiceAnalysisPanel.tsx
+++ b/src/pages/interview-report/ui/VoiceAnalysisPanel.tsx
@@ -1,0 +1,141 @@
+import type { BehaviorAnalysis } from "@/features/interview-session";
+
+interface VoiceAnalysisPanelProps {
+  analysis: BehaviorAnalysis;
+}
+
+function formatDuration(ms: number) {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+}
+
+export function VoiceAnalysisPanel({ analysis }: VoiceAnalysisPanelProps) {
+  if (!analysis.speechData) return null;
+
+  const { summary, timeline } = analysis.speechData;
+  const { totalDurationMs } = summary;
+
+  const getDbfsColor = (dbfs: number | null) => {
+    if (dbfs === null) return "bg-[#E5E7EB]";
+    if (dbfs >= -30) return "bg-[#059669]";
+    if (dbfs >= -45) return "bg-[#D97706]";
+    return "bg-[#DC2626]";
+  };
+
+  const getSilenceColor = (ratio: number) => {
+    if (ratio < 0.15) return "text-[#059669]";
+    if (ratio <= 0.3) return "text-[#D97706]";
+    return "text-[#DC2626]";
+  };
+
+  const silenceRatioPct = Math.round(summary.silenceRatio * 100);
+  const dashArray = `${silenceRatioPct}, 100`;
+
+  return (
+    <div className="bg-white border border-[#E5E7EB] rounded-xl p-4 flex flex-col gap-4 mt-4">
+      <div className="flex justify-between items-start">
+        <h4 className="text-[10px] font-bold uppercase tracking-wide text-[#0991B2]">음성 분석 결과</h4>
+        <div className="flex gap-4 text-[10px] text-[#6B7280]">
+          <div className="flex flex-col items-end">
+            <span>총 답변 시간</span>
+            <span className="text-[11px] font-bold text-gray-900">{formatDuration(summary.totalDurationMs)}</span>
+          </div>
+          <div className="flex flex-col items-end">
+            <span>발화 시간</span>
+            <span className="text-[11px] font-bold text-gray-900">{formatDuration(summary.speechDurationMs)}</span>
+          </div>
+          <div className="flex flex-col items-end">
+            <span>침묵 횟수</span>
+            <span className="text-[11px] font-bold text-gray-900">{summary.silenceSegmentCount}회</span>
+          </div>
+          <div className="flex flex-col items-end">
+            <span>평균 음량</span>
+            <span className="text-[11px] font-bold text-gray-900">
+              {summary.avgDbfsSpeech !== null ? `${summary.avgDbfsSpeech.toFixed(1)} dBFS` : "N/A"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-6 items-center">
+        <div className="flex flex-col items-center gap-1 shrink-0">
+          <span className="text-[10px] text-[#6B7280]">침묵 비율</span>
+          <div className="relative w-12 h-12 flex items-center justify-center rounded-full bg-gray-100">
+            <svg viewBox="0 0 36 36" className="absolute w-full h-full -rotate-90">
+              <path
+                className="text-gray-200"
+                d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className={getSilenceColor(summary.silenceRatio)}
+                d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="4"
+                strokeDasharray={dashArray}
+              />
+            </svg>
+            <span className={`text-[11px] font-bold ${getSilenceColor(summary.silenceRatio)}`}>
+              {silenceRatioPct}%
+            </span>
+          </div>
+        </div>
+
+        <div className="flex-1 flex flex-col gap-3 overflow-hidden">
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-[#6B7280]">발화/침묵 구간</span>
+            <div className="h-4 flex rounded-full overflow-hidden bg-gray-100 w-full group">
+              {timeline.map((seg, idx) => {
+                const widthPct = ((seg.endMs - seg.startMs) / totalDurationMs) * 100;
+                const label = seg.type === "speech" ? "발화" : "침묵";
+                return (
+                  <div
+                    key={idx}
+                    className={`h-full relative ${seg.type === "speech" ? "bg-[#059669]" : "bg-gray-300"}`}
+                    style={{ width: `${widthPct}%` }}
+                    title={`${label}: ${formatDuration(seg.startMs)} - ${formatDuration(seg.endMs)}`}
+                  />
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-[#6B7280]">음량 (dBFS)</span>
+            <div className="h-8 flex items-end w-full gap-[1px]">
+              {timeline.map((seg, idx) => {
+                if (seg.type === "silence") {
+                  const widthPct = ((seg.endMs - seg.startMs) / totalDurationMs) * 100;
+                  return <div key={idx} style={{ width: `${widthPct}%` }} className="h-0" />;
+                }
+                const widthPct = ((seg.endMs - seg.startMs) / totalDurationMs) * 100;
+                const dbfs = seg.dbfs || -60;
+                const heightPct = Math.max(10, Math.min(100, ((dbfs + 60) / 60) * 100));
+                
+                return (
+                  <div
+                    key={idx}
+                    className="flex items-end"
+                    style={{ width: `${widthPct}%`, height: "100%" }}
+                  >
+                    <div 
+                      className={`w-full rounded-t-sm ${getDbfsColor(dbfs)}`} 
+                      style={{ height: `${heightPct}%` }}
+                      title={`음량: ${dbfs.toFixed(1)} dBFS`}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/interview-report/ui/VoiceAnalysisPanel.tsx
+++ b/src/pages/interview-report/ui/VoiceAnalysisPanel.tsx
@@ -12,10 +12,12 @@ function formatDuration(ms: number) {
 }
 
 export function VoiceAnalysisPanel({ analysis }: VoiceAnalysisPanelProps) {
-  if (!analysis.speechData) return null;
+  if (!analysis.speechData?.summary || !analysis.speechData?.timeline) return null;
 
   const { summary, timeline } = analysis.speechData;
   const { totalDurationMs } = summary;
+
+  if (totalDurationMs <= 0 || timeline.length === 0) return null;
 
   const getDbfsColor = (dbfs: number | null) => {
     if (dbfs === null) return "bg-[#E5E7EB]";

--- a/src/pages/interview-session/hooks/useInterviewMachine.ts
+++ b/src/pages/interview-session/hooks/useInterviewMachine.ts
@@ -182,10 +182,10 @@ export function useInterviewMachine(deps: InterviewMachineDeps): UseInterviewMac
       if (busyRef.current || !state.turnId || !answer.trim()) return;
       busyRef.current = true;
 
+      dispatch({ type: "SUBMIT" });
       const d = depsRef.current;
       d.stopStt();
       await d.stopRecording();
-      dispatch({ type: "SUBMIT" });
 
       try {
         await submitInterviewAnswer(deps.sessionUuid, state.turnId, answer, speechSegments);

--- a/src/pages/interview-session/hooks/useInterviewMachine.ts
+++ b/src/pages/interview-session/hooks/useInterviewMachine.ts
@@ -1,0 +1,216 @@
+import { useReducer, useEffect, useRef, useCallback } from "react";
+import {
+  machineReducer,
+  initialMachineState,
+  type MachineState,
+  type MachineEvent,
+} from "../model/machine";
+import { useInterviewSessionStore } from "@/features/interview-session";
+
+export interface InterviewMachineDeps {
+  sessionUuid: string;
+  playTtsText: (text: string) => Promise<void>;
+  skipTts: () => void;
+  destroyTts: () => void;
+  startStt: () => void;
+  stopStt: () => void;
+  resetText: () => void;
+  cleanupMedia: () => void;
+  mediaReady: boolean;
+  prepareRecording: (turnId: number) => Promise<void>;
+  startRecording: (turnId: number) => Promise<void>;
+  stopRecording: () => Promise<void>;
+  abortRecording: () => Promise<void>;
+  avatarSpeak: (text: string) => void;
+  startVideoAnalysis: () => Promise<void>;
+  stopVideoAnalysis: () => void;
+  resetWarnings: () => void;
+  navigate: (to: string) => void;
+}
+
+export interface UseInterviewMachineReturn {
+  state: MachineState;
+  dispatch: React.Dispatch<MachineEvent>;
+  handleStart: () => Promise<void>;
+  handlePracticeStart: () => void;
+  handleSubmit: (answer: string, speechSegments?: { text: string; startMs: number; endMs: number }[]) => Promise<void>;
+}
+
+export function useInterviewMachine(deps: InterviewMachineDeps): UseInterviewMachineReturn {
+  const {
+    interviewSession,
+    interviewPhase: storePhase,
+    interviewError: storeError,
+    currentInterviewTurn,
+    startInterview,
+    submitInterviewAnswer,
+  } = useInterviewSessionStore();
+
+  const isRealMode = interviewSession?.interviewPracticeMode === "real";
+
+  const [state, dispatch] = useReducer(machineReducer, {
+    ...initialMachineState,
+    isRealMode,
+  });
+
+  useEffect(() => {
+    dispatch({ type: "SET_REAL_MODE", isRealMode });
+  }, [isRealMode]);
+
+  const depsRef = useRef(deps);
+  depsRef.current = deps;
+  const busyRef = useRef(false);
+
+  // ── Transition: idle → ready | resume ──
+  useEffect(() => {
+    if (state.phase !== "idle" || !deps.mediaReady) return;
+
+    if (storePhase === "listening" && currentInterviewTurn) {
+      depsRef.current.startVideoAnalysis().catch(() => {});
+      dispatch({
+        type: "RESUME",
+        turnId: currentInterviewTurn.id,
+        question: currentInterviewTurn.question,
+      });
+    } else if (storePhase === "finished") {
+      dispatch({ type: "FINISH" });
+    } else if (interviewSession && storePhase === "idle") {
+      dispatch({ type: "MEDIA_READY" });
+    }
+  }, [state.phase, deps.mediaReady, storePhase, currentInterviewTurn, interviewSession]);
+
+  // ── Store error → machine error ──
+  useEffect(() => {
+    if (storePhase === "error" && storeError) {
+      dispatch({ type: "ERROR", message: storeError });
+    }
+  }, [storePhase, storeError]);
+
+  // ── Store finished (external) → machine finished ──
+  useEffect(() => {
+    if (storePhase === "finished" && state.phase !== "finished" && state.phase !== "idle") {
+      dispatch({ type: "FINISH" });
+    }
+  }, [storePhase, state.phase]);
+
+  // ── Effect: tts_playing entry → play TTS + avatar + pre-init recording ──
+  useEffect(() => {
+    if (state.phase !== "tts_playing" || !state.question || !state.turnId) return;
+    let cancelled = false;
+
+    const d = depsRef.current;
+    d.resetText();
+    d.avatarSpeak(state.question);
+    d.prepareRecording(state.turnId).catch(() => {});
+    d.playTtsText(state.question).then(() => {
+      if (!cancelled) dispatch({ type: "TTS_DONE" });
+    });
+
+    return () => {
+      cancelled = true;
+      depsRef.current.skipTts();
+    };
+  }, [state.phase, state.turnId, state.question]);
+
+  // ── Effect: countdown tick ──
+  useEffect(() => {
+    if (state.phase !== "countdown" || state.countdown === null || state.countdown <= 0) return;
+    const id = setTimeout(() => dispatch({ type: "COUNTDOWN_TICK" }), 1000);
+    return () => clearTimeout(id);
+  }, [state.phase, state.countdown]);
+
+  // ── Effect: speaking entry → start STT + recording ──
+  useEffect(() => {
+    if (state.phase !== "speaking" || !state.turnId) return;
+    depsRef.current.startStt();
+    depsRef.current.startRecording(state.turnId).catch(() => {});
+  }, [state.phase, state.turnId]);
+
+  // ── Effect: finished entry → cleanup + navigate ──
+  useEffect(() => {
+    if (state.phase !== "finished") return;
+
+    const d = depsRef.current;
+    d.stopStt();
+    d.stopRecording().catch(() => {});
+    d.destroyTts();
+    d.cleanupMedia();
+    d.stopVideoAnalysis();
+
+    const timer = setTimeout(() => depsRef.current.navigate("/interview/results"), 1500);
+    return () => clearTimeout(timer);
+  }, [state.phase]);
+
+  // ── Handlers ──
+
+  const handleStart = useCallback(async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+
+    try {
+      dispatch({ type: "START" });
+      const d = depsRef.current;
+      d.resetWarnings();
+      await d.startVideoAnalysis();
+
+      await startInterview(deps.sessionUuid);
+      const store = useInterviewSessionStore.getState();
+
+      if (store.interviewPhase === "error") {
+        dispatch({ type: "ERROR", message: store.interviewError ?? "면접 시작에 실패했습니다." });
+        return;
+      }
+
+      if (store.currentInterviewTurn) {
+        dispatch({
+          type: "QUESTION_ARRIVED",
+          turnId: store.currentInterviewTurn.id,
+          question: store.currentInterviewTurn.question,
+        });
+      }
+    } finally {
+      busyRef.current = false;
+    }
+  }, [deps.sessionUuid, startInterview]);
+
+  const handlePracticeStart = useCallback(() => {
+    dispatch({ type: "PRACTICE_START" });
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (answer: string, speechSegments?: { text: string; startMs: number; endMs: number }[]) => {
+      if (busyRef.current || !state.turnId || !answer.trim()) return;
+      busyRef.current = true;
+
+      const d = depsRef.current;
+      d.stopStt();
+      await d.stopRecording();
+      dispatch({ type: "SUBMIT" });
+
+      try {
+        await submitInterviewAnswer(deps.sessionUuid, state.turnId, answer, speechSegments);
+        const store = useInterviewSessionStore.getState();
+
+        if (store.interviewPhase === "error") {
+          dispatch({ type: "ERROR", message: store.interviewError ?? "답변 제출에 실패했습니다." });
+          return;
+        }
+
+        if (store.interviewPhase === "finished") {
+          dispatch({ type: "FINISH" });
+        } else if (store.currentInterviewTurn && store.currentInterviewTurn.id !== state.turnId) {
+          dispatch({
+            type: "ANSWER_ACCEPTED",
+            nextTurnId: store.currentInterviewTurn.id,
+            nextQuestion: store.currentInterviewTurn.question,
+          });
+        }
+      } finally {
+        busyRef.current = false;
+      }
+    },
+    [state.turnId, deps.sessionUuid, submitInterviewAnswer],
+  );
+
+  return { state, dispatch, handleStart, handlePracticeStart, handleSubmit };
+}

--- a/src/pages/interview-session/hooks/useMediaSetup.ts
+++ b/src/pages/interview-session/hooks/useMediaSetup.ts
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback } from "react";
 import { WebSpeechSTTProvider } from "@/shared/lib/stt/WebSpeechSTTProvider";
+import type { STTSegment } from "@/shared/lib/stt/types";
 
 /**
  * Manages camera/mic stream, audio level metering, and STT provider.
@@ -20,6 +21,8 @@ export function useMediaSetup() {
   const [interimText, setInterimText] = useState("");
   const [audioLevel, setAudioLevel] = useState(0);
   const [mediaReady, setMediaReady] = useState(false);
+  const [sttSegments, setSttSegments] = useState<STTSegment[]>([]);
+  const lastFinalTimestampRef = useRef(0);
 
   const setupMedia = useCallback(async () => {
     try {
@@ -47,8 +50,16 @@ export function useMediaSetup() {
 
     sttRef.current = new WebSpeechSTTProvider();
     sttRef.current.onResult((result) => {
-      if (result.isFinal) { setFinalText((prev) => prev + (prev ? " " : "") + result.text); setInterimText(""); }
-      else setInterimText(result.text);
+      if (result.isFinal) {
+        const startMs = lastFinalTimestampRef.current;
+        const endMs = result.timestampMs;
+        lastFinalTimestampRef.current = endMs;
+        setSttSegments((prev) => [...prev, { text: result.text, startMs, endMs }]);
+        setFinalText((prev) => prev + (prev ? " " : "") + result.text);
+        setInterimText("");
+      } else {
+        setInterimText(result.text);
+      }
     });
     sttRef.current.onError((e) => console.warn("STT 오류:", e));
     setMediaReady(true);
@@ -78,6 +89,8 @@ export function useMediaSetup() {
   const resetText = useCallback(() => {
     setFinalText("");
     setInterimText("");
+    setSttSegments([]);
+    lastFinalTimestampRef.current = 0;
   }, []);
 
   return {
@@ -90,6 +103,7 @@ export function useMediaSetup() {
     interimText,
     audioLevel,
     mediaReady,
+    sttSegments,
     // Setters
     setIsListening,
     setFinalText,

--- a/src/pages/interview-session/hooks/useMediaSetup.ts
+++ b/src/pages/interview-session/hooks/useMediaSetup.ts
@@ -59,7 +59,9 @@ export function useMediaSetup() {
     mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
     mediaStreamRef.current = null;
     if (audioRafRef.current) cancelAnimationFrame(audioRafRef.current);
-    audioCtxRef.current?.close();
+    audioRafRef.current = null;
+    audioCtxRef.current?.close().catch(() => {});
+    audioCtxRef.current = null;
     analyserRef.current = null;
   }, []);
 

--- a/src/pages/interview-session/model/DESIGN.md
+++ b/src/pages/interview-session/model/DESIGN.md
@@ -1,0 +1,130 @@
+# Interview Session State Machine
+
+## State Diagram
+
+```
+                    ┌──────────────────────────────────────────────────┐
+                    │                    FINISH (global)               │
+                    ▼                                                  │
+┌──────┐  MEDIA_READY  ┌───────┐  START  ┌──────────┐  QUESTION_ARRIVED  ┌─────────────┐
+│ idle │──────────────▶│ ready │────────▶│ starting │���─────────────────▶│ tts_playing │
+└──────┘               └───────┘         └──────────┘                   └──────┬──────┘
+    │                                                                          │
+    │  RESUME                                                          TTS_DONE│
+    └──────────────────────────────────────────────────────────────────────┐    │
+                                                                          │    │
+                                                              ┌───────────┴────┴──────────────┐
+                                                              │         isRealMode?            │
+                                                              ├───────────────┬────────────────┤
+                                                              │ true          │ false          │
+                                                              ▼               ▼                │
+                                                        ┌───────────┐  ┌────────────────┐     │
+                                                        │ countdown │  │ awaiting_start │     │
+                                                        └─────┬─────┘  └───────┬────────┘     │
+                                                  COUNTDOWN   │  PRACTICE      │               │
+                                                  _TICK(→0)   │  _START        │               │
+                                                              ▼                ▼               │
+                                                        ┌──────────┐                          │
+                                                        │ speaking │                          │
+                                                        └────┬─────┘                          │
+                                                     SUBMIT  │                                │
+                                                             ▼                                │
+                                                      ┌────────────┐  ANSWER_ACCEPTED         │
+                                                      │ submitting │──────────────────────────┘
+                                                      └─────┬──────┘
+                                                    FINISH  │
+                                                            ▼
+                                                      ┌──────────┐
+                                                      │ finished │
+                                                      └──────────┘
+```
+
+## States
+
+| Phase | Description | Entry Side Effects |
+|---|---|---|
+| `idle` | Page mounted, waiting for session data + media device access | None |
+| `ready` | Media ready, session loaded — Start button enabled | None |
+| `starting` | `startInterview` API call in-flight | `startVideoAnalysis()`, `resetWarnings()` |
+| `tts_playing` | Question audio playing via TTS + avatar speaking | `resetText()`, `avatarSpeak(question)`, `playTtsText(question)` |
+| `countdown` | Real mode only — random 5-30s countdown before auto-start | Timer: 1s interval dispatching `COUNTDOWN_TICK` |
+| `awaiting_start` | Practice mode only — waiting for user to click "말하기 시작" | None |
+| `speaking` | STT listening + video recording active | `startStt()`, `startRecording(turnId)` |
+| `submitting` | Answer submitted to backend, awaiting response | `stopStt()`, `stopRecording()` (called in handler before dispatch) |
+| `finished` | Interview complete, navigating to results | `stopStt()`, `stopRecording()`, `destroyTts()`, `cleanupMedia()`, `stopVideoAnalysis()`, then `navigate("/interview/results")` after 1.5s |
+| `error` | Unrecoverable error occurred | None |
+
+## Events
+
+| Event | Payload | Accepted In | Transitions To |
+|---|---|---|---|
+| `MEDIA_READY` | — | `idle` | `ready` |
+| `RESUME` | `turnId`, `question` | `idle` | `tts_playing` |
+| `START` | — | `ready` | `starting` |
+| `QUESTION_ARRIVED` | `turnId`, `question` | `starting` | `tts_playing` |
+| `TTS_DONE` | — | `tts_playing` | `countdown` (real) / `awaiting_start` (practice) |
+| `COUNTDOWN_TICK` | — | `countdown` | `countdown` (decrement) / `speaking` (when 0) |
+| `PRACTICE_START` | — | `awaiting_start` | `speaking` |
+| `SUBMIT` | — | `speaking` | `submitting` |
+| `ANSWER_ACCEPTED` | `nextTurnId`, `nextQuestion` | `submitting` | `tts_playing` |
+| `FINISH` | ��� | **any** (global) | `finished` |
+| `ERROR` | `message` | **any** (global) | `error` |
+| `SET_REAL_MODE` | `isRealMode` | **any** (global) | same phase (context update) |
+
+## Context (MachineState)
+
+```typescript
+interface MachineState {
+  phase: MachinePhase;
+  isRealMode: boolean;      // real → countdown after TTS, practice → awaiting_start
+  turnId: number | null;    // current question turn ID
+  question: string | null;  // current question text
+  countdown: number | null; // countdown remaining seconds (real mode only)
+  error: string | null;     // error message
+}
+```
+
+## Two Interview Modes
+
+The state machine handles **followup** (꼬리질문형) and **full_process** (전체프로세스형) identically at the flow level. The branching happens inside the Zustand store's `submitInterviewAnswer` action:
+
+- **followup**: Backend generates follow-up questions based on the answer. Response includes `turns[]` and `followupExhausted` flag.
+- **full_process**: Backend returns the next pre-generated question, or signals completion.
+
+Both paths result in either `ANSWER_ACCEPTED` (next question) or `FINISH` (interview done). The machine reads the store state after `submitInterviewAnswer` completes to decide which event to dispatch.
+
+## Session Resume (Page Refresh)
+
+When the user refreshes the page mid-interview:
+
+1. `loadInterviewSession` loads session data, finds the first unanswered turn, sets `interviewPhase: "listening"`
+2. `setupMedia()` initializes camera/mic
+3. When both `mediaReady` and `storePhase === "listening"` become true, the machine dispatches `RESUME`
+4. `RESUME` transitions `idle → tts_playing`, replaying the current question's TTS
+
+## File Structure
+
+```
+pages/interview-session/
+├── model/
+│   ├── machine.ts        # Pure reducer + types (no side effects)
+│   └── DESIGN.md         # This file
+├── hooks/
+│   ├── useInterviewMachine.ts  # Hook: useReducer + side effects + handlers
+│   ├── useMediaSetup.ts        # Camera/mic/STT (imperative API)
+│   ├── useVideoAnalysis.ts     # Face detection (imperative API)
+│   ├── usePermissionMonitor.ts # Permission polling
+│   └── useScreenSize.ts        # Responsive check
+└── ui/
+    ├── InterviewSessionPage.tsx  # Page: wires machine + hooks + UI
+    ├── SessionActionPanel.tsx    # Action buttons: derives mode from machine phase
+    └── ...
+```
+
+## Architecture Rationale
+
+**Why `useReducer` over xstate**: No new dependency. The state machine is simple enough (10 states, 12 events) that a switch-case reducer with TypeScript discrimination is clear and testable. xstate would add value for parallel states or history nodes, neither of which apply here.
+
+**Why side effects in the hook, not the reducer**: React's `useReducer` must be pure. Side effects (TTS playback, STT start/stop, recording, navigation) are triggered by `useEffect` hooks keyed on `[state.phase, state.turnId]` in `useInterviewMachine`. Each effect maps to a state machine entry action.
+
+**Why the Zustand store is kept**: The store manages server-side data (session metadata, turns, API calls). The state machine manages client-side flow (when to play TTS, when to record, UI state). They interact via: machine reads store state after async actions, store changes can trigger machine events via `useEffect` watchers.

--- a/src/pages/interview-session/model/machine.ts
+++ b/src/pages/interview-session/model/machine.ts
@@ -1,0 +1,123 @@
+/**
+ * Interview Session State Machine — Pure reducer.
+ * idle → ready → starting → tts_playing ⇄ countdown|awaiting_start → speaking → submitting → (loop | finished)
+ * Side effects live in useInterviewMachine hook, not here.
+ */
+
+export type MachinePhase =
+  | "idle"            // waiting for session + media
+  | "ready"           // user can click Start
+  | "starting"        // startInterview API in-flight
+  | "tts_playing"     // question audio playing
+  | "countdown"       // real mode: auto-start countdown
+  | "awaiting_start"  // practice mode: waiting user click
+  | "speaking"        // STT + recording active
+  | "submitting"      // answer submitted, backend processing
+  | "finished"
+  | "error";
+
+export interface MachineState {
+  phase: MachinePhase;
+  isRealMode: boolean;
+  turnId: number | null;
+  question: string | null;
+  countdown: number | null;
+  error: string | null;
+}
+
+export type MachineEvent =
+  | { type: "MEDIA_READY" }
+  | { type: "RESUME"; turnId: number; question: string }
+  | { type: "START" }
+  | { type: "QUESTION_ARRIVED"; turnId: number; question: string }
+  | { type: "TTS_DONE" }
+  | { type: "COUNTDOWN_TICK" }
+  | { type: "PRACTICE_START" }
+  | { type: "SUBMIT" }
+  | { type: "ANSWER_ACCEPTED"; nextTurnId: number; nextQuestion: string }
+  | { type: "FINISH" }
+  | { type: "ERROR"; message: string }
+  | { type: "SET_REAL_MODE"; isRealMode: boolean };
+
+export const initialMachineState: MachineState = {
+  phase: "idle",
+  isRealMode: false,
+  turnId: null,
+  question: null,
+  countdown: null,
+  error: null,
+};
+
+function randomCountdown(): number {
+  return Math.floor(Math.random() * 26) + 5;
+}
+
+export function machineReducer(state: MachineState, event: MachineEvent): MachineState {
+  if (event.type === "ERROR") {
+    return { ...state, phase: "error", error: event.message };
+  }
+  if (event.type === "FINISH") {
+    return { ...state, phase: "finished", countdown: null };
+  }
+  if (event.type === "SET_REAL_MODE") {
+    return { ...state, isRealMode: event.isRealMode };
+  }
+
+  switch (state.phase) {
+    case "idle":
+      if (event.type === "MEDIA_READY") return { ...state, phase: "ready" };
+      if (event.type === "RESUME") {
+        return { ...state, phase: "tts_playing", turnId: event.turnId, question: event.question };
+      }
+      return state;
+
+    case "ready":
+      if (event.type === "START") return { ...state, phase: "starting" };
+      return state;
+
+    case "starting":
+      if (event.type === "QUESTION_ARRIVED") {
+        return { ...state, phase: "tts_playing", turnId: event.turnId, question: event.question };
+      }
+      return state;
+
+    case "tts_playing":
+      if (event.type === "TTS_DONE") {
+        return state.isRealMode
+          ? { ...state, phase: "countdown", countdown: randomCountdown() }
+          : { ...state, phase: "awaiting_start" };
+      }
+      return state;
+
+    case "countdown":
+      if (event.type === "COUNTDOWN_TICK") {
+        const next = (state.countdown ?? 1) - 1;
+        if (next <= 0) return { ...state, phase: "speaking", countdown: null };
+        return { ...state, countdown: next };
+      }
+      return state;
+
+    case "awaiting_start":
+      if (event.type === "PRACTICE_START") return { ...state, phase: "speaking" };
+      return state;
+
+    case "speaking":
+      if (event.type === "SUBMIT") return { ...state, phase: "submitting" };
+      return state;
+
+    case "submitting":
+      if (event.type === "ANSWER_ACCEPTED") {
+        return {
+          ...state,
+          phase: "tts_playing",
+          turnId: event.nextTurnId,
+          question: event.nextQuestion,
+        };
+      }
+      return state;
+
+    case "finished":
+    case "error":
+      return state;
+  }
+}

--- a/src/pages/interview-session/ui/InterviewSessionPage.tsx
+++ b/src/pages/interview-session/ui/InterviewSessionPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 
-import { useInterviewSessionStore } from "@/features/interview-session";
+import { useInterviewSessionStore, useRecordingManager, RecordingIndicator } from "@/features/interview-session";
 import { AvatarSection } from "@/features/interview-session/ui/AvatarSection";
 import { QuestionPanel } from "@/features/interview-session/ui/QuestionPanel";
 import { TranscriptPanel } from "@/features/interview-session/ui/TranscriptPanel";
@@ -47,6 +47,20 @@ export function InterviewSessionPage() {
   const video = useVideoAnalysis(videoRef);
   const { screenSize, isTooSmall } = useScreenSize();
 
+  const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
+
+  useEffect(() => {
+    if (videoRef.current?.srcObject) {
+      setMediaStream(videoRef.current.srcObject as MediaStream);
+    }
+  }, [mediaReady, videoRef]);
+
+  const recording = useRecordingManager({
+    sessionUuid: interviewSessionUuid ?? "",
+    externalStream: mediaStream,
+    enabled: !!interviewSessionUuid,
+  });
+
   const avatarRef = useRef<IAvatarProvider | null>(null);
   const prevTurnIdRef = useRef<number | null>(null);
   const speechAnalyzerRef = useRef(new SpeechAnalyzer());
@@ -71,7 +85,8 @@ export function InterviewSessionPage() {
     destroyTts();
     cleanupMedia();
     video.stopVideoAnalysis();
-  }, [stopStt, destroyTts, cleanupMedia, video]);
+    recording.abortRecording().catch(() => {});
+  }, [stopStt, destroyTts, cleanupMedia, video, recording]);
 
   // ── Init ──
   useEffect(() => {
@@ -83,10 +98,13 @@ export function InterviewSessionPage() {
   }, [interviewSessionUuid]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const handler = () => cleanup();
+    const handler = () => {
+      recording.abortRecording().catch(() => {});
+      cleanup();
+    };
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
-  }, [cleanup]);
+  }, [cleanup, recording]);
 
   // ── Resume session: use ref to avoid setState-in-effect ──
   const handleResumeSession = useCallback(() => {
@@ -138,7 +156,8 @@ export function InterviewSessionPage() {
     setCountdown(null);
     setAnswerState("speaking");
     startStt();
-  }, [startStt]);
+    if (currentInterviewTurn) recording.startRecording(currentInterviewTurn.id);
+  }, [startStt, currentInterviewTurn, recording]);
 
   useEffect(() => {
     if (countdown === 0 && isRealMode && hasStarted) {
@@ -149,12 +168,13 @@ export function InterviewSessionPage() {
   // ── Finished → navigate ──
   const handleFinished = useCallback(() => {
     stopStt();
+    recording.stopRecording().catch(() => {});
     setCountdown(null);
     destroyTts();
     cleanupMedia();
     video.stopVideoAnalysis();
     setTimeout(() => navigate("/interview/results"), 1500);
-  }, [stopStt, destroyTts, cleanupMedia, video, navigate]);
+  }, [stopStt, destroyTts, cleanupMedia, video, navigate, recording]);
 
   useEffect(() => {
     if (interviewPhase === "finished") {
@@ -188,6 +208,7 @@ export function InterviewSessionPage() {
     const answer = (finalText + " " + interimText).trim();
     if (!answer) return;
     stopStt();
+    await recording.stopRecording();
     setAnswerState("waiting_ready");
     setCountdown(null);
     await submitInterviewAnswer(interviewSessionUuid, currentInterviewTurn.id, answer);
@@ -213,9 +234,14 @@ export function InterviewSessionPage() {
 
       <main className="flex-1 flex overflow-hidden min-h-0">
         <section className="flex-1 flex flex-col overflow-hidden border-r border-white/10">
-          {(interviewError || isFinished) && (
+          {(interviewError || isFinished || recording.error) && (
             <div className="shrink-0 px-6 pt-4">
               {interviewError && <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-3 text-red-400 text-sm mb-3">{interviewError}</div>}
+              {recording.error && (
+                <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl p-3 text-amber-400 text-sm mb-3">
+                  녹화 오류: {recording.error}
+                </div>
+              )}
               {isFinished && (
                 <div className="bg-indigo-500/10 border border-indigo-500/30 rounded-xl p-4 text-center mb-3">
                   <p className="text-indigo-300 font-bold text-base mb-1">면접이 종료되었습니다</p>
@@ -246,7 +272,11 @@ export function InterviewSessionPage() {
             ttsPlaying={ttsPlaying} audioLevel={audioLevel}
             finalText={finalText} interimText={interimText}
             onStart={handleStart}
-            onPracticeStart={() => { setAnswerState("speaking"); startStt(); }}
+            onPracticeStart={() => { 
+              setAnswerState("speaking"); 
+              startStt(); 
+              if (currentInterviewTurn) recording.startRecording(currentInterviewTurn.id);
+            }}
             onSubmitAnswer={handleSubmitAnswer}
           />
           <div className="flex-1 min-h-0 p-4 flex">
@@ -262,6 +292,9 @@ export function InterviewSessionPage() {
                 <path d="M 50 10 C 35 10, 35 45, 50 45 C 65 45, 65 10, 50 10 Z" fill="none" stroke="currentColor" strokeWidth="2" strokeDasharray="4 6" />
                 <path d="M 10 95 C 10 60, 90 60, 90 95" fill="none" stroke="currentColor" strokeWidth="2" strokeDasharray="4 6" />
               </svg>
+            </div>
+            <div className="absolute top-2 right-2 z-10">
+              <RecordingIndicator isRecording={recording.isRecording} />
             </div>
             {video.isAnalyzing && (
               <div className="absolute top-2 left-2 text-[9px] font-bold text-green-400 bg-green-400/10 border border-green-400/30 rounded px-1.5 py-px flex items-center gap-1">

--- a/src/pages/interview-session/ui/InterviewSessionPage.tsx
+++ b/src/pages/interview-session/ui/InterviewSessionPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 
 import { useInterviewSessionStore, useRecordingManager, RecordingIndicator } from "@/features/interview-session";
@@ -9,12 +9,12 @@ import { BehaviorMetrics } from "@/features/interview-session/ui/BehaviorMetrics
 import { SpeechAnalyzer } from "@/shared/lib/speech/SpeechAnalyzer";
 import { useTts } from "@/shared/lib/tts/useTts";
 import type { IAvatarProvider } from "@/shared/lib/avatar/IAvatarProvider";
-import type { AnswerState } from "@/features/interview-session";
 
 import { useMediaSetup } from "../hooks/useMediaSetup";
 import { useVideoAnalysis } from "../hooks/useVideoAnalysis";
 import { usePermissionMonitor } from "../hooks/usePermissionMonitor";
 import { useScreenSize } from "../hooks/useScreenSize";
+import { useInterviewMachine } from "../hooks/useInterviewMachine";
 import { SessionHeader } from "./SessionHeader";
 import { SessionActionPanel } from "./SessionActionPanel";
 import { PermissionOverlay } from "./PermissionOverlay";
@@ -28,19 +28,14 @@ export function InterviewSessionPage() {
   const {
     interviewSession, currentInterviewTurn, currentInterviewTurnIndex,
     interviewPhase, interviewError,
-    loadInterviewSession, startInterview, submitInterviewAnswer, resetInterviewSession,
+    loadInterviewSession, resetInterviewSession,
   } = useInterviewSessionStore();
-
-  const practiceMode = interviewSession?.interviewPracticeMode ?? "practice";
-  const isRealMode = practiceMode === "real";
-  const isRealModeRef = useRef(isRealMode);
-  useEffect(() => { isRealModeRef.current = isRealMode; }, [isRealMode]);
 
   const { ttsPlaying, ttsMuted, setTtsMuted, ttsVolume, setTtsVolume, playTtsText, skipTts, destroyTts } = useTts();
 
   const {
     videoRef,
-    isListening, finalText, interimText, audioLevel, mediaReady,
+    isListening, finalText, interimText, audioLevel, mediaReady, sttSegments,
     setupMedia, cleanupMedia, startStt, stopStt, resetText,
   } = useMediaSetup();
 
@@ -48,7 +43,6 @@ export function InterviewSessionPage() {
   const { screenSize, isTooSmall } = useScreenSize();
 
   const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
-
   useEffect(() => {
     if (videoRef.current?.srcObject) {
       setMediaStream(videoRef.current.srcObject as MediaStream);
@@ -62,127 +56,67 @@ export function InterviewSessionPage() {
   });
 
   const avatarRef = useRef<IAvatarProvider | null>(null);
-  const prevTurnIdRef = useRef<number | null>(null);
   const speechAnalyzerRef = useRef(new SpeechAnalyzer());
-  const hasStartedRef = useRef(false);
 
-  const [hasStarted, setHasStarted] = useState(false);
-  const [answerState, setAnswerState] = useState<AnswerState>("waiting_ready");
-  const [countdown, setCountdown] = useState<number | null>(null);
+  const machine = useInterviewMachine({
+    sessionUuid: interviewSessionUuid ?? "",
+    playTtsText,
+    skipTts,
+    destroyTts,
+    startStt,
+    stopStt,
+    resetText,
+    cleanupMedia,
+    mediaReady,
+    prepareRecording: recording.prepareRecording,
+    startRecording: recording.startRecording,
+    stopRecording: recording.stopRecording,
+    abortRecording: recording.abortRecording,
+    avatarSpeak: (text: string) => { avatarRef.current?.speak("", text).catch(() => {}); },
+    startVideoAnalysis: video.startVideoAnalysis,
+    stopVideoAnalysis: video.stopVideoAnalysis,
+    resetWarnings: video.resetWarnings,
+    navigate,
+  });
+
+  const { phase } = machine.state;
+  const hasStarted = phase !== "idle" && phase !== "ready";
+  const isFinished = phase === "finished";
+  const isRealMode = interviewSession?.interviewPracticeMode === "real";
+  const difficultyLabel = { friendly: "친근한 면접관", normal: "일반 면접관", pressure: "압박 면접관" }[interviewSession?.interviewDifficultyLevel ?? "normal"] ?? "일반 면접관";
+
   const [showFinishModal, setShowFinishModal] = useState(false);
   const [speechMetrics, setSpeechMetrics] = useState({ wpm: 0, fillerCount: 0, badWordCount: 0, pauseWarnings: 0, highlightedHtml: "" });
 
-  const permissionError = usePermissionMonitor(hasStarted && interviewPhase !== "finished");
+  const permissionError = usePermissionMonitor(hasStarted && !isFinished);
 
-  const isSubmitting = interviewPhase === "submitting" || interviewPhase === "generating_followup";
-  const isStarting = interviewPhase === "starting" || interviewPhase === "connecting";
-  const isFinished = interviewPhase === "finished";
-  const difficultyLabel = { friendly: "친근한 면접관", normal: "일반 면접관", pressure: "압박 면접관" }[interviewSession?.interviewDifficultyLevel ?? "normal"] ?? "일반 면접관";
-
-  const cleanup = useCallback(() => {
-    stopStt();
-    avatarRef.current?.destroy();
-    destroyTts();
-    cleanupMedia();
-    video.stopVideoAnalysis();
-    recording.abortRecording().catch(() => {});
-  }, [stopStt, destroyTts, cleanupMedia, video, recording]);
-
-  // ── Init ──
   useEffect(() => {
     if (!interviewSessionUuid) return;
     resetInterviewSession();
     loadInterviewSession(interviewSessionUuid);
     setupMedia();
-    return () => cleanup();
+    return () => {
+      stopStt();
+      avatarRef.current?.destroy();
+      destroyTts();
+      cleanupMedia();
+      video.stopVideoAnalysis();
+      recording.abortRecording().catch(() => {});
+    };
   }, [interviewSessionUuid]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const handler = () => {
       recording.abortRecording().catch(() => {});
-      cleanup();
+      stopStt();
+      destroyTts();
+      cleanupMedia();
+      video.stopVideoAnalysis();
     };
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
-  }, [cleanup, recording]);
+  }, [recording, stopStt, destroyTts, cleanupMedia, video]);
 
-  // ── Resume session: use ref to avoid setState-in-effect ──
-  const handleResumeSession = useCallback(() => {
-    if (!hasStartedRef.current) {
-      hasStartedRef.current = true;
-      setHasStarted(true);
-      video.startVideoAnalysis();
-    }
-  }, [video]);
-
-  useEffect(() => {
-    if (mediaReady && interviewPhase === "listening") {
-      handleResumeSession(); // eslint-disable-line react-hooks/set-state-in-effect -- sync external store state
-    }
-  }, [mediaReady, interviewPhase, handleResumeSession]);
-
-  // ── New question arrival handler ──
-  const handleNewQuestion = useCallback((questionText: string) => {
-    stopStt();
-    resetText();
-    setAnswerState("waiting_ready");
-    setCountdown(null);
-
-    playTtsText(questionText).then(() => {
-      if (isRealModeRef.current) {
-        setCountdown(Math.floor(Math.random() * 26) + 5);
-      }
-    });
-  }, [stopStt, resetText, playTtsText]);
-
-  useEffect(() => {
-    if (!currentInterviewTurn || !hasStarted || interviewPhase !== "listening") return;
-    if (currentInterviewTurn.id === prevTurnIdRef.current) return;
-    prevTurnIdRef.current = currentInterviewTurn.id;
-
-    handleNewQuestion(currentInterviewTurn.question); // eslint-disable-line react-hooks/set-state-in-effect -- sync on new question from store
-    avatarRef.current?.speak("", currentInterviewTurn.question).catch(() => {});
-  }, [currentInterviewTurn, hasStarted, interviewPhase, handleNewQuestion]);
-
-  // ── Countdown tick (setState in setTimeout callback is fine) ──
-  useEffect(() => {
-    if (countdown === null || countdown <= 0) return;
-    const id = setTimeout(() => setCountdown((c) => (c !== null ? c - 1 : null)), 1000);
-    return () => clearTimeout(id);
-  }, [countdown]);
-
-  // ── Countdown 0 → start STT ──
-  const handleCountdownDone = useCallback(() => {
-    setCountdown(null);
-    setAnswerState("speaking");
-    startStt();
-    if (currentInterviewTurn) recording.startRecording(currentInterviewTurn.id);
-  }, [startStt, currentInterviewTurn, recording]);
-
-  useEffect(() => {
-    if (countdown === 0 && isRealMode && hasStarted) {
-      handleCountdownDone(); // eslint-disable-line react-hooks/set-state-in-effect -- countdown reached zero
-    }
-  }, [countdown, isRealMode, hasStarted, handleCountdownDone]);
-
-  // ── Finished → navigate ──
-  const handleFinished = useCallback(() => {
-    stopStt();
-    recording.stopRecording().catch(() => {});
-    setCountdown(null);
-    destroyTts();
-    cleanupMedia();
-    video.stopVideoAnalysis();
-    setTimeout(() => navigate("/interview/results"), 1500);
-  }, [stopStt, destroyTts, cleanupMedia, video, navigate, recording]);
-
-  useEffect(() => {
-    if (interviewPhase === "finished") {
-      handleFinished(); // eslint-disable-line react-hooks/set-state-in-effect -- sync on phase change from store
-    }
-  }, [interviewPhase, handleFinished]);
-
-  // ── Speech metrics ──
   useEffect(() => {
     let id: ReturnType<typeof setInterval>;
     if (isListening) {
@@ -193,30 +127,19 @@ export function InterviewSessionPage() {
     return () => clearInterval(id);
   }, [finalText, interimText, isListening]);
 
-  // ── Handlers ──
-  const handleStart = async () => {
-    if (!interviewSessionUuid) return;
-    hasStartedRef.current = true;
-    setHasStarted(true);
-    video.resetWarnings();
-    await video.startVideoAnalysis();
-    await startInterview(interviewSessionUuid);
-  };
-
-  const handleSubmitAnswer = async () => {
-    if (!interviewSessionUuid || !currentInterviewTurn) return;
+  const handleSubmitAnswer = () => {
     const answer = (finalText + " " + interimText).trim();
-    if (!answer) return;
-    stopStt();
-    await recording.stopRecording();
-    setAnswerState("waiting_ready");
-    setCountdown(null);
-    await submitInterviewAnswer(interviewSessionUuid, currentInterviewTurn.id, answer);
+    machine.handleSubmit(answer, sttSegments);
   };
 
   const handleFinishConfirm = () => {
     setShowFinishModal(false);
-    cleanup();
+    stopStt();
+    avatarRef.current?.destroy();
+    destroyTts();
+    cleanupMedia();
+    video.stopVideoAnalysis();
+    recording.abortRecording().catch(() => {});
     navigate("/interview/results");
   };
 
@@ -266,17 +189,16 @@ export function InterviewSessionPage() {
 
         <section className="w-[340px] shrink-0 flex flex-col bg-[#0b1420] border-l border-white/5">
           <SessionActionPanel
-            hasStarted={hasStarted} isFinished={isFinished} isRealMode={isRealMode}
-            isStarting={isStarting} isModelLoading={video.isModelLoading} isSubmitting={isSubmitting}
-            interviewPhase={interviewPhase} answerState={answerState} countdown={countdown}
-            ttsPlaying={ttsPlaying} audioLevel={audioLevel}
-            finalText={finalText} interimText={interimText}
-            onStart={handleStart}
-            onPracticeStart={() => { 
-              setAnswerState("speaking"); 
-              startStt(); 
-              if (currentInterviewTurn) recording.startRecording(currentInterviewTurn.id);
-            }}
+            machinePhase={phase}
+            isRealMode={isRealMode}
+            countdown={machine.state.countdown}
+            isModelLoading={video.isModelLoading}
+            interviewPhase={interviewPhase}
+            audioLevel={audioLevel}
+            finalText={finalText}
+            interimText={interimText}
+            onStart={machine.handleStart}
+            onPracticeStart={machine.handlePracticeStart}
             onSubmitAnswer={handleSubmitAnswer}
           />
           <div className="flex-1 min-h-0 p-4 flex">

--- a/src/pages/interview-session/ui/SessionActionPanel.tsx
+++ b/src/pages/interview-session/ui/SessionActionPanel.tsx
@@ -1,22 +1,30 @@
 import { useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
-import type { InterviewPhase, AnswerState } from "@/features/interview-session";
+import type { InterviewPhase } from "@/features/interview-session";
+import type { MachinePhase } from "../model/machine";
 import { SpeakingWarning } from "./SpeakingWarning";
 
 const AUDIO_WARN_THRESHOLD = 25;
 const WARN_HOLD_MS = 3000;
 
+type ActionMode =
+  | "loading"
+  | "not_started"
+  | "starting"
+  | "real_tts_playing"
+  | "real_countdown"
+  | "practice_tts_playing"
+  | "practice_ready"
+  | "speaking"
+  | "submitting"
+  | "finished";
+
 interface SessionActionPanelProps {
-  hasStarted: boolean;
-  isFinished: boolean;
+  machinePhase: MachinePhase;
   isRealMode: boolean;
-  isStarting: boolean;
-  isModelLoading: boolean;
-  isSubmitting: boolean;
-  interviewPhase: InterviewPhase;
-  answerState: AnswerState;
   countdown: number | null;
-  ttsPlaying: boolean;
+  isModelLoading: boolean;
+  interviewPhase: InterviewPhase;
   audioLevel: number;
   finalText: string;
   interimText: string;
@@ -25,23 +33,35 @@ interface SessionActionPanelProps {
   onSubmitAnswer: () => void;
 }
 
+function deriveActionMode(machinePhase: MachinePhase, isRealMode: boolean): ActionMode {
+  switch (machinePhase) {
+    case "idle": return "loading";
+    case "ready": return "not_started";
+    case "starting": return "starting";
+    case "tts_playing": return isRealMode ? "real_tts_playing" : "practice_tts_playing";
+    case "countdown": return "real_countdown";
+    case "awaiting_start": return "practice_ready";
+    case "speaking": return "speaking";
+    case "submitting": return "submitting";
+    case "finished": return "finished";
+    case "error": return "finished";
+  }
+}
+
 export function SessionActionPanel({
-  hasStarted, isFinished, isRealMode, isStarting, isModelLoading,
-  isSubmitting, interviewPhase, answerState, countdown, ttsPlaying,
-  audioLevel, finalText, interimText,
+  machinePhase, isRealMode, countdown, isModelLoading,
+  interviewPhase, audioLevel, finalText, interimText,
   onStart, onPracticeStart, onSubmitAnswer,
 }: SessionActionPanelProps) {
-  const shouldWarn =
-    !isRealMode && hasStarted && !isFinished &&
-    (answerState === "waiting_ready" || answerState === "waiting_start") &&
-    !ttsPlaying && !isSubmitting;
+  const mode = deriveActionMode(machinePhase, isRealMode);
 
+  const shouldWarn = mode === "practice_ready";
   const [warnVisible, setWarnVisible] = useState(false);
   const warnTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!shouldWarn) {
-      setWarnVisible(false); // eslint-disable-line react-hooks/set-state-in-effect -- clearing on deactivation
+      setWarnVisible(false); // eslint-disable-line react-hooks/set-state-in-effect -- reset on mode change
       if (warnTimerRef.current) { clearTimeout(warnTimerRef.current); warnTimerRef.current = null; }
       return;
     }
@@ -57,72 +77,70 @@ export function SessionActionPanel({
 
   useEffect(() => () => { if (warnTimerRef.current) clearTimeout(warnTimerRef.current); }, []);
 
+  const hasAnswer = !!(finalText.trim() || interimText.trim());
+  const showLoading = mode === "loading" || mode === "starting" || (mode === "not_started" && isModelLoading);
+
   return (
     <div className="shrink-0 p-4 border-b border-white/10 flex flex-col gap-2">
-      {!hasStarted && !isFinished && (
+      {(mode === "loading" || mode === "not_started" || mode === "starting") && (
         <button
           onClick={onStart}
-          disabled={isStarting || isModelLoading}
+          disabled={mode !== "not_started" || isModelLoading}
           className="w-full py-3 rounded-xl font-bold text-base bg-indigo-600 hover:bg-indigo-500 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
         >
-          {isStarting || isModelLoading
+          {showLoading
             ? <><Loader2 size={16} className="animate-spin" /> 준비 중...</>
             : "면접 시작"}
         </button>
       )}
 
-      {hasStarted && !isFinished && (
-        <>
-          {isRealMode && ttsPlaying && countdown === null && (
-            <div className="w-full py-3 rounded-xl bg-indigo-500/10 border border-indigo-500/30 text-center">
-              <p className="text-indigo-300 text-xs font-semibold flex items-center justify-center gap-1.5">
-                <Loader2 size={12} className="animate-spin" /> 질문 음성 재생 중...
-              </p>
-            </div>
-          )}
+      {mode === "real_tts_playing" && (
+        <div className="w-full py-3 rounded-xl bg-indigo-500/10 border border-indigo-500/30 text-center">
+          <p className="text-indigo-300 text-xs font-semibold flex items-center justify-center gap-1.5">
+            <Loader2 size={12} className="animate-spin" /> 질문 음성 재생 중...
+          </p>
+        </div>
+      )}
 
-          {isRealMode && countdown !== null && countdown > 0 && (
-            <div className="w-full py-3 rounded-xl bg-amber-500/10 border border-amber-500/30 text-center">
-              <p className="text-amber-400 text-xs font-semibold mb-1">잠시 후 자동 시작</p>
-              <p className="text-amber-300 text-3xl font-black">{countdown}</p>
-            </div>
-          )}
+      {mode === "real_countdown" && (
+        <div className="w-full py-3 rounded-xl bg-amber-500/10 border border-amber-500/30 text-center">
+          <p className="text-amber-400 text-xs font-semibold mb-1">잠시 후 자동 시작</p>
+          <p className="text-amber-300 text-3xl font-black">{countdown}</p>
+        </div>
+      )}
 
-          {!isRealMode && (answerState === "waiting_ready" || answerState === "waiting_start") && !isSubmitting && (
-            <button
-              onClick={onPracticeStart}
-              disabled={ttsPlaying}
-              className="w-full py-3 rounded-xl font-bold text-base bg-green-600 hover:bg-green-500 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
-            >
-              {ttsPlaying
-                ? <><Loader2 size={14} className="animate-spin" /> 질문 음성 재생 중...</>
-                : "말하기 시작"}
-            </button>
-          )}
+      {mode === "practice_tts_playing" && (
+        <button disabled className="w-full py-3 rounded-xl font-bold text-base bg-green-600 transition-colors opacity-50 flex items-center justify-center gap-2">
+          <Loader2 size={14} className="animate-spin" /> 질문 음성 재생 중...
+        </button>
+      )}
 
-          <SpeakingWarning visible={warnVisible} />
+      {mode === "practice_ready" && (
+        <button
+          onClick={onPracticeStart}
+          className="w-full py-3 rounded-xl font-bold text-base bg-green-600 hover:bg-green-500 transition-colors flex items-center justify-center gap-2"
+        >
+          말하기 시작
+        </button>
+      )}
 
-          {(answerState === "speaking" || isSubmitting) && (
-            <button
-              onClick={onSubmitAnswer}
-              disabled={isSubmitting || (!finalText.trim() && !interimText.trim())}
-              className="w-full py-3 rounded-xl font-bold text-base bg-indigo-600 hover:bg-indigo-500 transition-colors disabled:opacity-40 flex items-center justify-center gap-2"
-            >
-              {isSubmitting ? (
-                <><Loader2 size={16} className="animate-spin" />
-                  {interviewPhase === "generating_followup" ? "꼬리질문 생성 중..." : "제출 중..."}
-                </>
-              ) : "답변 제출"}
-            </button>
-          )}
+      <SpeakingWarning visible={warnVisible} />
 
-          {isSubmitting && answerState !== "speaking" && (
-            <div className="w-full py-2.5 rounded-xl bg-slate-800/50 text-center text-[12px] text-slate-400 flex items-center justify-center gap-1.5">
-              <Loader2 size={12} className="animate-spin" />
-              {interviewPhase === "generating_followup" ? "꼬리질문 생성 중..." : "처리 중..."}
-            </div>
-          )}
-        </>
+      {mode === "speaking" && (
+        <button
+          onClick={onSubmitAnswer}
+          disabled={!hasAnswer}
+          className="w-full py-3 rounded-xl font-bold text-base bg-indigo-600 hover:bg-indigo-500 transition-colors disabled:opacity-40 flex items-center justify-center gap-2"
+        >
+          답변 제출
+        </button>
+      )}
+
+      {mode === "submitting" && (
+        <button disabled className="w-full py-3 rounded-xl font-bold text-base bg-indigo-600 opacity-50 flex items-center justify-center gap-2">
+          <Loader2 size={16} className="animate-spin" />
+          {interviewPhase === "generating_followup" ? "꼬리질문 생성 중..." : "제출 중..."}
+        </button>
       )}
     </div>
   );

--- a/src/pages/interview-session/ui/SessionActionPanel.tsx
+++ b/src/pages/interview-session/ui/SessionActionPanel.tsx
@@ -139,7 +139,7 @@ export function SessionActionPanel({
       {mode === "submitting" && (
         <button disabled className="w-full py-3 rounded-xl font-bold text-base bg-indigo-600 opacity-50 flex items-center justify-center gap-2">
           <Loader2 size={16} className="animate-spin" />
-          {interviewPhase === "generating_followup" ? "꼬리질문 생성 중..." : "제출 중..."}
+          {interviewPhase === "generating_followup" ? "꼬리질문 생성 중..." : interviewPhase === "submitting" ? "제출 중..." : "답변 저장 중..."}
         </button>
       )}
     </div>

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -128,6 +128,31 @@ async function _request<T>(
   return body as T;
 }
 
+/* ── Authenticated fetch with 401 retry (for raw fetch calls outside apiRequest) ── */
+
+export async function fetchWithAuth(
+  url: string | URL,
+  options: RequestInit = {},
+): Promise<Response> {
+  const token = getAccessToken();
+  const headers = new Headers(options.headers);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+
+  const res = await fetch(url, { ...options, headers });
+
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken();
+    if (refreshed) {
+      const newToken = getAccessToken();
+      const retryHeaders = new Headers(options.headers);
+      if (newToken) retryHeaders.set("Authorization", `Bearer ${newToken}`);
+      return fetch(url, { ...options, headers: retryHeaders });
+    }
+  }
+
+  return res;
+}
+
 /* ── Token refresh helper ── */
 
 // refresh 실패 시 호출할 콜백 (순환 의존 방지를 위해 런타임에 등록)

--- a/src/shared/lib/stt/WebSpeechSTTProvider.ts
+++ b/src/shared/lib/stt/WebSpeechSTTProvider.ts
@@ -43,6 +43,7 @@ export class WebSpeechSTTProvider implements ISTTProvider {
   private resultCallback?: (result: STTResult) => void;
   private errorCallback?: (error: unknown) => void;
   private isIntentionalStop = false;
+  private startTime = 0;
 
   constructor() {
     const SpeechRecognitionClass = window.SpeechRecognition || window.webkitSpeechRecognition;
@@ -66,8 +67,9 @@ export class WebSpeechSTTProvider implements ISTTProvider {
         }
       }
       if (this.resultCallback) {
-        if (finalTranscript) this.resultCallback({ text: finalTranscript, isFinal: true });
-        if (interimTranscript) this.resultCallback({ text: interimTranscript, isFinal: false });
+        const timestampMs = Date.now() - this.startTime;
+        if (finalTranscript) this.resultCallback({ text: finalTranscript, isFinal: true, timestampMs });
+        if (interimTranscript) this.resultCallback({ text: interimTranscript, isFinal: false, timestampMs });
       }
     };
 
@@ -86,8 +88,13 @@ export class WebSpeechSTTProvider implements ISTTProvider {
   start(language: string): void {
     if (!this.recognition) return;
     this.isIntentionalStop = false;
+    this.startTime = Date.now();
     this.recognition.lang = language;
     try { this.recognition.start(); } catch { /* already started */ }
+  }
+
+  getStartTime(): number {
+    return this.startTime;
   }
 
   stop(): void {

--- a/src/shared/lib/stt/types.ts
+++ b/src/shared/lib/stt/types.ts
@@ -1,6 +1,13 @@
 export interface STTResult {
   text: string;
   isFinal: boolean;
+  timestampMs: number;
+}
+
+export interface STTSegment {
+  text: string;
+  startMs: number;
+  endMs: number;
 }
 
 export interface ISTTProvider {
@@ -9,4 +16,5 @@ export interface ISTTProvider {
   switchLanguage(language: string): void;
   onResult(callback: (result: STTResult) => void): void;
   onError(callback: (error: unknown) => void): void;
+  getStartTime(): number;
 }

--- a/src/shared/lib/tts/useTts.ts
+++ b/src/shared/lib/tts/useTts.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from "react";
-import { getAccessToken } from "@/shared/api/client";
+import { fetchWithAuth } from "@/shared/api/client";
 
 export const VOICE_API_BASE =
   import.meta.env.VITE_VOICE_API_BASE_URL || "https://mefit-voice.xn--hy1by51c.kr/voice-api/api/v1";
@@ -62,16 +62,12 @@ export function useTts(): UseTtsReturn {
       (async () => {
         try {
           setTtsPlaying(true);
-          const token = getAccessToken();
           const abort = new AbortController();
           abortRef.current = abort;
 
-          const res = await fetch(`${VOICE_API_BASE}/tts`, {
+          const res = await fetchWithAuth(`${VOICE_API_BASE}/tts`, {
             method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              ...(token ? { Authorization: `Bearer ${token}` } : {}),
-            },
+            headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
               text,
               language: "ko",


### PR DESCRIPTION
## 관련 이슈
Closes #106

## 변경 사항

면접 세션 영상 녹화, 음성 분석 시각화, State Machine 리팩토링 전체 구현.

### 녹화 (Recording)

#### 훅 (3개)
- `useMediaRecorder`: MediaRecorder API 래핑 (stream.clone, ref 기반 stale closure 해소)
- `useChunkUploader`: Presigned URL PUT + 5MB 버퍼링 + 지수 백오프 재시도
- `useRecordingManager`: 라이프사이클 오케스트레이터 (initiate → record → upload → complete/abort)
  - `prepareRecording(turnId)`: TTS 재생 중 S3 presigned URL 미리 발급 → 녹화 시작 지연 제거

#### 업로드 전략
- 짧은 녹화 (< 5MB): Backend proxy `PUT /recordings/{id}/upload/`
- 긴 녹화 (>= 5MB): S3 Presigned URL Multipart Upload

#### UI 컴포넌트
- `RecordingIndicator`: 🔴 REC + MM:SS 경과 시간
- `MediaPlayer`: video/audio 재생기

### 음성 분석 시각화

#### STT 세그먼트 수집
- `WebSpeechSTTProvider`에 `timestampMs` 추가
- `useMediaSetup`에서 `sttSegments` 수집 → submit 시 백엔드 전달

#### InteractiveTimeline 컴포넌트
- 영상 재생기 + dBFS 영역 차트 + 발화/침묵 바 + STT 텍스트 동기화
- 타임라인 클릭으로 영상 seek
- print 모드: 인터랙티브 요소 숨김, 정적 차트만 노출

#### VoiceAnalysisPanel
- 턴별 음성 통계 (침묵 비율 게이지, 발화/침묵 바, dBFS 바 차트)

#### 안전장치
- `speechData` nullable 허용 — Lambda 분석 실패 시 graceful degradation
- `totalDurationMs ≤ 0` / 빈 timeline 가드 (division by zero 방지)

### State Machine 리팩토링

#### 문제
- InterviewSessionPage에 10+ useEffect/useCallback 체인
- 5개 분산 상태 (hasStarted, answerState, countdown, interviewPhase, ttsPlaying) → race condition

#### 해결
- `useReducer` 기반 state machine: 10 phases, 12 events, exhaustive switch
- `useInterviewMachine` 훅: 상태 진입 시 side effect (TTS, STT, recording) 관리
- InterviewSessionPage 316→237 lines, useEffect 10개→3개
- SessionActionPanel 17→11 props

#### 상태 전이
```
idle → ready → starting → tts_playing ⇄ countdown|awaiting_start → speaking → submitting → (loop | finished)
```

### 토큰 갱신 (Token Refresh)

- `fetchWithAuth()` 헬퍼: raw fetch에 401→refresh→retry 로직 추가
- `useTts` (voice API), `recordingApi.upload` (S3 업로드)에 적용
- 기존 `apiRequest`는 이미 retry 지원 — raw fetch 호출만 수정

### 버튼 비활성화 타이밍
- `dispatch(SUBMIT)` → `stopRecording()` 순서로 변경
- 녹화 업로드 중에도 즉시 버튼 비활성화 + "답변 저장 중..." 표시
- 3단계 진행 레이블: 답변 저장 중 → 제출 중 → 꼬리질문 생성 중

## 변경 유형

- [x] 새로운 기능 (New feature)
- [x] 버그 수정 (Bug fix)
- [x] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [x] 테스트 추가 (Test addition)

## 테스트

### 자동화 테스트
- 18 suites, 112 tests 전체 통과
- `useChunkUploader` 5건, `useMediaRecorder` 5건, `useRecordingManager` 6건

### 수동 테스트
- [x] 면접 시작 → 답변 시 녹화 시작 → 답변 제출 → 녹화 중지 + 업로드
- [x] 결과 페이지에서 영상 재생 + InteractiveTimeline 동기화
- [x] 브라우저 닫기 → abort API 호출
- [x] 토큰 만료 중 TTS/업로드 → 자동 갱신
- [x] 음성 분석 데이터 없을 때 리포트 정상 표시

## 트러블슈팅

| 문제 | 해결 |
|------|------|
| React stale closure (urls=[], isRecording=true) | state → ref 기반 전환 |
| MediaRecorder stream에서 데이터 안 나옴 | `stream.clone()` 적용 |
| S3 Multipart 5MB 최소 제한 | 5MB 버퍼링 + 단일 업로드 fallback |
| 녹화 시작 200-700ms 지연 | TTS 중 `prepareRecording()` pre-initiate |
| 토큰 만료 시 TTS/업로드 실패 | `fetchWithAuth()` 401→refresh→retry |
| 10+ useEffect race condition | State machine (useReducer) |
| 답변 제출 버튼 중복 클릭 | dispatch SUBMIT → stopRecording 순서 변경 |

## 백엔드 의존성
이 PR은 backend PR #117 (`feature/116-interview-video-recording`)과 함께 동작합니다.