### PR TITLE
[108] icon 변경 및 요금제 페이지 수정

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -75,7 +75,7 @@ function App() {
         <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
         <Route path="/streak" element={<ProtectedRoute><StreakPage /></ProtectedRoute>} />
         <Route path="/achievements" element={<ProtectedRoute><AchievementsPage /></ProtectedRoute>} />
-        <Route path="/subscription" element={<Navigate to="/settings" replace />} />
+        <Route path="/subscription" element={<Navigate to="/settings?panel=subscription" replace />} />
         <Route path="/notifications" element={<ProtectedRoute><NotificationsPage /></ProtectedRoute>} />
 
         {/* ── 에러 페이지 ── */}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Toaster } from "sonner";
 import { useAuthStore } from "@/features/auth";
 import { useNotificationStore } from "@/features/notifications";
@@ -25,7 +25,6 @@ import { InterviewResultsPage } from "@/pages/interview-results";
 import { SettingsPage } from "@/pages/settings";
 import { StreakPage } from "@/pages/streak";
 import { AchievementsPage } from "@/pages/achievements";
-import { SubscriptionPage } from "@/pages/subscription";
 import { NotificationsPage } from "@/pages/notifications";
 import { NotFoundPage } from "@/pages/not-found";
 import { ServerErrorPage } from "@/pages/server-error";
