### PR TITLE
URL 파라미터로 선호 직무 지정 가능하도록 변경

### DIFF
--- a/src/features/interview-setup/api/setupApi.ts
+++ b/src/features/interview-setup/api/setupApi.ts
@@ -48,3 +48,25 @@ export async function fetchSetupJdListApi(): Promise<SetupJdItem[]> {
     };
   });
 }
+
+export async function fetchSetupJdByUuidApi(uuid: string): Promise<SetupJdItem | null> {
+  try {
+    const item = await userJobDescriptionApi.retrieve(uuid);
+    const jd = item.jobDescription;
+    const isReady = jd.collectionStatus === "done";
+    const isFailed = jd.collectionStatus === "error";
+
+    return {
+      uuid: item.uuid,
+      icon: pickIcon(jd.platform || "", jd.title || ""),
+      company: jd.company || "수집 중",
+      role: jd.title || "채용공고",
+      stage: jd.location || jd.workType || jd.platform || "",
+      badgeLabel: isReady ? "수집 완료" : isFailed ? "수집 실패" : "수집 중",
+      badgeType: isReady ? "green" : "accent",
+      disabled: !isReady,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/features/interview-setup/model/store.ts
+++ b/src/features/interview-setup/model/store.ts
@@ -1,5 +1,8 @@
 import { create } from "zustand";
-import { fetchSetupJdListApi } from "../api/setupApi";
+import {
+  fetchSetupJdByUuidApi,
+  fetchSetupJdListApi,
+} from "../api/setupApi";
 import type { SetupJdItem } from "../api/setupApi";
 import { interviewSetupApi } from "../api/interviewSetupApi";
 import type { ResumeOption, CreatedInterviewSession } from "../api/interviewSetupApi";
@@ -83,7 +86,16 @@ export const useInterviewSetupStore = create<InterviewSetupState>()((set, get) =
   loadJdList: async (preferredJdId) => {
     set({ jdListLoading: true });
     try {
-      const list = await fetchSetupJdListApi();
+      let list = await fetchSetupJdListApi();
+
+      // 전달된 jd가 목록에 없다면(페이지네이션/필터 영향), 단건 조회로 보강한다.
+      if (preferredJdId && !list.some((jd) => jd.uuid === preferredJdId)) {
+        const preferred = await fetchSetupJdByUuidApi(preferredJdId);
+        if (preferred) {
+          list = [preferred, ...list.filter((jd) => jd.uuid !== preferred.uuid)];
+        }
+      }
+
       set((s) => {
         const preferredEnabled = preferredJdId
           ? list.some((jd) => jd.uuid === preferredJdId && !jd.disabled)

--- a/src/features/interview-setup/model/store.ts
+++ b/src/features/interview-setup/model/store.ts
@@ -34,7 +34,7 @@ interface InterviewSetupState {
   createError: string | null;
   createdSessionUuid: string | null;
 
-  loadJdList: () => Promise<void>;
+  loadJdList: (preferredJdId?: string | null) => Promise<void>;
   selectJd: (uuid: string | null) => void;
   setInterviewMode: (mode: InterviewMode) => void;
   setPracticeMode: (mode: PracticeMode) => void;
@@ -80,11 +80,15 @@ export const useInterviewSetupStore = create<InterviewSetupState>()((set, get) =
   createError: null,
   createdSessionUuid: null,
 
-  loadJdList: async () => {
+  loadJdList: async (preferredJdId) => {
     set({ jdListLoading: true });
     try {
       const list = await fetchSetupJdListApi();
       set((s) => {
+        const preferredEnabled = preferredJdId
+          ? list.some((jd) => jd.uuid === preferredJdId && !jd.disabled)
+          : false;
+
         // 기존 선택값이 여전히 선택 가능한 상태면 유지, 아니면 수집 완료된 첫 항목으로 변경.
         const stillValid = list.some(
           (jd) => jd.uuid === s.selectedJdId && !jd.disabled,
@@ -93,7 +97,11 @@ export const useInterviewSetupStore = create<InterviewSetupState>()((set, get) =
         return {
           jdList: list,
           jdListLoading: false,
-          selectedJdId: stillValid ? s.selectedJdId : firstEnabled,
+          selectedJdId: preferredEnabled
+            ? preferredJdId
+            : stillValid
+              ? s.selectedJdId
+              : firstEnabled,
         };
       });
     } catch {

--- a/src/features/interview-setup/model/store.ts
+++ b/src/features/interview-setup/model/store.ts
@@ -14,6 +14,7 @@ import { buildSummary } from "../lib/buildSummary";
 interface InterviewSetupState {
   jdList: SetupJdItem[];
   jdListLoading: boolean;
+  preferredJdNotice: string | null;
 
   /** 선택된 UserJobDescription.uuid. 없으면 null. */
   selectedJdId: string | null;
@@ -64,6 +65,7 @@ interface InterviewSetupState {
 export const useInterviewSetupStore = create<InterviewSetupState>()((set, get) => ({
   jdList: [],
   jdListLoading: false,
+  preferredJdNotice: null,
 
   selectedJdId: null,
 
@@ -97,9 +99,17 @@ export const useInterviewSetupStore = create<InterviewSetupState>()((set, get) =
       }
 
       set((s) => {
-        const preferredEnabled = preferredJdId
-          ? list.some((jd) => jd.uuid === preferredJdId && !jd.disabled)
-          : false;
+        const preferredItem = preferredJdId
+          ? list.find((jd) => jd.uuid === preferredJdId) ?? null
+          : null;
+        const preferredEnabled = Boolean(preferredItem && !preferredItem.disabled);
+        const preferredJdNotice = preferredJdId
+          ? !preferredItem
+            ? "요청한 채용공고를 찾을 수 없어 선택 가능한 공고로 대체했습니다."
+            : preferredItem.disabled
+              ? "요청한 채용공고는 아직 수집이 완료되지 않아 선택할 수 없습니다."
+              : null
+          : null;
 
         // 기존 선택값이 여전히 선택 가능한 상태면 유지, 아니면 수집 완료된 첫 항목으로 변경.
         const stillValid = list.some(
@@ -114,10 +124,11 @@ export const useInterviewSetupStore = create<InterviewSetupState>()((set, get) =
             : stillValid
               ? s.selectedJdId
               : firstEnabled,
+          preferredJdNotice,
         };
       });
     } catch {
-      set({ jdListLoading: false });
+      set({ jdListLoading: false, preferredJdNotice: "채용공고 목록을 불러오지 못했습니다." });
     }
   },
 

--- a/src/features/jd/model/listStore.ts
+++ b/src/features/jd/model/listStore.ts
@@ -62,10 +62,14 @@ interface JdListState {
   searchQuery: string;
   activeFilter: FilterKey;
   isLoading: boolean;
+   isLoadingMore: boolean;
+   hasNext: boolean;
+   nextPage: number | null;
   error: string | null;
   filtered: JdListItem[];
 
   fetchList: () => Promise<void>;
+   loadMore: () => Promise<void>;
   setSearch: (q: string) => void;
   setFilter: (f: FilterKey) => void;
 }
@@ -134,13 +138,17 @@ export const useJdListStore = create<JdListState>()((set, get) => ({
   searchQuery: "",
   activeFilter: "all",
   isLoading: false,
+   isLoadingMore: false,
+   hasNext: false,
+   nextPage: null,
   error: null,
   filtered: [],
 
   fetchList: async () => {
     set({ isLoading: true, error: null });
     try {
-      const raw = await userJobDescriptionApi.list();
+      const page1 = await userJobDescriptionApi.listPage(1);
+      const raw = page1.results;
       const items = raw.map(transform);
       const { searchQuery, activeFilter } = get();
       set({
@@ -148,11 +156,43 @@ export const useJdListStore = create<JdListState>()((set, get) => ({
         items,
         stats: calcStats(items),
         filtered: applyFilter(items, searchQuery, activeFilter),
+        nextPage: page1.nextPage,
+        hasNext: page1.nextPage != null,
       });
     } catch (e) {
       set({
         isLoading: false,
         error: e instanceof Error ? e.message : "목록을 불러오지 못했습니다.",
+      });
+    }
+  },
+
+   loadMore: async () => {
+    const { nextPage, isLoading, isLoadingMore, hasNext } = get();
+    if (isLoading || isLoadingMore || !hasNext || nextPage == null) {
+      return;
+    }
+
+    set({ isLoadingMore: true, error: null });
+    try {
+      const page = await userJobDescriptionApi.listPage(nextPage);
+      const newItems = page.results.map(transform);
+
+      set((state) => {
+        const mergedItems = [...state.items, ...newItems];
+        return {
+          isLoadingMore: false,
+          items: mergedItems,
+          stats: calcStats(mergedItems),
+          filtered: applyFilter(mergedItems, state.searchQuery, state.activeFilter),
+          nextPage: page.nextPage,
+          hasNext: page.nextPage != null,
+        };
+      });
+    } catch (e) {
+      set({
+        isLoadingMore: false,
+        error: e instanceof Error ? e.message : "다음 목록을 불러오지 못했습니다.",
       });
     }
   },

--- a/src/features/user-job-description/api/userJobDescriptionApi.ts
+++ b/src/features/user-job-description/api/userJobDescriptionApi.ts
@@ -15,9 +15,26 @@ import type { CreatedUserJobDescription, UserJobDescription } from "./types";
 const BASE = "/api/v1/user-job-descriptions";
 
 export const userJobDescriptionApi = {
-  list: () =>
-    apiRequest<PaginatedResponse<UserJobDescription>>(`${BASE}/`, { auth: true })
-      .then((res) => res.results),
+  listPage: (page = 1) =>
+    apiRequest<PaginatedResponse<UserJobDescription>>(`${BASE}/?page=${page}`, { auth: true }),
+
+  list: async () => {
+    let page = 1;
+    let hasNext = true;
+    const all: UserJobDescription[] = [];
+
+    while (hasNext) {
+      const res = await userJobDescriptionApi.listPage(page);
+      all.push(...res.results);
+      if (res.nextPage == null) {
+        hasNext = false;
+      } else {
+        page = res.nextPage;
+      }
+    }
+
+    return all;
+  },
 
   retrieve: (uuid: string) =>
     apiRequest<UserJobDescription>(`${BASE}/${uuid}/`, { auth: true }),

--- a/src/pages/interview-setup/ui/InterviewSetupPage.tsx
+++ b/src/pages/interview-setup/ui/InterviewSetupPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useInterviewSetupStore } from "@/features/interview-setup";
 import { StepLayout } from "@/shared/ui/StepLayout";
 import { ResumeSection } from "./ResumeSection";
@@ -14,6 +15,8 @@ const nextCls = `${navBtnCls} text-white bg-[#0A0A0A] border-none shadow-[0_4px_
 
 export function InterviewSetupPage() {
   const [step, setStep] = useState<SetupStep>(1);
+  const [searchParams] = useSearchParams();
+  const preferredJdId = useMemo(() => searchParams.get("jd"), [searchParams]);
   const {
     jdList, jdListLoading, selectedJdId,
     interviewMode, practiceMode, interviewDifficultyLevel,
@@ -25,10 +28,10 @@ export function InterviewSetupPage() {
   } = useInterviewSetupStore();
 
   useEffect(() => {
-    loadJdList();
+    loadJdList(preferredJdId);
     fetchResumes();
     resetSetup();
-  }, [loadJdList, fetchResumes, resetSetup]);
+  }, [loadJdList, fetchResumes, resetSetup, preferredJdId]);
 
   const handleStartInterview = async () => {
     const session = await createSession();

--- a/src/pages/interview-setup/ui/InterviewSetupPage.tsx
+++ b/src/pages/interview-setup/ui/InterviewSetupPage.tsx
@@ -19,6 +19,7 @@ export function InterviewSetupPage() {
   const preferredJdId = useMemo(() => searchParams.get("jd"), [searchParams]);
   const {
     jdList, jdListLoading, selectedJdId,
+    preferredJdNotice,
     interviewMode, practiceMode, interviewDifficultyLevel,
     loadJdList, selectJd,
     setInterviewMode, setPracticeMode, setInterviewDifficultyLevel,
@@ -28,10 +29,13 @@ export function InterviewSetupPage() {
   } = useInterviewSetupStore();
 
   useEffect(() => {
-    loadJdList(preferredJdId);
     fetchResumes();
     resetSetup();
-  }, [loadJdList, fetchResumes, resetSetup, preferredJdId]);
+  }, [fetchResumes, resetSetup]);
+
+  useEffect(() => {
+    loadJdList(preferredJdId);
+  }, [loadJdList, preferredJdId]);
 
   const handleStartInterview = async () => {
     const session = await createSession();
@@ -49,6 +53,11 @@ export function InterviewSetupPage() {
           <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">▶ 면접 시작</div>
           <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">가상 면접 설정</h1>
           <p className="text-sm text-[#6B7280] mt-1.5">채용공고와 면접 방식을 선택하고 맞춤 가상 면접을 시작하세요.</p>
+          {preferredJdNotice && (
+            <div className="mt-3 rounded-lg border border-[#FED7AA] bg-[#FFF7ED] px-3 py-2 text-[12px] text-[#9A3412]">
+              {preferredJdNotice}
+            </div>
+          )}
         </div>
 
         {/* ══════ STEP 1: 지원 컨텍스트 ══════ */}

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useJdListStore, type JdListItem } from "@/features/jd";
 import { useUserJobDescriptionScrapingSse } from "@/features/user-job-description";
@@ -172,13 +172,44 @@ function JdCard({ item }: { item: JdListItem }) {
 export function JdListPage() {
   const {
     stats, filtered, searchQuery, activeFilter,
-    isLoading,
-    fetchList, setSearch, setFilter,
+    isLoading, isLoadingMore, hasNext,
+    fetchList, loadMore, setSearch, setFilter,
   } = useJdListStore();
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const setSentinelNode = useCallback((node: HTMLDivElement | null) => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+    if (!node) {
+      return;
+    }
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          void loadMore();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+
+    observerRef.current.observe(node);
+  }, [loadMore]);
 
   useEffect(() => {
     fetchList();
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+    };
   }, []);
 
   const FILTER_PILLS: { key: FilterKey; label: string; count: number }[] = [
@@ -293,11 +324,19 @@ export function JdListPage() {
             )}
           </div>
         ) : (
-          <div className="grid gap-[18px]" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))" }}>
-            {filtered.map((item) => (
-              <JdCard key={item.uuid} item={item} />
-            ))}
-          </div>
+          <>
+            <div className="grid gap-[18px]" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))" }}>
+              {filtered.map((item) => (
+                <JdCard key={item.uuid} item={item} />
+              ))}
+            </div>
+
+            {isLoadingMore && (
+              <div className="flex justify-center py-6 text-[13px] text-[#6B7280]">다음 공고를 불러오는 중...</div>
+            )}
+
+            {hasNext && <div ref={setSentinelNode} className="h-4" />}
+          </>
         )}
 
       </div>

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -155,7 +155,10 @@ function JdCard({ item }: { item: JdListItem }) {
         ) : (
           <button
             className="text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] border-none rounded-lg py-[7px] px-3.5 cursor-pointer transition-all hover:bg-[#cceef6] hover:-translate-y-px"
-            onClick={(e) => { e.stopPropagation(); navigate("/interview"); }}
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/interview/setup?jd=${encodeURIComponent(item.uuid)}`);
+            }}
           >
             면접 시작
           </button>


### PR DESCRIPTION
## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.
- URL 파라미터를 통해 선호 직무를 지정할 수 있도록 `loadJdList` 함수 수정
- `InterviewSetupPage`에서 URL 파라미터를 읽어오는 로직 추가
- `JdListPage`에서 면접 시작 버튼 클릭 시 선호 직무 UUID를 URL에 포함

## 변경 유형
- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.
- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 면접 설정 페이지에 접속할 때 URL에 `?jd=직무UUID` 파라미터를 추가하여 접속
2. 페이지 로드 후, 선호 직무가 올바르게 선택되었는지 확인
3. 면접 시작 버튼 클릭 시, 올바른 직무 UUID로 리디렉션되는지 확인

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.

---
_Branch: `fix/issue-03-jd-setup-handoff` → `develop`_
