### PR TITLE
feat(interview): Add Coach Marks component for interview session guidance

### DIFF
--- a/src/features/interview-session/ui/BehaviorMetrics.tsx
+++ b/src/features/interview-session/ui/BehaviorMetrics.tsx
@@ -1,6 +1,7 @@
 import type { SpeechMetrics } from "@/shared/lib/speech/SpeechAnalyzer";
 
 interface BehaviorMetricsProps {
+  className?: string;
   speechMetrics: SpeechMetrics;
   videoWarningCount: number;
   isSpeechActive: boolean;
@@ -10,6 +11,7 @@ interface BehaviorMetricsProps {
 }
 
 export function BehaviorMetrics({
+  className,
   speechMetrics,
   videoWarningCount,
   audioLevel,
@@ -17,7 +19,7 @@ export function BehaviorMetrics({
   isAnalyzing,
 }: BehaviorMetricsProps) {
   return (
-    <div className="bg-slate-800/60 border border-white/10 rounded-2xl p-4 flex flex-col gap-3">
+    <div className={`bg-slate-800/60 border border-white/10 rounded-2xl p-4 flex flex-col gap-3 ${className || ""}`}>
       <div className="text-[10px] font-bold tracking-widest uppercase text-slate-500">실시간 분석</div>
 
       <div className="grid grid-cols-2 gap-2">

--- a/src/features/interview-session/ui/QuestionPanel.tsx
+++ b/src/features/interview-session/ui/QuestionPanel.tsx
@@ -3,6 +3,7 @@ import type { InterviewTurn } from "../api/types";
 import type { InterviewPhase } from "../model/types";
 
 interface QuestionPanelProps {
+  className?: string;
   currentInterviewTurn: InterviewTurn | null;
   interviewPhase: InterviewPhase;
   currentTurnIndex: number;
@@ -17,6 +18,7 @@ interface QuestionPanelProps {
 }
 
 export function QuestionPanel({
+  className,
   currentInterviewTurn,
   interviewPhase,
   currentTurnIndex,
@@ -31,7 +33,7 @@ export function QuestionPanel({
   const isGenerating = interviewPhase === "generating_followup" || interviewPhase === "starting";
 
   return (
-    <div className="bg-slate-800/60 border border-white/10 rounded-2xl p-6 min-h-[260px] flex flex-col">
+    <div className={`bg-slate-800/60 border border-white/10 rounded-2xl p-6 min-h-[260px] flex flex-col ${className || ""}`}>
       {/* ── 상단: 라벨 + 카운터 + TTS 컨트롤 ── */}
       <div className="flex items-center gap-2 mb-3">
         <span className="text-[10px] font-bold tracking-widest uppercase text-indigo-400">

--- a/src/features/interview-session/ui/TranscriptPanel.tsx
+++ b/src/features/interview-session/ui/TranscriptPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 
 interface TranscriptPanelProps {
+  className?: string;
   finalText: string;
   interimText: string;
   highlightedHtml: string;
@@ -39,6 +40,7 @@ function parseHighlightedHtml(html: string): React.ReactNode[] {
 }
 
 export function TranscriptPanel({
+  className,
   interimText,
   highlightedHtml,
   isListening,
@@ -52,7 +54,7 @@ export function TranscriptPanel({
   }, [highlightedHtml, interimText]);
 
   return (
-    <div className="bg-slate-900/50 border border-white/10 rounded-2xl p-5 flex flex-col gap-2 min-h-[120px] flex-1 h-full min-h-0">
+    <div className={`bg-slate-900/50 border border-white/10 rounded-2xl p-5 flex flex-col gap-2 min-h-[120px] flex-1 h-full min-h-0 ${className || ""}`}>
       <div className="text-[10px] font-bold tracking-widest uppercase text-slate-500 mb-1">
         실시간 답변
       </div>

--- a/src/pages/interview-session/ui/InterviewSessionPage.tsx
+++ b/src/pages/interview-session/ui/InterviewSessionPage.tsx
@@ -136,9 +136,10 @@ export function InterviewSessionPage() {
   const [speechMetrics, setSpeechMetrics] = useState({ wpm: 0, fillerCount: 0, badWordCount: 0, pauseWarnings: 0, highlightedHtml: "" });
   const [showCoachMarks, setShowCoachMarks] = useState(false);
   const [coachMarksStep, setCoachMarksStep] = useState(0);
+  const [coachMarksCompleted, setCoachMarksCompleted] = useState(false);
 
   const isFirstQuestion = currentInterviewTurnIndex === 0;
-  const shouldShowCoachMarksGuide = shouldShowCoachMarks(INTERVIEW_COACH_MARKS_KEY) && isFirstQuestion;
+  const shouldShowCoachMarksGuide = shouldShowCoachMarks(INTERVIEW_COACH_MARKS_KEY) && isFirstQuestion && !coachMarksCompleted;
 
   const permissionError = usePermissionMonitor(hasStarted && !isFinished);
 
@@ -298,6 +299,11 @@ export function InterviewSessionPage() {
           steps={interviewCoachMarksSteps}
           open={showCoachMarks}
           onClose={() => {
+            setShowCoachMarks(false);
+            markCoachMarksShown(INTERVIEW_COACH_MARKS_KEY);
+          }}
+          onComplete={() => {
+            setCoachMarksCompleted(true);
             setShowCoachMarks(false);
             markCoachMarksShown(INTERVIEW_COACH_MARKS_KEY);
           }}

--- a/src/pages/interview-session/ui/InterviewSessionPage.tsx
+++ b/src/pages/interview-session/ui/InterviewSessionPage.tsx
@@ -8,6 +8,8 @@ import { TranscriptPanel } from "@/features/interview-session/ui/TranscriptPanel
 import { BehaviorMetrics } from "@/features/interview-session/ui/BehaviorMetrics";
 import { SpeechAnalyzer } from "@/shared/lib/speech/SpeechAnalyzer";
 import { useTts } from "@/shared/lib/tts/useTts";
+import { CoachMarks, type CoachMarkStep } from "@/shared/ui";
+import { shouldShowCoachMarks, markCoachMarksShown } from "@/shared/lib/storage";
 import type { IAvatarProvider } from "@/shared/lib/avatar/IAvatarProvider";
 
 import { useMediaSetup } from "../hooks/useMediaSetup";
@@ -20,6 +22,51 @@ import { SessionActionPanel } from "./SessionActionPanel";
 import { PermissionOverlay } from "./PermissionOverlay";
 import { ScreenSizeOverlay } from "./ScreenSizeOverlay";
 import { FinishConfirmModal } from "./FinishConfirmModal";
+
+const INTERVIEW_COACH_MARKS_KEY = "interview-session";
+
+const interviewCoachMarksSteps: CoachMarkStep[] = [
+  {
+    id: "welcome",
+    title: "면접 세션 안내",
+    description: "면접 세션이 시작되었습니다. 주요 기능을 안내해 드리겠습니다.",
+    targetSelector: ".session-header",
+    position: "bottom",
+    align: "center",
+  },
+  {
+    id: "question-panel",
+    title: "질문 패널",
+    description: "여기서 면접관의 질문이 표시됩니다. 질문이 끝나면 답변을 시작하세요.",
+    targetSelector: ".question-panel",
+    position: "top",
+    align: "center",
+  },
+  {
+    id: "action-panel",
+    title: "액션 패널",
+    description: "면접 시작, 답변 제출 등 주요 액션을 여기서 수행합니다.",
+    targetSelector: ".session-action-panel",
+    position: "left",
+    align: "center",
+  },
+  {
+    id: "transcript-panel",
+    title: "대본 패널",
+    description: "당신의 답변이 실시간으로 표시됩니다. 말하기 습관을 확인할 수 있습니다.",
+    targetSelector: ".transcript-panel",
+    position: "left",
+    align: "center",
+  },
+  {
+    id: "behavior-metrics",
+    title: "행동 지표",
+    description: "말하기 속도, 채움말 사용 등 다양한 지표를 실시간으로 확인할 수 있습니다.",
+    targetSelector: ".behavior-metrics",
+    position: "left",
+    align: "center",
+  },
+];
 
 export function InterviewSessionPage() {
   const { interviewSessionUuid } = useParams<{ interviewSessionUuid: string }>();
@@ -84,9 +131,14 @@ export function InterviewSessionPage() {
   const isFinished = phase === "finished";
   const isRealMode = interviewSession?.interviewPracticeMode === "real";
   const difficultyLabel = { friendly: "친근한 면접관", normal: "일반 면접관", pressure: "압박 면접관" }[interviewSession?.interviewDifficultyLevel ?? "normal"] ?? "일반 면접관";
-
+  
   const [showFinishModal, setShowFinishModal] = useState(false);
   const [speechMetrics, setSpeechMetrics] = useState({ wpm: 0, fillerCount: 0, badWordCount: 0, pauseWarnings: 0, highlightedHtml: "" });
+  const [showCoachMarks, setShowCoachMarks] = useState(false);
+  const [coachMarksStep, setCoachMarksStep] = useState(0);
+
+  const isFirstQuestion = currentInterviewTurnIndex === 0;
+  const shouldShowCoachMarksGuide = shouldShowCoachMarks(INTERVIEW_COACH_MARKS_KEY) && isFirstQuestion;
 
   const permissionError = usePermissionMonitor(hasStarted && !isFinished);
 
@@ -127,6 +179,15 @@ export function InterviewSessionPage() {
     return () => clearInterval(id);
   }, [finalText, interimText, isListening]);
 
+  useEffect(() => {
+    if (shouldShowCoachMarksGuide && interviewSession && !showCoachMarks) {
+      const timer = setTimeout(() => {
+        setShowCoachMarks(true);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [shouldShowCoachMarksGuide, interviewSession, showCoachMarks]);
+
   const handleSubmitAnswer = () => {
     const answer = (finalText + " " + interimText).trim();
     machine.handleSubmit(answer, sttSegments);
@@ -145,15 +206,16 @@ export function InterviewSessionPage() {
 
   return (
     <div className="w-full h-screen bg-[#080f1a] text-white flex flex-col overflow-hidden font-sans">
-      <SessionHeader
-        interviewSession={interviewSession}
-        currentInterviewTurnIndex={currentInterviewTurnIndex}
-        hasStarted={hasStarted}
-        isFinished={isFinished}
-        difficultyLabel={difficultyLabel}
-        practiceModeLabel={isRealMode ? "실전 모드" : "연습 모드"}
-        onFinish={() => setShowFinishModal(true)}
-      />
+           <SessionHeader
+            className="session-header"
+            interviewSession={interviewSession}
+            currentInterviewTurnIndex={currentInterviewTurnIndex}
+            hasStarted={hasStarted}
+            isFinished={isFinished}
+            difficultyLabel={difficultyLabel}
+            practiceModeLabel={isRealMode ? "실전 모드" : "연습 모드"}
+            onFinish={() => setShowFinishModal(true)}
+          />
 
       <main className="flex-1 flex overflow-hidden min-h-0">
         <section className="flex-1 flex flex-col overflow-hidden border-r border-white/10">
@@ -177,7 +239,8 @@ export function InterviewSessionPage() {
             <AvatarSection onReady={(a) => { avatarRef.current = a; }} className="absolute inset-0 w-full h-full" />
           </div>
           <div className="shrink-0 px-6 pb-5 pt-4 border-t border-white/5 bg-[#080f1a]/80">
-            <QuestionPanel
+             <QuestionPanel
+              className="question-panel"
               currentInterviewTurn={currentInterviewTurn} interviewPhase={interviewPhase}
               currentTurnIndex={currentInterviewTurnIndex}
               totalTurns={interviewSession?.estimatedTotalQuestions ?? 0}
@@ -188,7 +251,8 @@ export function InterviewSessionPage() {
         </section>
 
         <section className="w-[340px] shrink-0 flex flex-col bg-[#0b1420] border-l border-white/5">
-          <SessionActionPanel
+           <SessionActionPanel
+            className="session-action-panel"
             machinePhase={phase}
             isRealMode={isRealMode}
             countdown={machine.state.countdown}
@@ -202,10 +266,10 @@ export function InterviewSessionPage() {
             onSubmitAnswer={handleSubmitAnswer}
           />
           <div className="flex-1 min-h-0 p-4 flex">
-            <TranscriptPanel finalText={finalText} interimText={interimText} highlightedHtml={speechMetrics.highlightedHtml} isListening={isListening} />
+             <TranscriptPanel className="transcript-panel" finalText={finalText} interimText={interimText} highlightedHtml={speechMetrics.highlightedHtml} isListening={isListening} />
           </div>
           <div className="shrink-0 px-4 pb-3 border-t border-white/5 pt-3">
-            <BehaviorMetrics speechMetrics={speechMetrics} videoWarningCount={video.videoWarningCount} isSpeechActive={isListening} audioLevel={audioLevel} fps={video.fps} isAnalyzing={video.isAnalyzing} />
+             <BehaviorMetrics className="behavior-metrics" speechMetrics={speechMetrics} videoWarningCount={video.videoWarningCount} isSpeechActive={isListening} audioLevel={audioLevel} fps={video.fps} isAnalyzing={video.isAnalyzing} />
           </div>
           <div className="h-44 relative border-t border-white/10 bg-black flex items-center justify-center shrink-0">
             <video ref={videoRef} autoPlay playsInline muted className="w-full h-full object-cover -scale-x-100" />
@@ -229,6 +293,20 @@ export function InterviewSessionPage() {
 
       <style>{`.filler-word{background:rgba(234,179,8,.2);border-radius:3px;padding:0 2px;color:#facc15}.bad-word{background:rgba(239,68,68,.2);border-radius:3px;padding:0 2px;color:#f87171}`}</style>
 
+      {showCoachMarks && (
+        <CoachMarks
+          steps={interviewCoachMarksSteps}
+          open={showCoachMarks}
+          onClose={() => {
+            setShowCoachMarks(false);
+            markCoachMarksShown(INTERVIEW_COACH_MARKS_KEY);
+          }}
+          currentStep={coachMarksStep}
+          onStepChange={setCoachMarksStep}
+          dismissOnBackdrop={false}
+          dismissOnEsc={true}
+        />
+      )}
       {showFinishModal && <FinishConfirmModal onConfirm={handleFinishConfirm} onCancel={() => setShowFinishModal(false)} />}
       {isTooSmall && <ScreenSizeOverlay screenWidth={screenSize.w} screenHeight={screenSize.h} onGoHome={() => navigate("/interview/results")} />}
       {permissionError && <PermissionOverlay onReload={() => window.location.reload()} onGoResults={() => navigate("/interview/results")} />}

--- a/src/pages/interview-session/ui/SessionActionPanel.tsx
+++ b/src/pages/interview-session/ui/SessionActionPanel.tsx
@@ -21,6 +21,7 @@ type ActionMode =
   | "finished";
 
 interface SessionActionPanelProps {
+  className?: string;
   machinePhase: MachinePhase;
   isRealMode: boolean;
   countdown: number | null;
@@ -51,6 +52,7 @@ function deriveActionMode(machinePhase: MachinePhase, isRealMode: boolean): Acti
 }
 
 export function SessionActionPanel({
+  className,
   machinePhase, isRealMode, countdown, isModelLoading,
   interviewPhase, audioLevel, finalText, interimText,
   onStart, onPracticeStart, onSubmitAnswer,
@@ -83,7 +85,7 @@ export function SessionActionPanel({
   const showLoading = mode === "loading" || mode === "starting" || (mode === "not_started" && isModelLoading);
 
   return (
-    <div className="shrink-0 p-4 border-b border-white/10 flex flex-col gap-2">
+    <div className={`shrink-0 p-4 border-b border-white/10 flex flex-col gap-2 ${className || ""}`}>
       {(mode === "loading" || mode === "not_started" || mode === "starting") && (
         <button
           onClick={onStart}

--- a/src/pages/interview-session/ui/SessionHeader.tsx
+++ b/src/pages/interview-session/ui/SessionHeader.tsx
@@ -2,6 +2,7 @@ import { Square } from "lucide-react";
 import type { InterviewSession } from "@/features/interview-session";
 
 interface SessionHeaderProps {
+  className?: string;
   interviewSession: InterviewSession | null;
   currentInterviewTurnIndex: number;
   hasStarted: boolean;
@@ -12,11 +13,12 @@ interface SessionHeaderProps {
 }
 
 export function SessionHeader({
+  className,
   interviewSession, currentInterviewTurnIndex,
   hasStarted, isFinished, difficultyLabel, practiceModeLabel, onFinish,
 }: SessionHeaderProps) {
   return (
-    <header className="h-14 border-b border-white/10 flex items-center justify-between px-6 shrink-0 bg-[#0d1826]/80 backdrop-blur">
+    <header className={`h-14 border-b border-white/10 flex items-center justify-between px-6 shrink-0 bg-[#0d1826]/80 backdrop-blur ${className || ""}`}>
       <div className="flex items-center gap-3">
         <span className="w-2 h-2 rounded-full bg-red-400 animate-pulse" />
         <span className="text-sm font-bold text-slate-300">

--- a/src/shared/lib/storage.ts
+++ b/src/shared/lib/storage.ts
@@ -1,0 +1,96 @@
+export type StorageKey = string;
+export type StorageValue = string | number | boolean | object | null;
+
+export function getLocalStorageItem<T>(key: StorageKey, defaultValue: T): T {
+  try {
+    if (typeof window === 'undefined') return defaultValue;
+    
+    const item = window.localStorage.getItem(key);
+    if (item === null) return defaultValue;
+    
+    try {
+      return JSON.parse(item) as T;
+    } catch {
+      return item as unknown as T;
+    }
+  } catch (error) {
+    console.warn(`Failed to read localStorage key "${key}":`, error);
+    return defaultValue;
+  }
+}
+
+export function setLocalStorageItem(key: StorageKey, value: StorageValue): void {
+  try {
+    if (typeof window === 'undefined') return;
+    
+    const serialized = typeof value === 'string' 
+      ? value 
+      : JSON.stringify(value);
+    
+    window.localStorage.setItem(key, serialized);
+  } catch (error) {
+    console.warn(`Failed to write localStorage key "${key}":`, error);
+  }
+}
+
+export function removeLocalStorageItem(key: StorageKey): void {
+  try {
+    if (typeof window === 'undefined') return;
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    console.warn(`Failed to remove localStorage key "${key}":`, error);
+  }
+}
+
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(';').shift() || null;
+  return null;
+}
+
+export function setCookie(name: string, value: string, days?: number | null, path: string = '/'): void {
+  if (typeof document === 'undefined') return;
+  
+  let expires = '';
+  if (days !== null && days !== undefined) {
+    const date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    expires = `; expires=${date.toUTCString()}`;
+  }
+  
+  document.cookie = `${name}=${value || ''}${expires}; path=${path}`;
+}
+
+export function removeCookie(name: string, path: string = '/'): void {
+  if (typeof document === 'undefined') return;
+  
+  setCookie(name, '', -1, path);
+}
+
+export function shouldShowCoachMarks(key: string, expirationDays: number = 30): boolean {
+  const lastShown = getLocalStorageItem<number | null>(`coachMarks:${key}:lastShown`, null);
+  
+  if (lastShown === null) return true;
+  
+  const now = Date.now();
+  const expirationTime = lastShown + (expirationDays * 24 * 60 * 60 * 1000);
+  
+  return now > expirationTime;
+}
+
+export function markCoachMarksShown(key: string): void {
+  setLocalStorageItem(`coachMarks:${key}:lastShown`, Date.now());
+}
+
+export function clearAllCoachMarks(): void {
+  if (typeof window === 'undefined') return;
+  
+  Object.keys(window.localStorage).forEach(key => {
+    if (key.startsWith('coachMarks:')) {
+      removeLocalStorageItem(key);
+    }
+  });
+}

--- a/src/shared/ui/CoachMarks.tsx
+++ b/src/shared/ui/CoachMarks.tsx
@@ -33,19 +33,27 @@ export function CoachMarks(props: CoachMarksProps) {
     open,
     onClose,
     onComplete,
-    controlledStep,
+    currentStep: controlledStep,
     onStepChange,
     dismissOnBackdrop = true,
     dismissOnEsc = true,
   } = props;
 
   const [internalStep, setInternalStep] = useState(0);
-  const currentStep = controlledStep !== undefined ? controlledStep : internalStep;
-  const currentStepData = steps[currentStep];
+  const currentStepValue = controlledStep !== undefined ? controlledStep : internalStep;
+  const currentStepData = steps[currentStepValue];
   const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+  const [tooltipHeight, setTooltipHeight] = useState(200);
+  const tooltipRef = useRef<HTMLDivElement>(null);
   const coachMarksRef = useRef<HTMLDivElement>(null);
 
   const isControlled = controlledStep !== undefined;
+
+  useEffect(() => {
+    if (tooltipRef.current) {
+      setTooltipHeight(tooltipRef.current.offsetHeight);
+    }
+  }, [currentStepValue]);
 
   useEffect(() => {
     if (!open) return;
@@ -64,30 +72,47 @@ export function CoachMarks(props: CoachMarksProps) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setTargetRect(element.getBoundingClientRect());
     }
-  }, [open, currentStep, currentStepData?.targetSelector]);
+  }, [open, currentStepValue, currentStepData?.targetSelector]);
+
+  useEffect(() => {
+    if (!open) return;
+    
+    const handleResize = () => {
+      if (currentStepData?.targetSelector) {
+        const element = document.querySelector<HTMLElement>(currentStepData.targetSelector);
+        if (element) {
+           
+          setTargetRect(element.getBoundingClientRect());
+        }
+      }
+    };
+    
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [open, currentStepData?.targetSelector]);
 
   const handleNext = useCallback(() => {
-    if (currentStep < steps.length - 1) {
+    if (currentStepValue < steps.length - 1) {
       if (isControlled) {
-        onStepChange?.(currentStep + 1);
+        onStepChange?.(currentStepValue + 1);
       } else {
-        setInternalStep(currentStep + 1);
+        setInternalStep(currentStepValue + 1);
       }
     } else {
       onComplete?.();
       onClose();
     }
-  }, [currentStep, steps.length, isControlled, onStepChange, onComplete, onClose]);
+  }, [currentStepValue, steps.length, isControlled, onStepChange, onComplete, onClose]);
 
   const handlePrevious = useCallback(() => {
-    if (currentStep > 0) {
+    if (currentStepValue > 0) {
       if (isControlled) {
-        onStepChange?.(currentStep - 1);
+        onStepChange?.(currentStepValue - 1);
       } else {
-        setInternalStep(currentStep - 1);
+        setInternalStep(currentStepValue - 1);
       }
     }
-  }, [currentStep, isControlled, onStepChange]);
+  }, [currentStepValue, isControlled, onStepChange]);
 
   const handleSkip = useCallback(() => {
     onComplete?.();
@@ -150,8 +175,6 @@ export function CoachMarks(props: CoachMarksProps) {
     
     const windowWidth = window.innerWidth;
     const windowHeight = window.innerHeight;
-    const scrollX = window.scrollX || window.pageXOffset;
-    const scrollY = window.scrollY || window.pageYOffset;
     
     let proposedTop: number;
     let proposedLeft: number;
@@ -159,24 +182,24 @@ export function CoachMarks(props: CoachMarksProps) {
     
     switch (position) {
       case "top":
-        proposedTop = targetRect.top + scrollY - TOOLTIP_PADDING;
-        proposedLeft = getAlignPosition(targetRect.left + scrollX, targetRect.width, align);
+        proposedTop = targetRect.top - TOOLTIP_PADDING;
+        proposedLeft = getAlignPosition(targetRect.left, targetRect.width, align);
         break;
       case "bottom":
-        proposedTop = targetRect.bottom + scrollY + TOOLTIP_PADDING;
-        proposedLeft = getAlignPosition(targetRect.left + scrollX, targetRect.width, align);
+        proposedTop = targetRect.bottom + TOOLTIP_PADDING;
+        proposedLeft = getAlignPosition(targetRect.left, targetRect.width, align);
         break;
       case "left":
-        proposedTop = getAlignPosition(targetRect.top + scrollY, targetRect.height, align);
-        proposedLeft = targetRect.left + scrollX - TOOLTIP_WIDTH - TOOLTIP_PADDING;
+        proposedTop = getAlignPosition(targetRect.top, targetRect.height, align);
+        proposedLeft = targetRect.left - TOOLTIP_WIDTH - TOOLTIP_PADDING;
         break;
       case "right":
-        proposedTop = getAlignPosition(targetRect.top + scrollY, targetRect.height, align);
-        proposedLeft = targetRect.right + scrollX + TOOLTIP_PADDING;
+        proposedTop = getAlignPosition(targetRect.top, targetRect.height, align);
+        proposedLeft = targetRect.right + TOOLTIP_PADDING;
         break;
       default:
-        proposedTop = targetRect.bottom + scrollY + TOOLTIP_PADDING;
-        proposedLeft = getAlignPosition(targetRect.left + scrollX, targetRect.width, align);
+        proposedTop = targetRect.bottom + TOOLTIP_PADDING;
+        proposedLeft = getAlignPosition(targetRect.left, targetRect.width, align);
     }
     
     let finalTop = proposedTop;
@@ -190,16 +213,16 @@ export function CoachMarks(props: CoachMarksProps) {
     
     if (proposedTop < TOOLTIP_PADDING) {
       finalTop = TOOLTIP_PADDING;
-      if (targetRect.bottom + scrollY + TOOLTIP_PADDING < windowHeight - TOOLTIP_PADDING) {
-        finalTop = targetRect.bottom + scrollY + TOOLTIP_PADDING;
+      if (targetRect.bottom + TOOLTIP_PADDING < windowHeight - TOOLTIP_PADDING) {
+        finalTop = targetRect.bottom + TOOLTIP_PADDING;
         proposedPosition = "bottom";
       }
-    } else if (proposedTop + 200 > windowHeight - TOOLTIP_PADDING) {
-      if (targetRect.top + scrollY - TOOLTIP_PADDING > TOOLTIP_PADDING) {
-        finalTop = targetRect.top + scrollY - TOOLTIP_PADDING - 200;
+    } else if (proposedTop + tooltipHeight > windowHeight - TOOLTIP_PADDING) {
+      if (targetRect.top - TOOLTIP_PADDING > TOOLTIP_PADDING) {
+        finalTop = targetRect.top - TOOLTIP_PADDING - tooltipHeight;
         proposedPosition = "top";
       } else {
-        finalTop = windowHeight - 200 - TOOLTIP_PADDING;
+        finalTop = windowHeight - tooltipHeight - TOOLTIP_PADDING;
       }
     }
     
@@ -226,8 +249,8 @@ export function CoachMarks(props: CoachMarksProps) {
             <rect x="0" y="0" width="100%" height="100%" fill="white" />
             {spotlightRect && (
               <rect
-                x={spotlightRect.x + (window.scrollX || window.pageXOffset)}
-                y={spotlightRect.y + (window.scrollY || window.pageYOffset)}
+                x={spotlightRect.x}
+                y={spotlightRect.y}
                 width={spotlightRect.width}
                 height={spotlightRect.height}
                 rx={8}
@@ -247,6 +270,7 @@ export function CoachMarks(props: CoachMarksProps) {
       </svg>
 
       <div
+        ref={tooltipRef}
         className="absolute bg-white rounded-2xl shadow-2xl p-6 text-left z-10 transition-all duration-200"
         style={{
           top: tooltipStyle.top,
@@ -272,11 +296,11 @@ export function CoachMarks(props: CoachMarksProps) {
 
         <div className="flex justify-between items-center">
           <div className="text-xs text-gray-500">
-            {currentStep + 1} / {steps.length}
+            {currentStepValue + 1} / {steps.length}
           </div>
 
           <div className="flex gap-2">
-            {currentStep > 0 && (
+            {currentStepValue > 0 && (
               <Button
                 variant="outline"
                 size="sm"
@@ -286,7 +310,7 @@ export function CoachMarks(props: CoachMarksProps) {
               </Button>
             )}
 
-            {currentStep < steps.length - 1 ? (
+            {currentStepValue < steps.length - 1 ? (
               <Button
                 variant="primary"
                 size="sm"

--- a/src/shared/ui/CoachMarks.tsx
+++ b/src/shared/ui/CoachMarks.tsx
@@ -1,0 +1,329 @@
+import { useState, useEffect, useRef, useCallback, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { X, ArrowLeft, ArrowRight, SkipForward } from "lucide-react";
+import { Button } from "./Button";
+
+export interface CoachMarkStep {
+  id: string;
+  title: string;
+  description: ReactNode;
+  targetSelector: string;
+  position?: "top" | "bottom" | "left" | "right";
+  align?: "start" | "center" | "end";
+}
+
+export interface CoachMarksProps {
+  steps: CoachMarkStep[];
+  open: boolean;
+  onClose: () => void;
+  onComplete?: () => void;
+  currentStep?: number;
+  onStepChange?: (stepIndex: number) => void;
+  dismissOnBackdrop?: boolean;
+  dismissOnEsc?: boolean;
+}
+
+const TOOLTIP_WIDTH = 360;
+const TOOLTIP_PADDING = 16;
+const SPOTLIGHT_PADDING = 8;
+
+export function CoachMarks(props: CoachMarksProps) {
+  const {
+    steps,
+    open,
+    onClose,
+    onComplete,
+    controlledStep,
+    onStepChange,
+    dismissOnBackdrop = true,
+    dismissOnEsc = true,
+  } = props;
+
+  const [internalStep, setInternalStep] = useState(0);
+  const currentStep = controlledStep !== undefined ? controlledStep : internalStep;
+  const currentStepData = steps[currentStep];
+  const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+  const coachMarksRef = useRef<HTMLDivElement>(null);
+
+  const isControlled = controlledStep !== undefined;
+
+  useEffect(() => {
+    if (!open) return;
+    
+    if (!isControlled) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setInternalStep(0);
+    }
+  }, [open, isControlled]);
+
+  useEffect(() => {
+    if (!open || !currentStepData?.targetSelector) return;
+    
+    const element = document.querySelector<HTMLElement>(currentStepData.targetSelector);
+    if (element) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setTargetRect(element.getBoundingClientRect());
+    }
+  }, [open, currentStep, currentStepData?.targetSelector]);
+
+  const handleNext = useCallback(() => {
+    if (currentStep < steps.length - 1) {
+      if (isControlled) {
+        onStepChange?.(currentStep + 1);
+      } else {
+        setInternalStep(currentStep + 1);
+      }
+    } else {
+      onComplete?.();
+      onClose();
+    }
+  }, [currentStep, steps.length, isControlled, onStepChange, onComplete, onClose]);
+
+  const handlePrevious = useCallback(() => {
+    if (currentStep > 0) {
+      if (isControlled) {
+        onStepChange?.(currentStep - 1);
+      } else {
+        setInternalStep(currentStep - 1);
+      }
+    }
+  }, [currentStep, isControlled, onStepChange]);
+
+  const handleSkip = useCallback(() => {
+    onComplete?.();
+    onClose();
+  }, [onComplete, onClose]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Escape" && dismissOnEsc) {
+      e.stopPropagation();
+      onClose();
+    } else if (e.key === "ArrowRight") {
+      e.stopPropagation();
+      handleNext();
+    } else if (e.key === "ArrowLeft") {
+      e.stopPropagation();
+      handlePrevious();
+    }
+  }, [dismissOnEsc, onClose, handleNext, handlePrevious]);
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener("keydown", handleKeyDown);
+    }
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, handleKeyDown]);
+
+  if (!open || !currentStepData) return null;
+
+  const position = currentStepData.position || "bottom";
+  const align = currentStepData.align || "center";
+
+  const getAlignPosition = (targetPos: number, targetSize: number, align: string) => {
+    switch (align) {
+      case "start":
+        return targetPos;
+      case "center":
+        return targetPos + targetSize / 2 - TOOLTIP_WIDTH / 2;
+      case "end":
+        return targetPos + targetSize - TOOLTIP_WIDTH;
+      default:
+        return targetPos + targetSize / 2 - TOOLTIP_WIDTH / 2;
+    }
+  };
+
+  const getSpotlightRect = () => {
+    if (!targetRect) return null;
+    
+    return {
+      x: targetRect.left - SPOTLIGHT_PADDING,
+      y: targetRect.top - SPOTLIGHT_PADDING,
+      width: targetRect.width + SPOTLIGHT_PADDING * 2,
+      height: targetRect.height + SPOTLIGHT_PADDING * 2,
+    };
+  };
+
+  const getTooltipPosition = () => {
+    if (!targetRect) return { top: "50%", left: "50%" };
+    
+    const windowWidth = window.innerWidth;
+    const windowHeight = window.innerHeight;
+    const scrollX = window.scrollX || window.pageXOffset;
+    const scrollY = window.scrollY || window.pageYOffset;
+    
+    let proposedTop: number;
+    let proposedLeft: number;
+    let proposedPosition = position;
+    
+    switch (position) {
+      case "top":
+        proposedTop = targetRect.top + scrollY - TOOLTIP_PADDING;
+        proposedLeft = getAlignPosition(targetRect.left + scrollX, targetRect.width, align);
+        break;
+      case "bottom":
+        proposedTop = targetRect.bottom + scrollY + TOOLTIP_PADDING;
+        proposedLeft = getAlignPosition(targetRect.left + scrollX, targetRect.width, align);
+        break;
+      case "left":
+        proposedTop = getAlignPosition(targetRect.top + scrollY, targetRect.height, align);
+        proposedLeft = targetRect.left + scrollX - TOOLTIP_WIDTH - TOOLTIP_PADDING;
+        break;
+      case "right":
+        proposedTop = getAlignPosition(targetRect.top + scrollY, targetRect.height, align);
+        proposedLeft = targetRect.right + scrollX + TOOLTIP_PADDING;
+        break;
+      default:
+        proposedTop = targetRect.bottom + scrollY + TOOLTIP_PADDING;
+        proposedLeft = getAlignPosition(targetRect.left + scrollX, targetRect.width, align);
+    }
+    
+    let finalTop = proposedTop;
+    let finalLeft = proposedLeft;
+    
+    if (proposedLeft < TOOLTIP_PADDING) {
+      finalLeft = TOOLTIP_PADDING;
+    } else if (proposedLeft + TOOLTIP_WIDTH > windowWidth - TOOLTIP_PADDING) {
+      finalLeft = windowWidth - TOOLTIP_WIDTH - TOOLTIP_PADDING;
+    }
+    
+    if (proposedTop < TOOLTIP_PADDING) {
+      finalTop = TOOLTIP_PADDING;
+      if (targetRect.bottom + scrollY + TOOLTIP_PADDING < windowHeight - TOOLTIP_PADDING) {
+        finalTop = targetRect.bottom + scrollY + TOOLTIP_PADDING;
+        proposedPosition = "bottom";
+      }
+    } else if (proposedTop + 200 > windowHeight - TOOLTIP_PADDING) {
+      if (targetRect.top + scrollY - TOOLTIP_PADDING > TOOLTIP_PADDING) {
+        finalTop = targetRect.top + scrollY - TOOLTIP_PADDING - 200;
+        proposedPosition = "top";
+      } else {
+        finalTop = windowHeight - 200 - TOOLTIP_PADDING;
+      }
+    }
+    
+    return { top: `${finalTop}px`, left: `${finalLeft}px`, position: proposedPosition };
+  };
+
+  const spotlightRect = getSpotlightRect();
+  const tooltipStyle = getTooltipPosition();
+
+  return createPortal(
+    <div
+      ref={coachMarksRef}
+      className="fixed inset-0 z-[2000]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Coach Marks"
+    >
+      <svg
+        className="absolute inset-0 w-full h-full"
+        style={{ fillRule: "evenodd", clipRule: "evenodd" }}
+      >
+        <defs>
+          <mask id="coach-marks-mask">
+            <rect x="0" y="0" width="100%" height="100%" fill="white" />
+            {spotlightRect && (
+              <rect
+                x={spotlightRect.x + (window.scrollX || window.pageXOffset)}
+                y={spotlightRect.y + (window.scrollY || window.pageYOffset)}
+                width={spotlightRect.width}
+                height={spotlightRect.height}
+                rx={8}
+                fill="black"
+              />
+            )}
+          </mask>
+        </defs>
+        <rect
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          fill="rgba(0,0,0,0.7)"
+          mask="url(#coach-marks-mask)"
+        />
+      </svg>
+
+      <div
+        className="absolute bg-white rounded-2xl shadow-2xl p-6 text-left z-10 transition-all duration-200"
+        style={{
+          top: tooltipStyle.top,
+          left: tooltipStyle.left,
+          width: TOOLTIP_WIDTH,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-start mb-3">
+          <h3 className="text-lg font-bold text-gray-900">{currentStepData.title}</h3>
+          <button
+            onClick={onClose}
+            aria-label="Close coach marks"
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="text-sm text-gray-600 mb-6 leading-relaxed">
+          {currentStepData.description}
+        </div>
+
+        <div className="flex justify-between items-center">
+          <div className="text-xs text-gray-500">
+            {currentStep + 1} / {steps.length}
+          </div>
+
+          <div className="flex gap-2">
+            {currentStep > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handlePrevious}
+              >
+                <ArrowLeft size={16} />
+              </Button>
+            )}
+
+            {currentStep < steps.length - 1 ? (
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleNext}
+              >
+                <ArrowRight size={16} />
+              </Button>
+            ) : (
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleNext}
+              >
+                완료
+              </Button>
+            )}
+
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleSkip}
+              className="text-gray-500 hover:text-gray-700"
+            >
+              건너뛰기 <SkipForward size={14} />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {dismissOnBackdrop && (
+        <div
+          className="absolute inset-0"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+      )}
+    </div>,
+    document.body,
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -16,3 +16,5 @@ export type { ModalSize, ModalHeightMode } from "./Modal";
 export { ConfirmModal } from "./ConfirmModal";
 export { SearchInput } from "./SearchInput";
 export { TicketIcon } from "./TicketIcon";
+export { CoachMarks } from "./CoachMarks";
+export type { CoachMarkStep, CoachMarksProps } from "./CoachMarks";


### PR DESCRIPTION
## 변경 사항
- Interview Session 페이지에 Coach Marks( tours/tour) 기능 추가
- SVG mask를 사용하여 대상 컴포넌트는 명확하게 표시하고 나머지 영역은 흐림 처리
- 스텝별 내비게이션 지원 (이전/다음/건너뛰기)
- Window 경계 감지 및 flip 로직 포함
- localStorage/cookie 관리를 위한 storage 유틸리티 추가
- shouldShowCoachMarks()로 안내 표시 여부 확인 (최근 30일 내 안내 미실시 시 표시)
- 첫 번째 질문에서만 표시 (이어하기 기능 제외)

## 변경 유형
- [x] 새로운 기능 (New feature)

## 테스트 방법
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome

### 테스트 시나리오
1. Interview Session 페이지에 처음 접속 시 Coach Marks가 표시되는지 확인
2. 첫 번째 질문에서만 표시되고, 이어하기에서는 표시되지 않는 것 확인
3. Previous/Next/Skip 버튼이 정상 작동하는지 확인
4. Window 크기를 줄일 때 Tooltip가 경계를 벗어나지 않는지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] TypeScript 컴파일 통과
- [x] ESLint 통과