### PR TITLE
feat: Add career_stage to profile UI and API integration

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -38,7 +38,6 @@ function App() {
       "/",
       "/login",
       "/sign-up",
-      "/verify-email",
     ]);
     return publicAuthPaths.has(window.location.pathname);
   };
@@ -75,9 +74,9 @@ function App() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/sign-up" element={<SignUpPage />} />
-        <Route path="/verify-email" element={<VerifyEmailPage />} />
 
         {/* ── 보호 라우트 (로그인 필요) ── */}
+        <Route path="/verify-email" element={<ProtectedRoute><VerifyEmailPage /></ProtectedRoute>} />
         <Route path="/onboarding" element={<ProtectedRoute><OnboardingPage /></ProtectedRoute>} />
         <Route path="/jd/add" element={<ProtectedRoute><JdAddPage /></ProtectedRoute>} />
         <Route path="/jd/:uuid" element={<ProtectedRoute><JdDetailPage /></ProtectedRoute>} />

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -12,7 +12,7 @@ interface AppLayoutProps {
 }
 
 /** Pages that use their own full-screen layout (no nav/sidebar) */
-const FULL_SCREEN_PREFIXES = ["/interview/session/", "/interview/precheck/"];
+const FULL_SCREEN_PREFIXES = ["/interview/session/", "/interview/precheck/", "/verify-email", "/onboarding"];
 
 export function AppLayout({ children }: AppLayoutProps) {
   useNotificationToast();

--- a/src/features/auth/model/store.ts
+++ b/src/features/auth/model/store.ts
@@ -59,6 +59,10 @@ export const useAuthStore = create<AuthState>()((set) => ({
     }
     // 회원가입 후 토큰이 설정되었으므로 사용자 정보 조회
     const me = await getMeApi();
+    if (!me) {
+      set({ isLoading: false, error: "사용자 정보를 불러오는데 실패했습니다." });
+      return false;
+    }
     set({ isLoading: false, pendingEmail: email, user: me });
     return true;
   },
@@ -93,8 +97,12 @@ export const useAuthStore = create<AuthState>()((set) => ({
       set({ isVerifying: false, error: res.message });
       return false;
     }
-    // 인증된 사용자 -  최신 사용자 정보 업데이트
+    // 인증된 사용자 - 최신 사용자 정보 업데이트
     const me = await getMeApi();
+    if (!me) {
+      set({ isVerifying: false, error: "사용자 정보를 불러오는데 실패했습니다." });
+      return false;
+    }
     set({ isVerifying: false, user: me });
     return true;
   },

--- a/src/features/auth/model/store.ts
+++ b/src/features/auth/model/store.ts
@@ -57,7 +57,9 @@ export const useAuthStore = create<AuthState>()((set) => ({
       set({ isLoading: false, error: res.message });
       return false;
     }
-    set({ isLoading: false, pendingEmail: email });
+    // 회원가입 후 토큰이 설정되었으므로 사용자 정보 조회
+    const me = await getMeApi();
+    set({ isLoading: false, pendingEmail: email, user: me });
     return true;
   },
 
@@ -91,7 +93,9 @@ export const useAuthStore = create<AuthState>()((set) => ({
       set({ isVerifying: false, error: res.message });
       return false;
     }
-    set({ isVerifying: false });
+    // 인증된 사용자 -  최신 사용자 정보 업데이트
+    const me = await getMeApi();
+    set({ isVerifying: false, user: me });
     return true;
   },
 

--- a/src/features/onboarding/api/onboardingApi.ts
+++ b/src/features/onboarding/api/onboardingApi.ts
@@ -16,6 +16,7 @@ export async function fetchJobsByCategoryApi(jobCategoryId: number): Promise<Job
 export async function submitOnboardingProfileApi(payload: {
   jobCategoryId: number;
   jobIds: number[];
+  careerStage?: string;
 }): Promise<void> {
   await profileApi.saveMyProfile(payload);
 }

--- a/src/features/onboarding/model/store.ts
+++ b/src/features/onboarding/model/store.ts
@@ -103,12 +103,16 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
       set({ error: "희망 직업을 1개 이상 선택해주세요." });
       return false;
     }
+    if (!careerStage) {
+      set({ error: "현재 직업 상태를 선택해주세요." });
+      return false;
+    }
     set({ isLoading: true, error: null });
     try {
       await submitOnboardingProfileApi({
         jobCategoryId: selectedJobCategoryId,
         jobIds: selectedJobIds,
-        careerStage: careerStage || undefined,
+        careerStage,
       });
       set({ isLoading: false });
       return true;

--- a/src/features/onboarding/model/store.ts
+++ b/src/features/onboarding/model/store.ts
@@ -10,13 +10,13 @@ import {
 
 export const JOB_STATUS_OPTIONS = [
   { value: "", label: "선택해 주세요" },
-  { value: "student", label: "대학생/대학원생" },
-  { value: "job-seeker", label: "취업 준비생" },
-  { value: "new-grad", label: "신입 (1년 미만)" },
-  { value: "junior", label: "주니어 (1~3년)" },
-  { value: "mid", label: "미드레벨 (3~7년)" },
-  { value: "senior", label: "시니어 (7년 이상)" },
-  { value: "career-change", label: "이직 준비 중" },
+  { value: "university_student", label: "대학생" },
+  { value: "graduate_student", label: "대학원생" },
+  { value: "lt_1_year", label: "1년 미만" },
+  { value: "1_3_years", label: "1-3년" },
+  { value: "3_7_years", label: "3-7년" },
+  { value: "over_7_years", label: "7년 이상" },
+  { value: "other", label: "기타" },
 ] as const;
 
 interface OnboardingState {
@@ -28,14 +28,14 @@ interface OnboardingState {
   availableJobsLoading: boolean;
   selectedJobIds: number[];
 
-  jobStatus: string; // 프론트 전용 (백엔드 미지원)
+  careerStage: string;
   isLoading: boolean;
   error: string | null;
 
   loadJobCategories: () => Promise<void>;
   selectJobCategory: (jobCategoryId: number) => Promise<void>;
   toggleJobId: (jobId: number) => void;
-  setJobStatus: (status: string) => void;
+  setCareerStage: (status: string) => void;
   submitProfile: () => Promise<boolean>;
   clearError: () => void;
 }
@@ -49,7 +49,7 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
   availableJobsLoading: false,
   selectedJobIds: [],
 
-  jobStatus: "",
+  careerStage: "",
   isLoading: false,
   error: null,
 
@@ -91,10 +91,10 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
       return { selectedJobIds: [...state.selectedJobIds, jobId] };
     }),
 
-  setJobStatus: (status) => set({ jobStatus: status }),
+  setCareerStage: (status) => set({ careerStage: status }),
 
   submitProfile: async () => {
-    const { selectedJobCategoryId, selectedJobIds } = get();
+    const { selectedJobCategoryId, selectedJobIds, careerStage } = get();
     if (!selectedJobCategoryId) {
       set({ error: "희망 직군을 선택해주세요." });
       return false;
@@ -108,6 +108,7 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
       await submitOnboardingProfileApi({
         jobCategoryId: selectedJobCategoryId,
         jobIds: selectedJobIds,
+        careerStage: careerStage || undefined,
       });
       set({ isLoading: false });
       return true;

--- a/src/features/settings/api/settingsApi.ts
+++ b/src/features/settings/api/settingsApi.ts
@@ -16,6 +16,7 @@ export interface SettingsProfile {
   jobCategory: JobCategory | null;
   jobIds: number[];
   jobs: Job[];
+  careerStage: string;
 }
 
 export interface SettingsNotifications {
@@ -101,6 +102,7 @@ export async function fetchSettingsApi(): Promise<{ success: boolean; data?: Set
       jobCategory: profileData?.jobCategory ?? null,
       jobIds: profileData?.jobs?.map((j) => j.id) ?? [],
       jobs: profileData?.jobs ?? [],
+      careerStage: profileData?.careerStage ?? "",
     };
 
     // my-consents에서 이용약관/개인정보처리방침 동의일 추출
@@ -152,9 +154,10 @@ export async function uploadAvatarApi(file: File): Promise<{ success: boolean; a
 export async function updateProfileApi(payload: {
   jobCategoryId: number;
   jobIds: number[];
+  careerStage?: string;
 }): Promise<ApiResult> {
   try {
-    await profileApi.saveMyProfile({ jobCategoryId: payload.jobCategoryId, jobIds: payload.jobIds });
+    await profileApi.saveMyProfile({ jobCategoryId: payload.jobCategoryId, jobIds: payload.jobIds, careerStage: payload.careerStage });
     return { success: true, message: "프로필이 저장되었습니다." };
   } catch {
     return { success: false, message: "저장에 실패했습니다." };

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -19,6 +19,7 @@ interface ProfileDraft {
   name: string;
   jobCategoryId: number | null;
   jobIds: number[];
+  careerStage: string;
 }
 
 interface SettingsState {
@@ -71,7 +72,7 @@ interface SettingsState {
   clearMessage: () => void;
 }
 
-const EMPTY_PROFILE_DRAFT: ProfileDraft = { name: "", jobCategoryId: null, jobIds: [] };
+const EMPTY_PROFILE_DRAFT: ProfileDraft = { name: "", jobCategoryId: null, jobIds: [], careerStage: "" };
 
 export const useSettingsStore = create<SettingsState>()((set, get) => ({
   data: null,
@@ -104,6 +105,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
           name: profile.name,
           jobCategoryId: profile.jobCategoryId,
           jobIds: profile.jobIds,
+          careerStage: profile.careerStage,
         },
         notificationsDraft: { ...res.data.notifications },
         aiDataDraft: res.data.consents.aiDataAgreed,
@@ -196,6 +198,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     const res = await updateProfileApi({
       jobCategoryId: profileDraft.jobCategoryId,
       jobIds: profileDraft.jobIds,
+      careerStage: profileDraft.careerStage || undefined,
     });
     if (res.success) {
       // 로컬 data 업데이트
@@ -214,6 +217,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
               jobCategory: selectedCategory,
               jobIds: profileDraft.jobIds,
               jobs: selectedJobs,
+              careerStage: profileDraft.careerStage,
             } as SettingsProfile,
           },
         };
@@ -231,6 +235,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
           name: data.profile.name,
           jobCategoryId: data.profile.jobCategoryId,
           jobIds: data.profile.jobIds,
+          careerStage: data.profile.careerStage,
         },
         saveMessage: null,
       });

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -13,13 +13,13 @@ export function OnboardingPage() {
     availableJobs,
     availableJobsLoading,
     selectedJobIds,
-    jobStatus,
+    careerStage,
     isLoading,
     error,
     loadJobCategories,
     selectJobCategory,
     toggleJobId,
-    setJobStatus,
+    setCareerStage,
     submitProfile,
     clearError,
   } = useOnboardingStore();
@@ -269,8 +269,8 @@ export function OnboardingPage() {
             <div className="relative mb-6">
               <select
                 className="w-full py-[14px] pl-4 pr-10 font-plex-sans-kr text-[15px] text-[#0A0A0A] bg-white border border-[#E5E7EB] rounded-lg outline-none appearance-none cursor-pointer transition-[border-color] duration-200 focus:border-[#0991B2]"
-                value={jobStatus}
-                onChange={(e) => setJobStatus(e.target.value)}
+                value={careerStage}
+                onChange={(e) => setCareerStage(e.target.value)}
                 aria-label="현재 직업 상태"
               >
                 {JOB_STATUS_OPTIONS.map((opt) => (

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -5,7 +5,7 @@ import { useOnboardingStore, JOB_STATUS_OPTIONS } from "@/features/onboarding";
 
 export function OnboardingPage() {
   const navigate = useNavigate();
-  const { pendingEmail } = useAuthStore();
+  const { user } = useAuthStore();
   const {
     jobCategories,
     jobCategoriesLoading,
@@ -24,7 +24,7 @@ export function OnboardingPage() {
     clearError,
   } = useOnboardingStore();
 
-  const email = pendingEmail || "hello@mefit.kr";
+  const email = user?.email ?? "hello@mefit.kr";
 
   // 자동완성 상태
   const [acOpen, setAcOpen] = useState(false);

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { useSettingsStore } from "@/features/settings";
 import { useSubscriptionStore } from "@/features/subscription";
 import { TicketPolicyInfo } from "@/features/subscription/ui/TicketPolicyInfo";
 import { JobCategorySelector } from "./JobCategorySelector";
+import { JOB_STATUS_OPTIONS } from "@/features/onboarding";
 import type { SettingsPanel } from "@/features/settings";
 
 /* ── Password strength helper ── */
@@ -173,6 +174,24 @@ export function SettingsPage() {
                             onToggle: toggleJobId,
                           }}
                         />
+                      </div>
+                      <div className="flex flex-col gap-[5px] mt-4">
+                        <label className="font-plex-sans-kr text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px]">현재 직업 상태</label>
+                        <div className="relative">
+                          <select
+                            className={inputClass}
+                            value={profileDraft.careerStage}
+                            onChange={(e) => setProfileDraftField("careerStage", e.target.value)}
+                            aria-label="현재 직업 상태"
+                          >
+                            {JOB_STATUS_OPTIONS.map((opt) => (
+                              <option key={opt.value} value={opt.value}>
+                                {opt.label}
+                              </option>
+                            ))}
+                          </select>
+                          <svg className="absolute right-[14px] top-1/2 -translate-y-1/2 pointer-events-none" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6B7280" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9" /></svg>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/pages/verify-email/ui/VerifyEmailPage.tsx
+++ b/src/pages/verify-email/ui/VerifyEmailPage.tsx
@@ -4,12 +4,12 @@ import { Link, useNavigate } from "react-router-dom";
 
 export function VerifyEmailPage() {
   const navigate = useNavigate();
-  const { pendingEmail, isVerifying, isResending, error, resendVerification, verifyCode, logout, clearError } = useAuthStore();
+  const { user, isVerifying, isResending, error, resendVerification, verifyCode, logout, clearError } = useAuthStore();
   const [resent, setResent] = useState(false);
   const [code, setCode] = useState(["", "", "", "", "", ""]);
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
-  const email = pendingEmail || "hello@mefit.kr";
+  const email = user?.email ?? "hello@mefit.kr";
 
   const handleResend = async () => {
     setResent(false);

--- a/src/shared/api/profileApi.ts
+++ b/src/shared/api/profileApi.ts
@@ -16,6 +16,7 @@ export interface UserProfile {
   user: number;
   jobCategory: JobCategory;
   jobs: Job[];
+  careerStage: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -23,6 +24,7 @@ export interface UserProfile {
 export interface SaveProfileParams {
   jobCategoryId: number;
   jobIds: number[];
+  careerStage?: string;
 }
 
 export interface PaginatedJobCategories {
@@ -51,7 +53,11 @@ export const profileApi = {
     apiRequest<UserProfile>("/api/v1/profiles/me/", {
       method: "POST",
       auth: true,
-      body: JSON.stringify({ jobCategoryId: params.jobCategoryId, jobIds: params.jobIds }),
+      body: JSON.stringify({
+        jobCategoryId: params.jobCategoryId,
+        jobIds: params.jobIds,
+        ...(params.careerStage && { career_stage: params.careerStage }),
+      }),
     }),
 
   getAvatar: () =>


### PR DESCRIPTION
## Summary
- Onboarding 및 Settings 페이지에 career_stage 필드 추가
- Backend API와 career_stage 연동
- Auth flow 개선 (signUp, verifyCode 후 user 상태 업데이트)
- verify-email, onboarding 페이지를 minimal layout으로 변경

## Changes
- `onboarding/model/store.ts` - careerStage state 및 필수 검증
- `onboarding/api/onboardingApi.ts` - careerStage 파라미터 추가
- `shared/api/profileApi.ts` - careerStage 타입 및 전송 추가
- `settings/model/store.ts` - careerStage state 추가
- `settings/api/settingsApi.ts` - careerStage 연동
- `pages/onboarding/ui/OnboardingPage.tsx` - career_stage UI
- `pages/settings/ui/SettingsPage.tsx` - career_stage UI
- `app/AppLayout.tsx` - verify-email, onboarding minimal layout
- `app/App.tsx` - verify-email protected route
- `features/auth/model/store.ts` - signUp, verifyCode user 업데이트