### PR TITLE
feat(jd): Add getStats API to fetch job description counts from backend

### DIFF
--- a/src/features/jd/model/listStore.ts
+++ b/src/features/jd/model/listStore.ts
@@ -9,11 +9,7 @@
  */
 
 import { create } from "zustand";
-import {
-  userJobDescriptionApi,
-  type JobDescriptionCollectionStatus,
-  type UserJobDescription,
-} from "@/features/user-job-description";
+import { userJobDescriptionApi, type JobDescriptionCollectionStatus, type UserJobDescription } from "@/features/user-job-description";
 import {
   getCompanyColor,
   getCompanyInitial,
@@ -103,15 +99,6 @@ function transform(item: UserJobDescription): JdListItem {
   };
 }
 
-function calcStats(items: JdListItem[]): JdListStats {
-  return {
-    total: items.filter((i) => i.status !== "analyzing").length,
-    planned: items.filter((i) => i.status === "planned").length,
-    applied: items.filter((i) => i.status === "applied").length,
-    saved: items.filter((i) => i.status === "saved").length,
-  };
-}
-
 function applyFilter(items: JdListItem[], query: string, filter: FilterKey): JdListItem[] {
   let result = items;
 
@@ -147,14 +134,17 @@ export const useJdListStore = create<JdListState>()((set, get) => ({
   fetchList: async () => {
     set({ isLoading: true, error: null });
     try {
-      const page1 = await userJobDescriptionApi.listPage(1);
+      const [page1, statsData] = await Promise.all([
+        userJobDescriptionApi.listPage(1),
+        userJobDescriptionApi.getStats(),
+      ]);
       const raw = page1.results;
       const items = raw.map(transform);
       const { searchQuery, activeFilter } = get();
       set({
         isLoading: false,
         items,
-        stats: calcStats(items),
+        stats: statsData,
         filtered: applyFilter(items, searchQuery, activeFilter),
         nextPage: page1.nextPage,
         hasNext: page1.nextPage != null,
@@ -183,7 +173,6 @@ export const useJdListStore = create<JdListState>()((set, get) => ({
         return {
           isLoadingMore: false,
           items: mergedItems,
-          stats: calcStats(mergedItems),
           filtered: applyFilter(mergedItems, state.searchQuery, state.activeFilter),
           nextPage: page.nextPage,
           hasNext: page.nextPage != null,

--- a/src/features/jd/model/listStore.ts
+++ b/src/features/jd/model/listStore.ts
@@ -9,7 +9,7 @@
  */
 
 import { create } from "zustand";
-import { userJobDescriptionApi, type JobDescriptionCollectionStatus, type UserJobDescription } from "@/features/user-job-description";
+import { userJobDescriptionApi, type JobDescriptionCollectionStatus, type UserJobDescription, type UserJobDescriptionStats } from "@/features/user-job-description";
 import {
   getCompanyColor,
   getCompanyInitial,
@@ -43,14 +43,9 @@ export interface JdListItem {
   raw: UserJobDescription;
 }
 
-export interface JdListStats {
-  total: number;
-  planned: number;
-  applied: number;
-  saved: number;
-}
-
 export type FilterKey = "all" | "planned" | "applied" | "saved";
+
+export type JdListStats = UserJobDescriptionStats;
 
 interface JdListState {
   items: JdListItem[];

--- a/src/features/user-job-description/api/types.ts
+++ b/src/features/user-job-description/api/types.ts
@@ -47,3 +47,11 @@ export interface CreatedUserJobDescription {
   collectionStatus: JobDescriptionCollectionStatus;
   createdAt: string;
 }
+
+/** 채용공고 상태별 카운트. */
+export interface UserJobDescriptionStats {
+  total: number;
+  planned: number;
+  saved: number;
+  applied: number;
+}

--- a/src/features/user-job-description/api/userJobDescriptionApi.ts
+++ b/src/features/user-job-description/api/userJobDescriptionApi.ts
@@ -62,4 +62,7 @@ export const userJobDescriptionApi = {
 
   remove: (uuid: string) =>
     apiRequest<void>(`${BASE}/${uuid}/`, { method: "DELETE", auth: true }),
+
+  getStats: () =>
+    apiRequest<{ total: number; planned: number; saved: number; applied: number }>(`${BASE}/stats/count/`, { auth: true }),
 };

--- a/src/features/user-job-description/api/userJobDescriptionApi.ts
+++ b/src/features/user-job-description/api/userJobDescriptionApi.ts
@@ -10,7 +10,7 @@
 
 import { apiRequest } from "@/shared/api/client";
 import type { PaginatedResponse } from "@/shared/api";
-import type { CreatedUserJobDescription, UserJobDescription } from "./types";
+import type { CreatedUserJobDescription, UserJobDescription, UserJobDescriptionStats } from "./types";
 
 const BASE = "/api/v1/user-job-descriptions";
 
@@ -64,5 +64,5 @@ export const userJobDescriptionApi = {
     apiRequest<void>(`${BASE}/${uuid}/`, { method: "DELETE", auth: true }),
 
   getStats: () =>
-    apiRequest<{ total: number; planned: number; saved: number; applied: number }>(`${BASE}/stats/count/`, { auth: true }),
+    apiRequest<UserJobDescriptionStats>(`${BASE}/stats/count/`, { auth: true }),
 };

--- a/src/features/user-job-description/index.ts
+++ b/src/features/user-job-description/index.ts
@@ -5,6 +5,7 @@ export type {
   JobDescription,
   JobDescriptionCollectionStatus,
   UserJobDescription,
+  UserJobDescriptionStats,
 } from "./api/types";
 export { useUserJobDescriptionScrapingSse } from "./hooks/useUserJobDescriptionScrapingSse";
 export type { UserJobDescriptionCollectionStatusEvent } from "./hooks/useUserJobDescriptionScrapingSse";


### PR DESCRIPTION
## 관련 이슈
Closes #121

## 변경 사항
- userJobDescriptionApi에 `getStats()` 메서드 추가 - `/stats/count/` API 호출
- listStore에서 클라이언트 사이드 통계 계산 대신 서버 API에서 통계 데이터 패치
-Promise.all()로 목록과 통계 API 병렬 호출로 성능 최적화

## 변경 유형
- [x] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)

## 테스트 방법
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome

테스트 시나리오:
1. `/jd` 페이지 접속
2. 상단 통계 패널에 정확한 카운트 표시 확인
3. 필터 칩에 정확한 숫자 표시 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 빌드가 정상적으로 완료됩니다