@@ -76,7 +75,7 @@ function App() {
         <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
         <Route path="/streak" element={<ProtectedRoute><StreakPage /></ProtectedRoute>} />
         <Route path="/achievements" element={<ProtectedRoute><AchievementsPage /></ProtectedRoute>} />
-        <Route path="/subscription" element={<ProtectedRoute><SubscriptionPage /></ProtectedRoute>} />
+        <Route path="/subscription" element={<Navigate to="/settings" replace />} />
         <Route path="/notifications" element={<ProtectedRoute><NotificationsPage /></ProtectedRoute>} />
 
         {/* ── 에러 페이지 ── */}

--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -98,6 +98,14 @@ export interface HomeData {
 }
 
 // Mock data fallback
+function labelToIconKey(label: string): string {
+  if (label.includes("면접")) return "target";
+  if (label.includes("점수")) return "trending-up";
+  if (label.includes("스트릭")) return "flame";
+  if (label.includes("시간")) return "timer";
+  return "bar-chart";
+}
+
 const MOCK_DATA: HomeData = {
   user: {
     name: "김현준",
@@ -105,10 +113,10 @@ const MOCK_DATA: HomeData = {
     lastInterviewDaysAgo: 2,
   },
   stats: [
-    { icon: "🎯", value: 24,           label: "총 면접 횟수",    delta: "↑ 이번 주 +3",     deltaType: "up" },
-    { icon: "📈", value: 82, unit: "점", label: "평균 점수",      delta: "↑ 지난주 대비 +7", deltaType: "up" },
-    { icon: "🔥", value: 12, unit: "일", label: "현재 스트릭",    delta: "🏆 최장 기록!",     deltaType: "neutral" },
-    { icon: "⏱️", value: 8,  unit: "h", label: "총 연습 시간",   delta: "↓ 목표 -2h",        deltaType: "down" },
+    { icon: "target",      value: 24,            label: "총 면접 횟수",  delta: "↑ 이번 주 +3",     deltaType: "up" },
+    { icon: "trending-up", value: 82, unit: "점", label: "평균 점수",     delta: "↑ 지난주 대비 +7", deltaType: "up" },
+    { icon: "flame",       value: 12, unit: "일", label: "현재 스트릭",   delta: "🏆 최장 기록!",     deltaType: "neutral" },
+    { icon: "timer",       value: 8,  unit: "h",  label: "총 연습 시간",  delta: "↓ 목표 -2h",        deltaType: "down" },
   ],
   recentSessions: [
     { id: "s1", icon: "🏦", company: "카카오뱅크", badgeLabel: "꼬리질문",    badgeType: "accent",  role: "백엔드 개발자",    round: "1차 면접", date: "어제 오후 3:24",    score: 88 },
@@ -167,7 +175,7 @@ export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: Hom
           lastInterviewDaysAgo: data.user?.last_interview_days_ago ?? 0,
         },
         stats: (data.stats || []).map((stat) => ({
-          icon: stat.icon || "📊",
+          icon: labelToIconKey(stat.label || ""),
           value: stat.value ?? 0,
           unit: stat.unit,
           label: stat.label || "",

--- a/src/pages/home/ui/components/HomeSidebar.tsx
+++ b/src/pages/home/ui/components/HomeSidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "react-router-dom";
-import { Home, Video, FileText, Building2, BarChart2, Flame, Trophy, CreditCard, Settings } from "lucide-react";
+import { Home, Video, FileText, Building2, BarChart2, Flame, Trophy, Settings } from "lucide-react";
 
 interface HomeSidebarProps {
   menuOpen: boolean;
@@ -48,9 +48,6 @@ export function HomeSidebar({ menuOpen, currentStreak, floating = false, activeI
         <span className="hp-sb-icon"><Trophy size={18} /></span>도전과제
       </Link>
       <div className="hp-sb-sep">설정</div>
-      <Link to="/subscription" className={`hp-sb-item${isActive("/subscription") ? " active" : ""}`}>
-        <span className="hp-sb-icon"><CreditCard size={18} /></span>요금제
-      </Link>
       <Link to="/settings" className={`hp-sb-item${isActive("/settings") ? " active" : ""}`}>
         <span className="hp-sb-icon"><Settings size={18} /></span>계정 설정
       </Link>

--- a/src/pages/home/ui/components/JobStatus.tsx
+++ b/src/pages/home/ui/components/JobStatus.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { ClipboardList } from "lucide-react";
 import type { HomeJob } from "@/features/home/api/homeApi";
 
 interface JobStatusProps {
@@ -12,9 +13,12 @@ export function JobStatus({ jobs, revealed }: JobStatusProps) {
       className={`hp-card-white hp-rv${revealed ? " hp-rv-in" : ""}`}
       style={{ padding: 20, transitionDelay: "550ms" }}
     >
-      <div className="hp-sec-head" style={{ marginBottom: 12 }}>
-        <div className="hp-sec-title" style={{ fontSize: 13 }}>📋 지원 현황</div>
-        <Link to="/jd" className="hp-sec-link">관리 →</Link>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center">
+          <ClipboardList size={14} className="text-[#0991B2]" />
+        </span>
+        <h3 className="text-[14px] font-bold text-[#0A0A0A]">지원 현황</h3>
+        <Link to="/jd" className="text-[12px] text-[#0991B2] ml-auto">관리 →</Link>
       </div>
       {jobs.map((job) => (
         <div key={job.id} className="hp-job-item">

--- a/src/pages/home/ui/components/StatsGrid.tsx
+++ b/src/pages/home/ui/components/StatsGrid.tsx
@@ -1,4 +1,13 @@
+import { Target, TrendingUp, Flame, Timer, BarChart2 } from "lucide-react";
 import type { HomeStat } from "@/features/home/api/homeApi";
+
+const ICON_MAP: Record<string, React.ReactNode> = {
+  "target":      <Target      size={20} className="text-[#0991B2]" />,
+  "trending-up": <TrendingUp  size={20} className="text-[#059669]" />,
+  "flame":       <Flame       size={20} className="text-[#F97316]" />,
+  "timer":       <Timer       size={20} className="text-[#8B5CF6]" />,
+  "bar-chart":   <BarChart2   size={20} className="text-[#9CA3AF]" />,
+};
 
 interface StatsGridProps {
   stats: HomeStat[];
@@ -14,7 +23,9 @@ export function StatsGrid({ stats, revealed }: StatsGridProps) {
           className={`hp-stat-card hp-rv${revealed ? " hp-rv-in" : ""}`}
           style={{ transitionDelay: `${55 + i * 55}ms` }}
         >
-          <span className="hp-stat-icon">{stat.icon}</span>
+          <span className="hp-stat-icon">
+            {ICON_MAP[stat.icon] ?? <BarChart2 size={20} className="text-[#9CA3AF]" />}
+          </span>
           <div className="hp-stat-num">
             {stat.value}
             {stat.unit && (

--- a/src/pages/settings/ui/JobCategorySelector.tsx
+++ b/src/pages/settings/ui/JobCategorySelector.tsx
@@ -1,0 +1,171 @@
+import { useState, useRef, useEffect } from "react";
+import {
+  ChevronDown, Check,
+  DollarSign, Handshake, Megaphone, Users, Code2, Wrench,
+  Stethoscope, GraduationCap, Truck, Palette, ShieldCheck, MoreHorizontal,
+} from "lucide-react";
+import type { JobCategory, Job } from "@/shared/api/profileApi";
+
+/* 직군 이름 → lucide 아이콘 + 색상 매핑 */
+const CATEGORY_ICON: Record<string, { icon: React.ReactNode }> = {
+  "금융/회계":    { icon: <DollarSign  size={16} className="text-[#F59E0B]" /> },
+  "영업/서비스":  { icon: <Handshake   size={16} className="text-[#0991B2]" /> },
+  "마케팅":       { icon: <Megaphone   size={16} className="text-[#EC4899]" /> },
+  "인사/HR":      { icon: <Users       size={16} className="text-[#8B5CF6]" /> },
+  "IT/개발":      { icon: <Code2       size={16} className="text-[#059669]" /> },
+  "엔지니어링":   { icon: <Wrench      size={16} className="text-[#6B7280]" /> },
+  "의료/보건":    { icon: <Stethoscope size={16} className="text-[#EF4444]" /> },
+  "교육":         { icon: <GraduationCap size={16} className="text-[#F97316]" /> },
+  "물류/유통":    { icon: <Truck       size={16} className="text-[#0EA5E9]" /> },
+  "디자인":       { icon: <Palette     size={16} className="text-[#A855F7]" /> },
+  "법률/공공":    { icon: <ShieldCheck size={16} className="text-[#374151]" /> },
+};
+
+function getCategoryIcon(name: string) {
+  return CATEGORY_ICON[name]?.icon ?? <MoreHorizontal size={16} className="text-[#9CA3AF]" />;
+}
+
+interface JobCategorySelectorProps {
+  categories: JobCategory[];
+  categoriesLoading: boolean;
+  selectedCategoryId: number | null;
+  availableJobs: Job[];
+  jobsLoading: boolean;
+  selectedJobIds: number[];
+  onSelectCategory: (id: number) => void;
+  onToggleJob: (id: number) => void;
+}
+
+export function JobCategorySelector({
+  categories,
+  categoriesLoading,
+  selectedCategoryId,
+  availableJobs,
+  jobsLoading,
+  selectedJobIds,
+  onSelectCategory,
+  onToggleJob,
+}: JobCategorySelectorProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const selected = categories.find((c) => c.id === selectedCategoryId);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* 직군 드롭다운 */}
+      <div className="flex flex-col gap-[5px]">
+        <label className="font-plex-sans-kr text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px] flex items-center gap-1">
+          희망 직군 <span className="text-[#EF4444] text-[10px]">*</span>
+        </label>
+
+        {categoriesLoading ? (
+          <div className="h-[42px] rounded-lg skeleton-shimmer" />
+        ) : (
+          <div ref={ref} className="relative">
+            {/* 트리거 버튼 */}
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              className={`w-full flex items-center justify-between gap-2 px-[14px] py-[10px] rounded-lg border-[1.5px] bg-white text-[14px] font-normal transition-all duration-150 ${
+                open
+                  ? "border-[#0991B2] shadow-[0_0_0_3px_rgba(9,145,178,0.1)]"
+                  : "border-[#E5E7EB] hover:border-[#0991B2]"
+              }`}
+            >
+              {selected ? (
+                <span className="flex items-center gap-2 text-[#0A0A0A]">
+                  {getCategoryIcon(selected.name)}
+                  {selected.name}
+                </span>
+              ) : (
+                <span className="text-[#9CA3AF]">직군을 선택하세요</span>
+              )}
+              <ChevronDown
+                size={16}
+                className={`text-[#9CA3AF] flex-shrink-0 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+              />
+            </button>
+
+            {/* 드롭다운 목록 */}
+            {open && (
+              <div className="absolute z-50 top-[calc(100%+4px)] left-0 right-0 bg-white border border-[#E5E7EB] rounded-xl shadow-[0_8px_24px_rgba(0,0,0,0.1)] overflow-hidden">
+                {categories.map((cat) => {
+                  const isSelected = cat.id === selectedCategoryId;
+                  return (
+                    <button
+                      key={cat.id}
+                      type="button"
+                      onClick={() => { onSelectCategory(cat.id); setOpen(false); }}
+                      className={`w-full flex items-center gap-3 px-4 py-[10px] text-left text-[14px] font-normal transition-colors duration-100 ${
+                        isSelected
+                          ? "bg-[#E6F7FA] text-[#0991B2]"
+                          : "text-[#374151] hover:bg-[#F9FAFB]"
+                      }`}
+                    >
+                      <span className="flex-shrink-0">{getCategoryIcon(cat.name)}</span>
+                      <span className="flex-1">{cat.name}</span>
+                      {isSelected && <Check size={14} className="text-[#0991B2] flex-shrink-0" />}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+        <p className="text-[11px] text-[#6B7280] leading-[1.45]">면접 질문 생성에 반영됩니다</p>
+      </div>
+
+      {/* 직업 다중 선택 */}
+      {selectedCategoryId && (
+        <div className="flex flex-col gap-[5px]">
+          <label className="font-plex-sans-kr text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px]">
+            직업 선택{" "}
+            <span className="text-[11px] font-normal text-[#6B7280]">(복수 선택 가능)</span>
+          </label>
+
+          {jobsLoading ? (
+            <div className="grid grid-cols-2 gap-2 max-[640px]:grid-cols-1">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="h-9 rounded-lg skeleton-shimmer" />
+              ))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-2 max-[640px]:grid-cols-1">
+              {availableJobs.map((job) => {
+                const isSelected = selectedJobIds.includes(job.id);
+                return (
+                  <button
+                    key={job.id}
+                    type="button"
+                    onClick={() => onToggleJob(job.id)}
+                    className={`flex items-center gap-2 text-left text-[14px] font-normal px-3 py-2 rounded-lg border-[1.5px] transition-all duration-150 ${
+                      isSelected
+                        ? "border-[#0991B2] bg-[#E6F7FA] text-[#0991B2]"
+                        : "border-[#E5E7EB] bg-[#F9FAFB] text-[#374151] hover:border-[#0991B2] hover:bg-white"
+                    }`}
+                  >
+                    <Check
+                      size={13}
+                      className={`flex-shrink-0 transition-opacity duration-150 ${isSelected ? "opacity-100 text-[#0991B2]" : "opacity-0"}`}
+                    />
+                    {job.name}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          <p className="text-[11px] text-[#6B7280] leading-[1.45]">면접 맥락 설정에 활용됩니다</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/settings/ui/JobCategorySelector.tsx
+++ b/src/pages/settings/ui/JobCategorySelector.tsx
@@ -1,28 +1,21 @@
 import { useState, useRef, useEffect } from "react";
 import {
   ChevronDown, Check,
-  DollarSign, Handshake, Megaphone, Users, Code2, Wrench,
-  Stethoscope, GraduationCap, Truck, Palette, ShieldCheck, MoreHorizontal,
+  DollarSign, Handshake, Megaphone, Users, Code2, MoreHorizontal,
 } from "lucide-react";
 import type { JobCategory, Job } from "@/shared/api/profileApi";
 
-/* 직군 이름 → lucide 아이콘 + 색상 매핑 */
-const CATEGORY_ICON: Record<string, { icon: React.ReactNode }> = {
-  "금융/회계":    { icon: <DollarSign  size={16} className="text-[#F59E0B]" /> },
-  "영업/서비스":  { icon: <Handshake   size={16} className="text-[#0991B2]" /> },
-  "마케팅":       { icon: <Megaphone   size={16} className="text-[#EC4899]" /> },
-  "인사/HR":      { icon: <Users       size={16} className="text-[#8B5CF6]" /> },
-  "IT/개발":      { icon: <Code2       size={16} className="text-[#059669]" /> },
-  "엔지니어링":   { icon: <Wrench      size={16} className="text-[#6B7280]" /> },
-  "의료/보건":    { icon: <Stethoscope size={16} className="text-[#EF4444]" /> },
-  "교육":         { icon: <GraduationCap size={16} className="text-[#F97316]" /> },
-  "물류/유통":    { icon: <Truck       size={16} className="text-[#0EA5E9]" /> },
-  "디자인":       { icon: <Palette     size={16} className="text-[#A855F7]" /> },
-  "법률/공공":    { icon: <ShieldCheck size={16} className="text-[#374151]" /> },
+/* 직군 ID → lucide 아이콘 + 색상 매핑 */
+const CATEGORY_ICON: Record<number, { icon: React.ReactNode }> = {
+  3: { icon: <DollarSign size={16} className="text-[#F59E0B]" /> },  // 금융/회계
+  4: { icon: <Handshake  size={16} className="text-[#0991B2]" /> },  // 영업/서비스
+  2: { icon: <Megaphone  size={16} className="text-[#EC4899]" /> },  // 마케팅
+  5: { icon: <Users      size={16} className="text-[#8B5CF6]" /> },  // 인사/HR
+  1: { icon: <Code2      size={16} className="text-[#059669]" /> },  // IT/개발
 };
 
-function getCategoryIcon(name: string) {
-  return CATEGORY_ICON[name]?.icon ?? <MoreHorizontal size={16} className="text-[#9CA3AF]" />;
+function getCategoryIcon(id: number) {
+  return CATEGORY_ICON[id]?.icon ?? <MoreHorizontal size={16} className="text-[#9CA3AF]" />;
 }
 
 interface CategoryProps {
@@ -87,7 +80,7 @@ export function JobCategorySelector({
             >
               {selected ? (
                 <span className="flex items-center gap-2 text-[#0A0A0A]">
-                  {getCategoryIcon(selected.name)}
+                  {getCategoryIcon(selected.id)}
                   {selected.name}
                 </span>
               ) : (
@@ -115,7 +108,7 @@ export function JobCategorySelector({
                           : "text-[#374151] hover:bg-[#F9FAFB]"
                       }`}
                     >
-                      <span className="flex-shrink-0">{getCategoryIcon(cat.name)}</span>
+                      <span className="flex-shrink-0">{getCategoryIcon(cat.id)}</span>
                       <span className="flex-1">{cat.name}</span>
                       {isSelected && <Check size={14} className="text-[#0991B2] flex-shrink-0" />}
                     </button>

--- a/src/pages/settings/ui/JobCategorySelector.tsx
+++ b/src/pages/settings/ui/JobCategorySelector.tsx
@@ -25,27 +25,31 @@ function getCategoryIcon(name: string) {
   return CATEGORY_ICON[name]?.icon ?? <MoreHorizontal size={16} className="text-[#9CA3AF]" />;
 }
 
-interface JobCategorySelectorProps {
+interface CategoryProps {
   categories: JobCategory[];
-  categoriesLoading: boolean;
-  selectedCategoryId: number | null;
-  availableJobs: Job[];
-  jobsLoading: boolean;
-  selectedJobIds: number[];
-  onSelectCategory: (id: number) => void;
-  onToggleJob: (id: number) => void;
+  loading: boolean;
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+}
+
+interface JobProps {
+  jobs: Job[];
+  loading: boolean;
+  selectedIds: number[];
+  onToggle: (id: number) => void;
+}
+
+interface JobCategorySelectorProps {
+  categoryProps: CategoryProps;
+  jobProps: JobProps;
 }
 
 export function JobCategorySelector({
-  categories,
-  categoriesLoading,
-  selectedCategoryId,
-  availableJobs,
-  jobsLoading,
-  selectedJobIds,
-  onSelectCategory,
-  onToggleJob,
+  categoryProps,
+  jobProps,
 }: JobCategorySelectorProps) {
+  const { categories, loading: categoriesLoading, selectedId: selectedCategoryId, onSelect: onSelectCategory } = categoryProps;
+  const { jobs: availableJobs, loading: jobsLoading, selectedIds: selectedJobIds, onToggle: onToggleJob } = jobProps;
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -97,7 +101,7 @@ export function JobCategorySelector({
 
             {/* 드롭다운 목록 */}
             {open && (
-              <div className="absolute z-50 top-[calc(100%+4px)] left-0 right-0 bg-white border border-[#E5E7EB] rounded-xl shadow-[0_8px_24px_rgba(0,0,0,0.1)] overflow-hidden">
+              <div className="absolute z-50 top-[calc(100%+4px)] left-0 right-0 bg-white border border-[#E5E7EB] rounded-xl shadow-[0_8px_24px_rgba(0,0,0,0.1)] overflow-hidden max-h-[300px] overflow-y-auto">
                 {categories.map((cat) => {
                   const isSelected = cat.id === selectedCategoryId;
                   return (

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { Archive, Eye, FileText, Gem, Star, Zap } from "lucide-react";
 import { useSettingsStore } from "@/features/settings";
+import { useSubscriptionStore } from "@/features/subscription";
+import { TicketPolicyInfo } from "@/features/subscription/ui/TicketPolicyInfo";
 import type { SettingsPanel } from "@/features/settings";
 
 /* ── Password strength helper ── */
@@ -41,6 +44,11 @@ export function SettingsPage() {
     clearMessage,
   } = useSettingsStore();
 
+  const {
+    status: subStatus,
+    fetchStatus: fetchSubStatus,
+  } = useSubscriptionStore();
+
   const [searchParams] = useSearchParams();
   const [deleteConfirm, setDeleteConfirm] = useState<"data" | "account" | null>(null);
   const avatarInputRef = useRef<HTMLInputElement>(null);
@@ -54,7 +62,8 @@ export function SettingsPage() {
   useEffect(() => {
     fetchSettings();
     loadJobCategories();
-  }, [fetchSettings, loadJobCategories]);
+    fetchSubStatus();
+  }, [fetchSettings, loadJobCategories, fetchSubStatus]);
 
   useEffect(() => {
     if (saveMessage) {
@@ -339,7 +348,9 @@ export function SettingsPage() {
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
-                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">⭐ 현재 플랜</div>
+                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">
+                      <Star size={15} className="text-[#F59E0B]" /> 현재 플랜
+                    </div>
                     <div className="bg-[#0A0A0A] rounded-[10px] px-[22px] py-5 relative overflow-hidden">
                       <div className="flex items-center justify-between gap-3 max-[640px]:flex-col max-[640px]:items-start">
                         <div>
@@ -368,16 +379,18 @@ export function SettingsPage() {
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
-                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">💎 Pro 플랜 혜택</div>
+                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">
+                      <Gem size={15} className="text-[#0991B2]" /> Pro 플랜 혜택
+                    </div>
                     <div className="grid grid-cols-2 gap-[10px] max-[640px]:grid-cols-1">
-                      {[
-                        { icon: "👁️", name: "시선 추적 분석", desc: "면접 중 시선 이탈 횟수 측정" },
-                        { icon: "⚡", name: "실전 모드", desc: "랜덤 대기 후 자동 시작" },
-                        { icon: "📄", name: "상세 리포트 PDF", desc: "면접 리포트 저장·공유" },
-                        { icon: "🗂️", name: "무제한 아카이브", desc: "전체 면접 세션 보관" },
-                      ].map((item) => (
+                      {([
+                        { icon: <Eye size={20} className="text-[#8B5CF6]" />, name: "시선 추적 분석", desc: "면접 중 시선 이탈 횟수 측정" },
+                        { icon: <Zap size={20} className="text-[#F59E0B]" />, name: "실전 모드", desc: "랜덤 대기 후 자동 시작" },
+                        { icon: <FileText size={20} className="text-[#0991B2]" />, name: "상세 리포트 PDF", desc: "면접 리포트 저장·공유" },
+                        { icon: <Archive size={20} className="text-[#059669]" />, name: "무제한 아카이브", desc: "전체 면접 세션 보관" },
+                      ] as const).map((item) => (
                         <div key={item.name} className="bg-white border border-[#E5E7EB] rounded-[10px] px-4 py-[14px] transition-all duration-150 hover:border-[rgba(9,145,178,0.3)] hover:shadow-[0_2px_8px_rgba(0,0,0,0.1),0_8px_24px_rgba(0,0,0,0.08)]">
-                          <div className="text-[20px] mb-[6px]">{item.icon}</div>
+                          <div className="mb-[8px]">{item.icon}</div>
                           <div className="font-plex-sans-kr text-[13px] font-bold text-[#0A0A0A] mb-0.5">{item.name}</div>
                           <div className="text-[11px] text-[#6B7280]">{item.desc}</div>
                         </div>
@@ -388,10 +401,12 @@ export function SettingsPage() {
                         className="font-plex-sans-kr text-[14px] font-bold text-white bg-[#0A0A0A] border-none rounded-lg py-[10px] cursor-pointer transition-all duration-150 flex items-center gap-[7px] hover:opacity-85 hover:-translate-y-px justify-center w-full"
                         style={{ borderRadius: 8 }}
                       >
-                        💎 Pro 업그레이드 — 첫 7일 무료
+                        <Gem size={15} className="text-[#06B6D4]" /> Pro 업그레이드 — 첫 7일 무료
                       </button>
                     </div>
                   </div>
+
+                  <TicketPolicyInfo currentPlan={subStatus?.currentPlan ?? "free"} />
                 </div>
 
                 {/* ─── CONSENT PANEL ─── */}

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Archive, Eye, FileText, Flame, Gem, Megaphone, ShieldCheck, Star, TriangleAlert, Zap } from "lucide-react";
+import { Archive, ClipboardList, Eye, FileText, Flame, Gem, KeyRound, Lock, Megaphone, ShieldCheck, Star, TriangleAlert, UserCircle, Zap } from "lucide-react";
 import { useSettingsStore } from "@/features/settings";
 import { useSubscriptionStore } from "@/features/subscription";
 import { TicketPolicyInfo } from "@/features/subscription/ui/TicketPolicyInfo";
@@ -113,7 +113,9 @@ export function SettingsPage() {
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
-                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">👤 프로필 사진</div>
+                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">
+                      <UserCircle size={15} className="text-[#0991B2]" /> 프로필 사진
+                    </div>
                     <div className="flex items-center gap-4 mb-5">
                       {data.profile.avatarUrl ? (
                         <img src={data.profile.avatarUrl} alt="프로필" className="w-16 h-16 rounded-full object-cover shadow-[0_2px_8px_rgba(9,145,178,0.3)] shrink-0" />
@@ -133,7 +135,9 @@ export function SettingsPage() {
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
-                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">📝 기본 정보</div>
+                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">
+                      <ClipboardList size={15} className="text-[#059669]" /> 기본 정보
+                    </div>
                     <div className="flex flex-col gap-4">
                       <div className="flex flex-col gap-[5px]">
                         <label className="font-plex-sans-kr text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px] flex items-center gap-1">
@@ -185,7 +189,9 @@ export function SettingsPage() {
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
-                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">🔑 비밀번호 변경</div>
+                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">
+                      <KeyRound size={15} className="text-[#F59E0B]" /> 비밀번호 변경
+                    </div>
                     <div className="flex flex-col gap-4">
                       <div className="flex flex-col gap-[5px]">
                         <label className="font-plex-sans-kr text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px] flex items-center gap-1">현재 비밀번호 <span className="text-[#EF4444] text-[10px]">*</span></label>
@@ -213,7 +219,7 @@ export function SettingsPage() {
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]" style={{ background: "rgba(9,145,178,.03)", borderColor: "rgba(9,145,178,.12)" }}>
                     <p style={{ fontSize: 13, color: "#6B7280", lineHeight: 1.7 }}>
-                      🔒 비밀번호는 암호화되어 저장됩니다.<br />
+                      <Lock size={13} className="text-[#0991B2] inline-block mr-1 align-text-bottom" /> 비밀번호는 암호화되어 저장됩니다.<br />
                       분실 시 로그인 화면에서 <strong style={{ color: "#0991B2" }}>비밀번호 찾기</strong>를 이용하세요.
                     </p>
                   </div>

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { Archive, Eye, FileText, Flame, Gem, Megaphone, ShieldCheck, Star, Trian
 import { useSettingsStore } from "@/features/settings";
 import { useSubscriptionStore } from "@/features/subscription";
 import { TicketPolicyInfo } from "@/features/subscription/ui/TicketPolicyInfo";
+import { JobCategorySelector } from "./JobCategorySelector";
 import type { SettingsPanel } from "@/features/settings";
 
 /* ── Password strength helper ── */
@@ -88,7 +89,6 @@ export function SettingsPage() {
   };
 
   const inputClass = "font-plex-sans-kr text-[14px] text-[#0A0A0A] bg-white border-[1.5px] border-[#E5E7EB] rounded-lg px-[14px] py-[10px] outline-none transition-[border-color,box-shadow] duration-[180ms] w-full placeholder-[#9CA3AF] focus:border-[#0991B2] focus:shadow-[0_0_0_3px_rgba(9,145,178,0.1)] read-only:opacity-50 read-only:cursor-not-allowed read-only:bg-[#F9FAFB]";
-  const selectClass = "font-plex-sans-kr text-[14px] text-[#0A0A0A] bg-white border-[1.5px] border-[#E5E7EB] rounded-lg px-[14px] py-[10px] outline-none appearance-none cursor-pointer w-full transition-[border-color] duration-[180ms] focus:border-[#0991B2] focus:shadow-[0_0_0_3px_rgba(9,145,178,0.1)]";
 
   return (
     <>
@@ -155,65 +155,16 @@ export function SettingsPage() {
                         <p className="text-[11px] text-[#6B7280] leading-[1.45]">이메일 주소는 변경할 수 없습니다. 고객센터로 문의해주세요.</p>
                       </div>
                       <div className="flex flex-col gap-4">
-                        {/* 직군 선택 */}
-                        <div className="flex flex-col gap-[5px]">
-                          <label className="font-plex-sans-kr text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px] flex items-center gap-1">
-                            희망 직군 <span className="text-[#EF4444] text-[10px]">*</span>
-                          </label>
-                          {jobCategoriesLoading ? (
-                            <div className="text-[12px] text-[#9CA3AF] py-2">직군 목록 불러오는 중...</div>
-                          ) : (
-                            <select
-                              className={selectClass}
-                              value={profileDraft.jobCategoryId ?? ""}
-                              onChange={(e) => {
-                                const id = e.target.value ? Number(e.target.value) : null;
-                                setProfileDraftField("jobCategoryId", id);
-                              }}
-                            >
-                              <option value="">직군을 선택하세요</option>
-                              {jobCategories.map((cat) => (
-                                <option key={cat.id} value={cat.id}>
-                                  {cat.emoji} {cat.name}
-                                </option>
-                              ))}
-                            </select>
-                          )}
-                          <p className="text-[11px] text-[#6B7280] leading-[1.45]">면접 질문 생성에 반영됩니다</p>
-                        </div>
-
-                        {/* 직업 다중 선택 */}
-                        {profileDraft.jobCategoryId && (
-                          <div className="flex flex-col gap-[5px]">
-                            <label className="font-plex-sans-kr text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px]">
-                              직업 선택 <span className="text-[11px] font-normal text-[#6B7280]">(복수 선택 가능)</span>
-                            </label>
-                            {availableJobsLoading ? (
-                              <div className="text-[12px] text-[#9CA3AF]">직업 목록 불러오는 중...</div>
-                            ) : (
-                              <div className="grid grid-cols-2 gap-2 max-[640px]:grid-cols-1">
-                                {availableJobs.map((job) => {
-                                  const isSelected = profileDraft.jobIds.includes(job.id);
-                                  return (
-                                    <button
-                                      key={job.id}
-                                      type="button"
-                                      onClick={() => toggleJobId(job.id)}
-                                      className={`text-left text-[12px] font-semibold px-3 py-2 rounded-lg border-[1.5px] transition-all ${
-                                        isSelected
-                                          ? "border-[#0991B2] bg-[#E6F7FA] text-[#0991B2]"
-                                          : "border-[#E5E7EB] bg-[#F9FAFB] text-[#374151] hover:border-[#0991B2]"
-                                      }`}
-                                    >
-                                      {isSelected ? "✓ " : ""}{job.name}
-                                    </button>
-                                  );
-                                })}
-                              </div>
-                            )}
-                            <p className="text-[11px] text-[#6B7280] leading-[1.45]">면접 맥락 설정에 활용됩니다</p>
-                          </div>
-                        )}
+                        <JobCategorySelector
+                          categories={jobCategories}
+                          categoriesLoading={jobCategoriesLoading}
+                          selectedCategoryId={profileDraft.jobCategoryId}
+                          availableJobs={availableJobs}
+                          jobsLoading={availableJobsLoading}
+                          selectedJobIds={profileDraft.jobIds}
+                          onSelectCategory={(id) => setProfileDraftField("jobCategoryId", id)}
+                          onToggleJob={toggleJobId}
+                        />
                       </div>
                     </div>
                   </div>

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -160,14 +160,18 @@ export function SettingsPage() {
                       </div>
                       <div className="flex flex-col gap-4">
                         <JobCategorySelector
-                          categories={jobCategories}
-                          categoriesLoading={jobCategoriesLoading}
-                          selectedCategoryId={profileDraft.jobCategoryId}
-                          availableJobs={availableJobs}
-                          jobsLoading={availableJobsLoading}
-                          selectedJobIds={profileDraft.jobIds}
-                          onSelectCategory={(id) => setProfileDraftField("jobCategoryId", id)}
-                          onToggleJob={toggleJobId}
+                          categoryProps={{
+                            categories: jobCategories,
+                            loading: jobCategoriesLoading,
+                            selectedId: profileDraft.jobCategoryId,
+                            onSelect: (id) => setProfileDraftField("jobCategoryId", id),
+                          }}
+                          jobProps={{
+                            jobs: availableJobs,
+                            loading: availableJobsLoading,
+                            selectedIds: profileDraft.jobIds,
+                            onToggle: toggleJobId,
+                          }}
                         />
                       </div>
                     </div>

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Archive, Eye, FileText, Gem, ShieldCheck, Star, TriangleAlert, Zap } from "lucide-react";
+import { Archive, Eye, FileText, Flame, Gem, Megaphone, ShieldCheck, Star, TriangleAlert, Zap } from "lucide-react";
 import { useSettingsStore } from "@/features/settings";
 import { useSubscriptionStore } from "@/features/subscription";
 import { TicketPolicyInfo } from "@/features/subscription/ui/TicketPolicyInfo";
@@ -289,7 +289,9 @@ export function SettingsPage() {
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
-                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">🔥 스트릭 &amp; 면접</div>
+                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">
+                      <Flame size={15} className="text-[#F97316]" /> 스트릭 &amp; 면접
+                    </div>
                     {([
                       { key: "streakReminder" as const, title: "스트릭 리마인더", desc: "오늘 면접 연습을 아직 하지 않았을 때 저녁 8시에 알림" },
                       { key: "streakExpire" as const, title: "스트릭 만료 경고", desc: "자정 1시간 전, 오늘 스트릭이 만료될 예정일 때 알림" },
@@ -311,7 +313,9 @@ export function SettingsPage() {
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
-                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">📢 서비스 &amp; 마케팅</div>
+                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">
+                      <Megaphone size={15} className="text-[#0991B2]" /> 서비스 &amp; 마케팅
+                    </div>
                     {([
                       { key: "serviceNotice" as const, title: "서비스 공지 및 업데이트", desc: "새 기능, 점검, 약관 변경 등 중요 서비스 소식" },
                       { key: "marketing" as const, title: "마케팅 정보 수신", desc: "할인, 프로모션, 이벤트 등 혜택 정보 이메일 발송" },

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Archive, Eye, FileText, Gem, Star, Zap } from "lucide-react";
+import { Archive, Eye, FileText, Gem, ShieldCheck, Star, TriangleAlert, Zap } from "lucide-react";
 import { useSettingsStore } from "@/features/settings";
 import { useSubscriptionStore } from "@/features/subscription";
 import { TicketPolicyInfo } from "@/features/subscription/ui/TicketPolicyInfo";
@@ -417,7 +417,9 @@ export function SettingsPage() {
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
-                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">📋 약관 및 개인정보 동의</div>
+                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-[18px] flex items-center gap-[7px] text-[#0A0A0A]">
+                      <ShieldCheck size={15} className="text-[#0991B2]" /> 약관 및 개인정보 동의
+                    </div>
 
                     <div className="flex gap-3 px-4 py-[14px] bg-white border border-[#E5E7EB] rounded-[10px] mb-2 transition-all duration-150">
                       <button className="w-[22px] h-[22px] rounded-[6px] shrink-0 flex items-center justify-center text-[10px] font-extrabold cursor-not-allowed opacity-70 border-none bg-[#0991B2] text-white shadow-[0_2px_8px_rgba(9,145,178,0.3)] mt-0.5" disabled>✓</button>
@@ -470,13 +472,15 @@ export function SettingsPage() {
                         <p className="text-[12px] text-[#6B7280] leading-[1.55]">
                           면접 영상·음성 데이터를 AI 모델 개선에 활용하는 것에 동의합니다. 동의 시 서비스 품질 향상에 기여하며 추가 스트릭 보상을 받을 수 있어요.
                         </p>
-                        <div className="inline-flex items-center gap-1 text-[10px] font-bold text-white bg-[#0A0A0A] px-2 py-0.5 rounded-full mt-[5px]">⚠ v2025-03 업데이트 · 재동의 필요</div>
+                        <div className="inline-flex items-center gap-1 text-[10px] font-bold text-white bg-[#0A0A0A] px-2 py-0.5 rounded-full mt-[5px]"><TriangleAlert size={10} /> v2025-03 업데이트 · 재동의 필요</div>
                       </div>
                     </div>
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
-                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-3 flex items-center gap-[7px] text-[#EF4444]">⚠ 위험 구역</div>
+                    <div className="font-plex-sans-kr text-[14px] font-extrabold tracking-[-0.1px] mb-3 flex items-center gap-[7px] text-[#EF4444]">
+                      <TriangleAlert size={15} className="text-[#EF4444]" /> 위험 구역
+                    </div>
                     <div className="bg-[rgba(239,68,68,0.03)] border border-[rgba(239,68,68,0.15)] rounded-[10px] px-5 py-[18px]">
                       <div className="flex items-center justify-between gap-3 flex-wrap py-[10px] border-b border-[rgba(239,68,68,0.08)] first:pt-0 last:border-b-0 last:pb-0">
                         <div>

--- a/src/pages/streak/ui/components/Milestones.tsx
+++ b/src/pages/streak/ui/components/Milestones.tsx
@@ -1,3 +1,5 @@
+import { Medal } from "lucide-react";
+
 interface Milestone {
   days: number;
   reward: string;
@@ -42,7 +44,9 @@ export function Milestones({ milestones, revealed }: MilestonesProps) {
       style={{ transitionDelay: "150ms" }}
     >
       <div className="flex items-center gap-2 mb-4">
-        <span className="w-7 h-7 rounded-lg bg-[#FFF7ED] flex items-center justify-center text-sm">🏅</span>
+        <span className="w-7 h-7 rounded-lg bg-[#FFF7ED] flex items-center justify-center">
+          <Medal size={14} className="text-[#F97316]" />
+        </span>
         <h3 className="text-[14px] font-bold text-[#0A0A0A]">마일스톤</h3>
       </div>
 

--- a/src/pages/streak/ui/components/NextReward.tsx
+++ b/src/pages/streak/ui/components/NextReward.tsx
@@ -1,3 +1,5 @@
+import { Target, Gift } from "lucide-react";
+
 interface NextRewardData {
   targetDays: number;
   daysRemaining: number;
@@ -21,7 +23,9 @@ export function NextReward({ nextReward, currentStreak, revealed }: NextRewardPr
       style={{ transitionDelay: "100ms" }}
     >
       <div className="flex items-center gap-2 mb-4">
-        <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center text-sm">🎯</span>
+        <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center">
+          <Target size={14} className="text-[#0991B2]" />
+        </span>
         <h3 className="text-[14px] font-bold text-[#0A0A0A]">다음 목표</h3>
       </div>
 
@@ -43,8 +47,9 @@ export function NextReward({ nextReward, currentStreak, revealed }: NextRewardPr
         <span className="text-[11px] text-[#9CA3AF] font-medium">
           {currentStreak} / {nextReward.targetDays}일
         </span>
-        <span className="text-[11px] font-bold text-[#0991B2] bg-[#E6F7FA] py-[3px] px-2 rounded-full">
-          🎁 {nextReward.reward}
+        <span className="text-[11px] font-bold text-[#0991B2] bg-[#E6F7FA] py-[3px] px-2 rounded-full flex items-center gap-1">
+          <Gift size={10} className="text-[#0991B2]" />
+          {nextReward.reward}
         </span>
       </div>
 

--- a/src/pages/streak/ui/components/RewardHistory.tsx
+++ b/src/pages/streak/ui/components/RewardHistory.tsx
@@ -1,3 +1,5 @@
+import { Gift, Package } from "lucide-react";
+
 interface RewardHistoryItem {
   id: string;
   icon: string;
@@ -23,13 +25,17 @@ export function RewardHistory({ rewardHistory, revealed }: RewardHistoryProps) {
       style={{ transitionDelay: "130ms" }}
     >
       <div className="flex items-center gap-2 mb-4">
-        <span className="w-7 h-7 rounded-lg bg-[#ECFDF5] flex items-center justify-center text-sm">🎁</span>
+        <span className="w-7 h-7 rounded-lg bg-[#ECFDF5] flex items-center justify-center">
+          <Gift size={14} className="text-[#059669]" />
+        </span>
         <h3 className="text-[14px] font-bold text-[#0A0A0A]">보상 수령 이력</h3>
       </div>
 
       {rewardHistory.length === 0 ? (
         <div className="text-center py-8">
-          <span className="text-[28px] block mb-2">📦</span>
+          <span className="flex justify-center mb-2">
+            <Package size={28} className="text-[#D1D5DB]" />
+          </span>
           <p className="text-[12px] text-[#9CA3AF] font-medium">아직 수령한 보상이 없어요</p>
           <p className="text-[11px] text-[#D1D5DB] mt-1">마일스톤을 달성하면 보상이 지급됩니다</p>
         </div>

--- a/src/pages/streak/ui/components/StreakCalendar.tsx
+++ b/src/pages/streak/ui/components/StreakCalendar.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState, useEffect } from "react";
+import { Calendar } from "lucide-react";
 
 const MONTH_SHORT = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
 const CELL_GAP    = 3;
@@ -144,7 +145,9 @@ export function StreakCalendar({
       style={{ transitionDelay: "80ms" }}
     >
       <div className="flex items-center gap-2 mb-4">
-        <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center text-sm">📅</span>
+        <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center">
+          <Calendar size={14} className="text-[#0991B2]" />
+        </span>
         <h3 className="text-[14px] font-bold text-[#0A0A0A]">참여 기록</h3>
         <span className="text-[11px] text-[#9CA3AF] font-medium ml-auto">
           {visibleWeeks < MAX_WEEKS ? `최근 ${visibleWeeks}주` : "최근 52주"} ·{" "}

--- a/src/pages/streak/ui/components/StreakHero.tsx
+++ b/src/pages/streak/ui/components/StreakHero.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Flame, Trophy, Calendar, Gift } from "lucide-react";
 
 interface StreakHeroProps {
   currentStreak: number;
@@ -33,7 +34,7 @@ export function StreakHero({
         <div className="flex items-start justify-between gap-4 flex-wrap">
           <div>
             <div className="flex items-center gap-3 mb-2">
-              <span className="text-[40px] leading-none max-sm:text-[32px]">🔥</span>
+              <Flame size={40} className="text-[#F97316] max-sm:w-8 max-sm:h-8" />
               <span className="text-[64px] font-black leading-[.85] tracking-[-3px] text-white max-sm:text-[48px]">
                 {currentStreak}
               </span>
@@ -76,9 +77,9 @@ export function StreakHero({
       {/* Bottom stats strip */}
       <div className="relative z-[1] border-t border-white/[.06] grid grid-cols-3 max-sm:grid-cols-3">
         {[
-          { label: "최장 기록", value: `${bestStreak}일`, icon: "🏆" },
-          { label: "총 참여일", value: `${totalDays}일`, icon: "📅" },
-          { label: "보상 수령", value: `${rewardsCount}회`, icon: "🎁" },
+          { label: "최장 기록", value: `${bestStreak}일`, icon: <Trophy size={14} className="text-[#F59E0B]" /> },
+          { label: "총 참여일", value: `${totalDays}일`, icon: <Calendar size={14} className="text-[#0991B2]" /> },
+          { label: "보상 수령", value: `${rewardsCount}회`, icon: <Gift size={14} className="text-[#059669]" /> },
         ].map((s, i) => (
           <div
             key={i}
@@ -86,7 +87,7 @@ export function StreakHero({
               i < 2 ? "border-r border-white/[.06]" : ""
             }`}
           >
-            <span className="text-[12px] block mb-0.5">{s.icon}</span>
+            <span className="flex justify-center mb-1.5">{s.icon}</span>
             <div className="text-[18px] font-black text-white leading-none tracking-[-0.5px] max-sm:text-[16px]">
               {s.value}
             </div>


### PR DESCRIPTION
## 관련 이슈
Closes #108 

## 변경 사항
이모지 아이콘을 lucide-react 아이콘으로 전환하여 UI 일관성을 개선했습니다.

### 설정 페이지 (SettingsPage)
- 요금제 패널: ⭐→Star, 💎→Gem, Pro 혜택 아이콘들 (Eye, Zap, FileText, Archive)
- 동의 관리 패널: 📋→ShieldCheck, ⚠→TriangleAlert
- 알림 설정 패널: 🔥→Flame, 📢→Megaphone
- 계정 정보 수정 패널: 👤→UserCircle, 📝→ClipboardList, 🔑→KeyRound, 🔒→Lock
- 희망직군 선택 커스텀 드롭다운 컴포넌트 추가 (JobCategorySelector)

### 홈 페이지
- StatsGrid: 이모지를 lucide-react 아이콘으로 변경 (Target, TrendingUp, Flame, Timer)
- JobStatus: 📋→ClipboardList, 헤더 스타일 통일
- StreakCalendar: 📅→Calendar

### 스트릭 페이지
- StreakHero: 🔥→Flame, 🏆→Trophy, 📅→Calendar, 🎁→Gift
- Milestones: 🏅→Medal
- NextReward: 🎯→Target, 🎁→Gift
- RewardHistory: 🎁→Gift, 📦→Package

---

## 변경 유형
해당하는 항목에 체크해주세요.
- [ ] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.
- [] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 설정 페이지에서 각 패널(요금제, 동의 관리, 알림 설정, 계정 정보 수정)의 아이콘이 lucide-react로 표시되는지 확인
2. 홈 페이지에서 StatsGrid, JobStatus, StreakCalendar 아이콘이 정상 표시되는지 확인
3. 스트릭 페이지에서 StreakHero, Milestones, NextReward, RewardHistory 아이콘 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다 (96개 테스트 통과)
- [x] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보

