### PR TITLE
[114] interview 설정 과정 및 채용공고, 이력서 UI 부분 수정

### DIFF
--- a/src/features/interview-setup/api/setupApi.ts
+++ b/src/features/interview-setup/api/setupApi.ts
@@ -5,12 +5,12 @@
  */
 
 import { userJobDescriptionApi } from "@/features/user-job-description";
+import { inferCategoryId } from "@/shared/ui/inferCategoryId";
 
 export interface SetupJdItem {
   /** UserJobDescription.uuid — 인터뷰 세션 생성 시 이 값을 그대로 사용. */
   uuid: string;
-  /** lucide-react 아이콘 선택을 위한 platform 문자열 */
-  platform: string;
+  categoryId: number;
   company: string;
   role: string;
   stage: string;
@@ -26,11 +26,12 @@ export async function fetchSetupJdListApi(): Promise<SetupJdItem[]> {
     const jd = item.jobDescription;
     const isReady = jd.collectionStatus === "done";
     const isFailed = jd.collectionStatus === "error";
+    const role = jd.title || "채용공고";
     return {
       uuid: item.uuid,
-      platform: jd.platform || "",
+      categoryId: inferCategoryId(jd.platform || "", role),
       company: jd.company || "수집 중",
-      role: jd.title || "채용공고",
+      role,
       stage: jd.location || jd.workType || jd.platform || "",
       badgeLabel: isReady ? "수집 완료" : isFailed ? "수집 실패" : "수집 중",
       badgeType: isReady ? "green" : "accent",
@@ -47,11 +48,12 @@ export async function fetchSetupJdByUuidApi(uuid: string): Promise<SetupJdItem |
     const isReady = jd.collectionStatus === "done";
     const isFailed = jd.collectionStatus === "error";
 
+    const role = jd.title || "채용공고";
     return {
       uuid: item.uuid,
-      platform: jd.platform || "",
+      categoryId: inferCategoryId(jd.platform || "", role),
       company: jd.company || "수집 중",
-      role: jd.title || "채용공고",
+      role,
       stage: jd.location || jd.workType || jd.platform || "",
       badgeLabel: isReady ? "수집 완료" : isFailed ? "수집 실패" : "수집 중",
       badgeType: isReady ? "green" : "accent",

--- a/src/features/interview-setup/api/setupApi.ts
+++ b/src/features/interview-setup/api/setupApi.ts
@@ -20,45 +20,37 @@ export interface SetupJdItem {
   disabled: boolean;
 }
 
+function toBadgeLabel(isReady: boolean, isFailed: boolean): string {
+  if (isReady) return "수집 완료";
+  if (isFailed) return "수집 실패";
+  return "수집 중";
+}
+
+function toSetupJdItem(uuid: string, jd: { platform?: string; title?: string; company?: string; location?: string; workType?: string; collectionStatus?: string }): SetupJdItem {
+  const isReady = jd.collectionStatus === "done";
+  const isFailed = jd.collectionStatus === "error";
+  const role = jd.title || "채용공고";
+  return {
+    uuid,
+    categoryId: inferCategoryId(jd.platform || "", role),
+    company: jd.company || "수집 중",
+    role,
+    stage: jd.location || jd.workType || jd.platform || "",
+    badgeLabel: toBadgeLabel(isReady, isFailed),
+    badgeType: isReady ? "green" : "accent",
+    disabled: !isReady,
+  };
+}
+
 export async function fetchSetupJdListApi(): Promise<SetupJdItem[]> {
   const raw = await userJobDescriptionApi.list();
-  return raw.map((item) => {
-    const jd = item.jobDescription;
-    const isReady = jd.collectionStatus === "done";
-    const isFailed = jd.collectionStatus === "error";
-    const role = jd.title || "채용공고";
-    return {
-      uuid: item.uuid,
-      categoryId: inferCategoryId(jd.platform || "", role),
-      company: jd.company || "수집 중",
-      role,
-      stage: jd.location || jd.workType || jd.platform || "",
-      badgeLabel: isReady ? "수집 완료" : isFailed ? "수집 실패" : "수집 중",
-      badgeType: isReady ? "green" : "accent",
-      // 수집이 완료된 공고만 면접 선택 가능.
-      disabled: !isReady,
-    };
-  });
+  return raw.map((item) => toSetupJdItem(item.uuid, item.jobDescription));
 }
 
 export async function fetchSetupJdByUuidApi(uuid: string): Promise<SetupJdItem | null> {
   try {
     const item = await userJobDescriptionApi.retrieve(uuid);
-    const jd = item.jobDescription;
-    const isReady = jd.collectionStatus === "done";
-    const isFailed = jd.collectionStatus === "error";
-
-    const role = jd.title || "채용공고";
-    return {
-      uuid: item.uuid,
-      categoryId: inferCategoryId(jd.platform || "", role),
-      company: jd.company || "수집 중",
-      role,
-      stage: jd.location || jd.workType || jd.platform || "",
-      badgeLabel: isReady ? "수집 완료" : isFailed ? "수집 실패" : "수집 중",
-      badgeType: isReady ? "green" : "accent",
-      disabled: !isReady,
-    };
+    return toSetupJdItem(item.uuid, item.jobDescription);
   } catch {
     return null;
   }

--- a/src/features/interview-setup/api/setupApi.ts
+++ b/src/features/interview-setup/api/setupApi.ts
@@ -9,7 +9,8 @@ import { userJobDescriptionApi } from "@/features/user-job-description";
 export interface SetupJdItem {
   /** UserJobDescription.uuid — 인터뷰 세션 생성 시 이 값을 그대로 사용. */
   uuid: string;
-  icon: string;
+  /** lucide-react 아이콘 선택을 위한 platform 문자열 */
+  platform: string;
   company: string;
   role: string;
   stage: string;
@@ -17,16 +18,6 @@ export interface SetupJdItem {
   badgeType: "green" | "accent";
   /** 수집이 완료되지 않은 항목은 선택 불가. */
   disabled: boolean;
-}
-
-function pickIcon(platform: string, title: string): string {
-  const source = `${platform} ${title}`.toLowerCase();
-  if (source.includes("bank")) return "🏦";
-  if (source.includes("pay") || source.includes("toss")) return "💳";
-  if (source.includes("naver")) return "🟢";
-  if (source.includes("kakao")) return "🟡";
-  if (source.includes("design") || source.includes("디자인")) return "🎨";
-  return "🏢";
 }
 
 export async function fetchSetupJdListApi(): Promise<SetupJdItem[]> {
@@ -37,7 +28,7 @@ export async function fetchSetupJdListApi(): Promise<SetupJdItem[]> {
     const isFailed = jd.collectionStatus === "error";
     return {
       uuid: item.uuid,
-      icon: pickIcon(jd.platform || "", jd.title || ""),
+      platform: jd.platform || "",
       company: jd.company || "수집 중",
       role: jd.title || "채용공고",
       stage: jd.location || jd.workType || jd.platform || "",
@@ -58,7 +49,7 @@ export async function fetchSetupJdByUuidApi(uuid: string): Promise<SetupJdItem |
 
     return {
       uuid: item.uuid,
-      icon: pickIcon(jd.platform || "", jd.title || ""),
+      platform: jd.platform || "",
       company: jd.company || "수집 중",
       role: jd.title || "채용공고",
       stage: jd.location || jd.workType || jd.platform || "",

--- a/src/features/jd/model/detailStore.ts
+++ b/src/features/jd/model/detailStore.ts
@@ -12,11 +12,8 @@ import {
   type UserJobDescription,
   type JobDescriptionCollectionStatus,
 } from "@/features/user-job-description";
-import {
-  getCompanyColor,
-  getCompanyInitial,
-  getRelativeTime,
-} from "../api/jdListHelpers";
+import { getRelativeTime } from "../api/jdListHelpers";
+import { inferCategoryId } from "@/shared/ui/inferCategoryId";
 import type { JdStatus } from "./listStore";
 
 export interface JdRequirement {
@@ -27,8 +24,7 @@ export interface JdRequirement {
 export interface JdDetail {
   id: string; // UserJobDescription.uuid
   company: string;
-  companyInitial: string;
-  companyColor: string;
+  categoryId: number;
   title: string;
   source: string;
   location: string;
@@ -72,8 +68,7 @@ function toDetail(item: UserJobDescription): JdDetail {
   return {
     id: item.uuid,
     company,
-    companyInitial: getCompanyInitial(company),
-    companyColor: getCompanyColor(company),
+    categoryId: inferCategoryId(jd.platform || "", title),
     title,
     source: jd.platform || "",
     location: jd.location || "",

--- a/src/features/jd/model/listStore.ts
+++ b/src/features/jd/model/listStore.ts
@@ -16,6 +16,7 @@ import {
   getRelativeTime,
   getTagColor,
 } from "../api/jdListHelpers";
+import { inferCategoryId } from "@/shared/ui/inferCategoryId";
 
 /** 사용자 상태 (프론트 placeholder — 추후 backend 에 저장). */
 export type JdStatus = "planned" | "applied" | "saved";
@@ -34,6 +35,7 @@ export interface JdListItem {
   companyInitial: string;
   companyColor: string;
   title: string;
+  categoryId: number;
   status: JdListStatus;
   tags: JdTag[];
   registeredAt: string;
@@ -85,6 +87,7 @@ function transform(item: UserJobDescription): JdListItem {
     companyInitial: getCompanyInitial(company),
     companyColor: getCompanyColor(company),
     title,
+    categoryId: inferCategoryId(jd.platform || "", title),
     status,
     tags,
     registeredAt: getRelativeTime(item.createdAt),

--- a/src/pages/interview-setup/ui/DifficultySection.tsx
+++ b/src/pages/interview-setup/ui/DifficultySection.tsx
@@ -1,3 +1,5 @@
+import type React from "react";
+import { Flame, Smile, UserCheck } from "lucide-react";
 import { SetupSection } from "@/shared/ui/SetupSection";
 import { OptionCard } from "@/shared/ui/OptionCard";
 import type { InterviewDifficultyLevel } from "@/features/interview-session";
@@ -7,11 +9,26 @@ interface DifficultySectionProps {
   onDifficultyChange: (level: InterviewDifficultyLevel) => void;
 }
 
-const DIFFICULTIES = [
-  { value: "friendly", label: "친근한 면접관", icon: "😊", desc: "부드럽고 격려적인 질문. 긴장감이 낮아 처음 연습할 때 적합해요." },
-  { value: "normal", label: "일반 면접관", icon: "🤵", desc: "표준적인 면접 형식. 실제 면접과 가장 유사한 환경을 제공해요." },
-  { value: "pressure", label: "압박 면접관", icon: "🔍", desc: "날카롭고 도전적인 질문. 실전 대비 역량을 최대한 이끌어내요." },
-] as const;
+const DIFFICULTIES: { value: InterviewDifficultyLevel; label: string; icon: React.ReactNode; desc: string }[] = [
+  {
+    value: "friendly",
+    label: "친근한 면접관",
+    icon: <div className="w-8 h-8 rounded-lg bg-[#ECFDF5] flex items-center justify-center"><Smile size={16} className="text-[#059669]" /></div>,
+    desc: "부드럽고 격려적인 질문. 긴장감이 낮아 처음 연습할 때 적합해요.",
+  },
+  {
+    value: "normal",
+    label: "일반 면접관",
+    icon: <div className="w-8 h-8 rounded-lg bg-[#E6F7FA] flex items-center justify-center"><UserCheck size={16} className="text-[#0991B2]" /></div>,
+    desc: "표준적인 면접 형식. 실제 면접과 가장 유사한 환경을 제공해요.",
+  },
+  {
+    value: "pressure",
+    label: "압박 면접관",
+    icon: <div className="w-8 h-8 rounded-lg bg-[#FEF2F2] flex items-center justify-center"><Flame size={16} className="text-[#DC2626]" /></div>,
+    desc: "날카롭고 도전적인 질문. 실전 대비 역량을 최대한 이끌어내요.",
+  },
+];
 
 export function DifficultySection({ interviewDifficultyLevel, onDifficultyChange }: DifficultySectionProps) {
   return (

--- a/src/pages/interview-setup/ui/InterviewModeSection.tsx
+++ b/src/pages/interview-setup/ui/InterviewModeSection.tsx
@@ -1,3 +1,4 @@
+import { BookOpen, Lock, Zap } from "lucide-react";
 import { SetupSection } from "@/shared/ui/SetupSection";
 import { OptionCard } from "@/shared/ui/OptionCard";
 import { InfoTooltip } from "@/shared/ui/InfoTooltip";
@@ -44,7 +45,7 @@ export function InterviewModeSection({
               </span>
             }
           >
-            <div className="text-[10px] text-[#6B7280] mt-1">🔒 Pro 플랜 필요</div>
+            <div className="flex items-center gap-1 text-[10px] text-[#6B7280] mt-1"><Lock size={10} className="text-[#9CA3AF]" /> Pro 플랜 필요</div>
           </OptionCard>
         </div>
       </SetupSection>
@@ -54,7 +55,7 @@ export function InterviewModeSection({
           <OptionCard
             selected={practiceMode === "practice"}
             onClick={() => onPracticeModeChange("practice")}
-            icon="🎮"
+            icon={<div className="w-8 h-8 rounded-lg bg-[#ECFDF5] flex items-center justify-center"><BookOpen size={16} className="text-[#059669]" /></div>}
             title="연습 모드"
             description="준비 후 직접 시작"
             badge={<InfoTooltip text="질문 음성이 끝난 후 '말하기 시작' 버튼을 직접 눌러 답변합니다. 자신의 페이스에 맞춰 충분히 생각한 후 답변할 수 있어요." />}
@@ -62,7 +63,7 @@ export function InterviewModeSection({
           <OptionCard
             selected={practiceMode === "real"}
             onClick={() => onPracticeModeChange("real")}
-            icon="⚡"
+            icon={<div className="w-8 h-8 rounded-lg bg-[#FFFBEB] flex items-center justify-center"><Zap size={16} className="text-[#D97706]" /></div>}
             title="실전 모드"
             description="랜덤 대기 후 자동 시작"
             badge={<InfoTooltip text="질문 음성이 끝나면 5~30초 랜덤 대기 후 자동으로 STT가 시작됩니다. 실제 면접의 긴장감을 최대한 재현합니다." />}

--- a/src/pages/interview-setup/ui/JdSavedTab.tsx
+++ b/src/pages/interview-setup/ui/JdSavedTab.tsx
@@ -1,11 +1,12 @@
 import { SelectableCard } from "@/shared/ui/SelectableCard";
+import { CompanyIcon } from "@/shared/ui/CompanyIcon";
 
 interface JdItem {
   uuid: string;
   company: string;
   role: string;
   stage: string;
-  icon: string;
+  platform: string;
   badgeLabel: string;
   badgeType: string;
   disabled: boolean;
@@ -30,7 +31,9 @@ export function JdSavedTab({ jdList, jdListLoading, selectedJdId, onSelectJd }: 
           disabled={jd.disabled}
           onClick={() => { if (!jd.disabled) onSelectJd(jd.uuid); }}
         >
-          <div className="w-8 h-8 rounded-lg bg-white border border-[#E5E7EB] flex items-center justify-center text-sm shrink-0">{jd.icon}</div>
+          <div className="w-8 h-8 rounded-lg shrink-0 overflow-hidden">
+              <CompanyIcon platform={jd.platform} title={jd.role} size={16} />
+            </div>
           <div className="flex-1 min-w-0">
             <div className="text-[12px] font-bold">{jd.company}</div>
             <div className="text-[11px] text-[#6B7280] mt-px">{jd.role} · {jd.stage}</div>

--- a/src/pages/interview-setup/ui/JdSavedTab.tsx
+++ b/src/pages/interview-setup/ui/JdSavedTab.tsx
@@ -6,7 +6,7 @@ interface JdItem {
   company: string;
   role: string;
   stage: string;
-  platform: string;
+  categoryId: number;
   badgeLabel: string;
   badgeType: string;
   disabled: boolean;
@@ -32,7 +32,7 @@ export function JdSavedTab({ jdList, jdListLoading, selectedJdId, onSelectJd }: 
           onClick={() => { if (!jd.disabled) onSelectJd(jd.uuid); }}
         >
           <div className="w-8 h-8 rounded-lg shrink-0 overflow-hidden">
-              <CompanyIcon platform={jd.platform} title={jd.role} size={16} />
+              <CompanyIcon categoryId={jd.categoryId} size={16} />
             </div>
           <div className="flex-1 min-w-0">
             <div className="text-[12px] font-bold">{jd.company}</div>

--- a/src/pages/interview-setup/ui/JdSection.tsx
+++ b/src/pages/interview-setup/ui/JdSection.tsx
@@ -6,7 +6,7 @@ interface JdItem {
   company: string;
   role: string;
   stage: string;
-  icon: string;
+  platform: string;
   badgeLabel: string;
   badgeType: string;
   disabled: boolean;

--- a/src/pages/interview-setup/ui/JdSection.tsx
+++ b/src/pages/interview-setup/ui/JdSection.tsx
@@ -6,7 +6,7 @@ interface JdItem {
   company: string;
   role: string;
   stage: string;
-  platform: string;
+  categoryId: number;
   badgeLabel: string;
   badgeType: string;
   disabled: boolean;

--- a/src/pages/interview-setup/ui/ResumeSection.tsx
+++ b/src/pages/interview-setup/ui/ResumeSection.tsx
@@ -1,5 +1,6 @@
 import { SetupSection } from "@/shared/ui/SetupSection";
 import { SelectableCard } from "@/shared/ui/SelectableCard";
+import { FileText, PencilLine } from "lucide-react";
 
 interface Resume {
   uuid: string;
@@ -44,8 +45,11 @@ export function ResumeSection({
             const eligible = isEligible(r);
             return (
               <SelectableCard key={r.uuid} selected={selectedResumeUuid === r.uuid} disabled={!eligible} onClick={() => onSelectResume(r.uuid)}>
-                <div className="w-8 h-8 rounded-lg bg-white border border-[#E5E7EB] flex items-center justify-center text-sm shrink-0">
-                  {r.type === "file" ? "📄" : "📝"}
+                <div className="w-8 h-8 rounded-lg bg-[#F3F4F6] border border-[#E5E7EB] flex items-center justify-center shrink-0">
+                  {r.type === "file"
+                    ? <FileText size={16} className="text-[#6B7280]" />
+                    : <PencilLine size={16} className="text-[#6B7280]" />
+                  }
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="text-[12px] font-bold truncate">{r.title}</div>

--- a/src/pages/jd-add/ui/JdAddPage.tsx
+++ b/src/pages/jd-add/ui/JdAddPage.tsx
@@ -1,4 +1,9 @@
+import type React from "react";
 import { Link, useNavigate } from "react-router-dom";
+import {
+  Building2, Calendar, CheckCircle2, ClipboardList,
+  Globe, Lightbulb, Link2, Loader2, MapPin, Star,
+} from "lucide-react";
 import { useJdAddStore, type JdStatus } from "@/features/jd";
 import {
   Card,
@@ -11,10 +16,10 @@ import {
   Badge,
 } from "@/shared/ui";
 
-const STATUS_OPTIONS: { value: JdStatus; icon: string; label: string; desc: string }[] = [
-  { value: "planned", icon: "📅", label: "지원 예정", desc: "곧 지원할 예정" },
-  { value: "saved", icon: "⭐", label: "관심 저장", desc: "관심만 저장" },
-  { value: "applied", icon: "✅", label: "지원 완료", desc: "이미 지원함" },
+const STATUS_OPTIONS: { value: JdStatus; icon: React.ReactNode; label: string; desc: string }[] = [
+  { value: "planned", icon: <Calendar size={22} className="text-[#0991B2]" />, label: "지원 예정", desc: "곧 지원할 예정" },
+  { value: "saved",   icon: <Star size={22} className="text-[#F59E0B]" />,    label: "관심 저장", desc: "관심만 저장" },
+  { value: "applied", icon: <CheckCircle2 size={22} className="text-[#059669]" />, label: "지원 완료", desc: "이미 지원함" },
 ];
 
 const PLATFORMS = [
@@ -68,7 +73,7 @@ export function JdAddPage() {
         {/* PAGE HEADER */}
         <div className="flex items-start justify-between mb-8 gap-4">
           <div>
-            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">+ 채용공고 추가</div>
+            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-lg mb-2.5"><ClipboardList size={12} /> 채용공고 추가</div>
             <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">새 채용공고 등록</h1>
             <p className="text-sm text-[#6B7280] mt-1.5">URL만 붙여넣으면 AI가 나머지를 분석해 드려요</p>
           </div>
@@ -97,10 +102,9 @@ export function JdAddPage() {
               {/* URL 섹션 */}
               <section className="mb-8">
                 <SectionHeader
-                  icon="🔗"
+                  icon={<div className="w-8 h-8 rounded-lg bg-[#E6F7FA] flex items-center justify-center"><Link2 size={16} className="text-[#0991B2]" /></div>}
                   title="채용공고 URL"
-                  description="⚠️정확한 채용공고 페이지 URL을 입력해주세요."
-                  gradient="linear-gradient(135deg,#60A5FA,#2563EB)"
+                  description="정확한 채용공고 페이지 URL을 입력해주세요."
                 />
 
                 <div className="mb-5">
@@ -108,7 +112,7 @@ export function JdAddPage() {
                     label="URL"
                     required
                     helperText="사람인, 잡코리아, 원티드, 링크드인 등"
-                    icon="🔗"
+                    icon={<Link2 size={14} />}
                     type="url"
                     placeholder="https://www.saramin.co.kr/zf_user/jobs/relay/view?..."
                     value={url}
@@ -118,16 +122,16 @@ export function JdAddPage() {
 
                   {urlValidState !== "idle" && (
                     <div className={`flex items-center gap-1.5 text-[12px] font-semibold mt-1.5 ${fieldStatusCls()}`}>
-                      {urlValidState === "checking" && "⟳ URL 확인 중..."}
-                      {urlValidState === "ok" && "✓ 유효한 URL입니다"}
+                      {urlValidState === "checking" && <><Loader2 size={12} className="animate-spin" /> URL 확인 중...</>}
+                      {urlValidState === "ok" && <><CheckCircle2 size={12} /> 유효한 URL입니다</>}
                       {urlValidState === "error" && "✗ 올바른 URL을 입력해 주세요"}
                     </div>
                   )}
 
                   {urlValidState === "ok" && urlAnalysis && (
                     <div className="mt-3 py-[14px] px-4 bg-[#ECFDF5] rounded-lg border border-[#A7F3D0] flex items-center gap-3">
-                      <div className="w-9 h-9 rounded-lg bg-[#D1FAE5] flex items-center justify-center text-base shrink-0">
-                        🏢
+                      <div className="w-9 h-9 rounded-lg bg-[#D1FAE5] flex items-center justify-center shrink-0">
+                        <Building2 size={18} className="text-[#059669]" />
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="text-[12px] font-semibold text-[#6B7280]">
@@ -157,10 +161,9 @@ export function JdAddPage() {
               {/* 지원 상태 */}
               <section className="mb-8">
                 <SectionHeader
-                  icon="📌"
+                  icon={<div className="w-8 h-8 rounded-lg bg-[#E6F7FA] flex items-center justify-center"><MapPin size={16} className="text-[#0991B2]" /></div>}
                   title="지원 상태"
                   description="현재 지원 진행 상태를 선택해 주세요"
-                  gradient="linear-gradient(135deg,#67E8F9,#0891B2)"
                 />
                 <StatusCard options={STATUS_OPTIONS} selected={status} onSelect={setStatus} />
               </section>
@@ -198,7 +201,7 @@ export function JdAddPage() {
           <div className="max-[900px]:grid max-[900px]:grid-cols-2 max-[900px]:gap-3.5 max-sm:grid-cols-1">
             <Card className="mb-[18px] max-[900px]:mb-0">
               <div className="text-sm font-black text-[#0A0A0A] mb-4 flex items-center gap-2">
-                <span style={{ fontSize: 18 }}>💡</span>
+                <Lightbulb size={16} className="text-[#F59E0B]" />
                 이렇게 활용해요
               </div>
               {[
@@ -221,7 +224,7 @@ export function JdAddPage() {
 
             <Card>
               <div className="text-sm font-black text-[#0A0A0A] mb-4 flex items-center gap-2">
-                <span style={{ fontSize: 18 }}>🌐</span>
+                <Globe size={16} className="text-[#0991B2]" />
                 지원 플랫폼
               </div>
               {PLATFORMS.map((p) => (

--- a/src/pages/jd-detail/ui/JdDetailPage.tsx
+++ b/src/pages/jd-detail/ui/JdDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { Loader2 } from "lucide-react";
 import { useJdDetailStore, type JdStatus } from "@/features/jd";
+import { CompanyIcon } from "@/shared/ui/CompanyIcon";
 import {
   useUserJobDescriptionScrapingSse,
   type JobDescriptionCollectionStatus,
@@ -138,11 +139,8 @@ export function JdDetailPage() {
             <div className={`${cardCls} p-[36px_32px] relative overflow-hidden max-sm:p-[24px_16px]`}>
               <div className="absolute inset-0 bg-gradient-to-br from-[rgba(9,145,178,0.05)] to-[rgba(6,182,212,0.03)] pointer-events-none" />
               <div className="flex items-center gap-3.5 mb-[18px] relative">
-                <div
-                  className="w-[54px] h-[54px] rounded-lg flex items-center justify-center text-[22px] font-black text-white shrink-0 shadow-[0_4px_12px_rgba(0,0,0,0.12)]"
-                  style={{ background: jd.companyColor }}
-                >
-                  {jd.companyInitial}
+                <div className="w-[54px] h-[54px] rounded-lg shrink-0 shadow-[0_4px_12px_rgba(0,0,0,0.12)] overflow-hidden">
+                  <CompanyIcon categoryId={jd.categoryId} size={24} />
                 </div>
                 <div>
                   <div className="text-[13px] text-[#6B7280] font-semibold mb-0.5">{jd.company} · {jd.source}</div>

--- a/src/pages/jd-detail/ui/JdDetailPage.tsx
+++ b/src/pages/jd-detail/ui/JdDetailPage.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   AlignLeft, Briefcase, Building2, Calendar, Check, CheckCircle2,
   CheckSquare, ClipboardList, Clock, ExternalLink, Info, Loader2,
-  MapPin, Mic, Pin, Star, Trash2, Zap,
+  MapPin, Pin, Star, Trash2, Zap,
 } from "lucide-react";
 import { useJdDetailStore, type JdStatus } from "@/features/jd";
 import { CompanyIcon } from "@/shared/ui/CompanyIcon";
@@ -164,7 +164,7 @@ export function JdDetailPage() {
               </div>
 
               <div className="flex gap-2.5 mt-5 relative flex-wrap">
-                <Link to="/interview" className="inline-flex items-center gap-2 text-[13px] font-bold text-white bg-[#0A0A0A] border-none cursor-pointer py-3 px-5 rounded-lg shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-opacity hover:opacity-85 no-underline whitespace-nowrap">
+                <Link to="/interview/setup" className="inline-flex items-center gap-2 text-[13px] font-bold text-white bg-[#0A0A0A] border-none cursor-pointer py-3 px-5 rounded-lg shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-opacity hover:opacity-85 no-underline whitespace-nowrap">
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
                     <path d="M2 7h10M8 3l4 4-4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
                   </svg>
@@ -298,17 +298,7 @@ export function JdDetailPage() {
                 <span className="w-7 h-7 rounded-lg bg-[#FFFBEB] flex items-center justify-center shrink-0"><Zap size={14} className="text-[#F59E0B]" /></span> 빠른 액션
               </div>
               <div className="flex flex-col gap-2">
-                <Link to="/interview" className="flex items-center gap-2.5 p-[12px_14px] rounded-lg border border-[#E5E7EB] bg-white cursor-pointer text-[13px] font-semibold text-[#0A0A0A] transition-all no-underline hover:bg-[#F9FAFB] hover:-translate-y-px hover:shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)]">
-                  <div className="w-8 h-8 rounded-lg bg-[#E6F7FA] flex items-center justify-center shrink-0">
-                    <Mic size={16} className="text-[#0991B2]" />
-                  </div>
-                  <div className="flex-1">
-                    <div className="text-[13px] font-extrabold">꼬리질문 면접</div>
-                    <div className="text-[11px] font-normal text-[#6B7280] mt-px">심화 질문 집중 연습</div>
-                  </div>
-                  <span className="text-[#9CA3AF] text-base">›</span>
-                </Link>
-                <Link to="/interview" className="flex items-center gap-2.5 p-[12px_14px] rounded-lg border border-[#E5E7EB] bg-white cursor-pointer text-[13px] font-semibold text-[#0A0A0A] transition-all no-underline hover:bg-[#F9FAFB] hover:-translate-y-px hover:shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)]">
+<Link to="/interview/setup" className="flex items-center gap-2.5 p-[12px_14px] rounded-lg border border-[#E5E7EB] bg-white cursor-pointer text-[13px] font-semibold text-[#0A0A0A] transition-all no-underline hover:bg-[#F9FAFB] hover:-translate-y-px hover:shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)]">
                   <div className="w-8 h-8 rounded-lg bg-[#ECFDF5] flex items-center justify-center shrink-0">
                     <ClipboardList size={16} className="text-[#059669]" />
                   </div>

--- a/src/pages/jd-detail/ui/JdDetailPage.tsx
+++ b/src/pages/jd-detail/ui/JdDetailPage.tsx
@@ -1,6 +1,11 @@
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { Loader2 } from "lucide-react";
+import {
+  AlignLeft, Briefcase, Building2, Calendar, Check, CheckCircle2,
+  CheckSquare, ClipboardList, Clock, ExternalLink, Info, Loader2,
+  MapPin, Mic, Pin, Star, Trash2, Zap,
+} from "lucide-react";
 import { useJdDetailStore, type JdStatus } from "@/features/jd";
 import { CompanyIcon } from "@/shared/ui/CompanyIcon";
 import {
@@ -8,10 +13,10 @@ import {
   type JobDescriptionCollectionStatus,
 } from "@/features/user-job-description";
 
-const STATUS_OPTIONS: { value: JdStatus; icon: string; label: string; sub: string }[] = [
-  { value: "planned", icon: "📅", label: "지원 예정",  sub: "곧 지원할 예정" },
-  { value: "saved",   icon: "⭐", label: "관심 저장",  sub: "관심만 저장" },
-  { value: "applied", icon: "✅", label: "지원 완료",  sub: "이미 지원 완료" },
+const STATUS_OPTIONS: { value: JdStatus; icon: ReactNode; label: string; sub: string }[] = [
+  { value: "planned", icon: <Calendar size={18} className="text-[#0991B2]" />, label: "지원 예정",  sub: "곧 지원할 예정" },
+  { value: "saved",   icon: <Star size={18} className="text-[#F59E0B]" />,    label: "관심 저장",  sub: "관심만 저장" },
+  { value: "applied", icon: <CheckCircle2 size={18} className="text-[#059669]" />, label: "지원 완료",  sub: "이미 지원 완료" },
 ];
 
 const STATUS_LABEL: Record<JdStatus, string> = {
@@ -149,10 +154,10 @@ export function JdDetailPage() {
               </div>
 
               <div className="flex flex-wrap gap-2 mt-4 relative">
-                <span className="inline-flex items-center gap-[5px] text-[12px] font-semibold py-[5px] px-3 rounded-full bg-white text-[#6B7280] border border-[#E5E7EB] shadow-[0_1px_3px_rgba(0,0,0,0.06)]">🏢 {jd.company}</span>
-                <span className="inline-flex items-center gap-[5px] text-[12px] font-semibold py-[5px] px-3 rounded-full bg-white text-[#6B7280] border border-[#E5E7EB] shadow-[0_1px_3px_rgba(0,0,0,0.06)]">📍 {jd.location}</span>
-                <span className="inline-flex items-center gap-[5px] text-[12px] font-semibold py-[5px] px-3 rounded-full bg-white text-[#6B7280] border border-[#E5E7EB] shadow-[0_1px_3px_rgba(0,0,0,0.06)]">💼 {jd.experience}</span>
-                <span className="inline-flex items-center gap-[5px] text-[12px] font-semibold py-[5px] px-3 rounded-full bg-white text-[#6B7280] border border-[#E5E7EB] shadow-[0_1px_3px_rgba(0,0,0,0.06)]">🕐 {jd.period}</span>
+                <span className="inline-flex items-center gap-[5px] text-[12px] font-semibold py-[5px] px-3 rounded-full bg-white text-[#6B7280] border border-[#E5E7EB] shadow-[0_1px_3px_rgba(0,0,0,0.06)]"><Building2 size={12} /> {jd.company}</span>
+                <span className="inline-flex items-center gap-[5px] text-[12px] font-semibold py-[5px] px-3 rounded-full bg-white text-[#6B7280] border border-[#E5E7EB] shadow-[0_1px_3px_rgba(0,0,0,0.06)]"><MapPin size={12} /> {jd.location}</span>
+                <span className="inline-flex items-center gap-[5px] text-[12px] font-semibold py-[5px] px-3 rounded-full bg-white text-[#6B7280] border border-[#E5E7EB] shadow-[0_1px_3px_rgba(0,0,0,0.06)]"><Briefcase size={12} /> {jd.experience}</span>
+                <span className="inline-flex items-center gap-[5px] text-[12px] font-semibold py-[5px] px-3 rounded-full bg-white text-[#6B7280] border border-[#E5E7EB] shadow-[0_1px_3px_rgba(0,0,0,0.06)]"><Clock size={12} /> {jd.period}</span>
                 <span className="inline-flex items-center gap-[5px] text-[12px] font-semibold py-[5px] px-3 rounded-full bg-[#E6F7FA] text-[#0991B2] border border-[#0991B2] shadow-[0_1px_3px_rgba(0,0,0,0.06)]">
                   {STATUS_OPTIONS.find((o) => o.value === jd.status)?.icon} {STATUS_LABEL[jd.status]}
                 </span>
@@ -166,7 +171,7 @@ export function JdDetailPage() {
                   면접 시작하기
                 </Link>
                 <a href={jd.originalUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-[13px] font-semibold text-[#6B7280] bg-transparent border-none cursor-pointer py-[10px] px-4 rounded-lg transition-all hover:text-[#0A0A0A] hover:bg-[#F3F4F6] no-underline">
-                  🔗 원문 보기
+                  <ExternalLink size={14} /> 원문 보기
                 </a>
                 <button
                   type="button"
@@ -176,7 +181,7 @@ export function JdDetailPage() {
                   onClick={isProcessing ? undefined : handleDelete}
                   disabled={isProcessing}
                 >
-                  🗑 {isProcessing ? "수집 중..." : "삭제"}
+                  <Trash2 size={14} /> {isProcessing ? "수집 중..." : "삭제"}
                 </button>
               </div>
             </div>
@@ -184,7 +189,9 @@ export function JdDetailPage() {
             {/* 직무 요약 */}
             <div className={`${cardCls} p-[28px_32px] max-sm:p-[20px_16px]`}>
               <div className="text-base font-black text-[#0A0A0A] mb-[18px] flex items-center gap-2">
-                <span className="w-8 h-8 rounded-lg flex items-center justify-center text-[15px] shrink-0" style={{ background: "linear-gradient(135deg,#67E8F9,#0891B2)" }}>📄</span>
+                <span className="w-8 h-8 rounded-lg bg-[#E6F7FA] flex items-center justify-center shrink-0">
+                  <AlignLeft size={16} className="text-[#0991B2]" />
+                </span>
                 직무 요약
               </div>
               {jd.summary ? (
@@ -199,18 +206,19 @@ export function JdDetailPage() {
             {/* 필수 자격 요건 */}
             <div className={`${cardCls} p-[28px_32px] max-sm:p-[20px_16px]`}>
               <div className="text-base font-black text-[#0A0A0A] mb-[18px] flex items-center gap-2">
-                <span className="w-8 h-8 rounded-lg flex items-center justify-center text-[15px] shrink-0" style={{ background: "linear-gradient(135deg,#34D399,#059669)" }}>⚡</span>
+                <span className="w-8 h-8 rounded-lg bg-[#ECFDF5] flex items-center justify-center shrink-0">
+                  <CheckSquare size={16} className="text-[#059669]" />
+                </span>
                 필수 자격 요건
               </div>
               {jd.requirements.length > 0 ? (
                 <div className="flex flex-col gap-2">
                   {jd.requirements.map((req, i) => (
                     <div key={i} className="flex items-start gap-2.5 p-[10px_14px] bg-white border border-[#E5E7EB] rounded-lg text-[13px] text-[#0A0A0A] leading-[1.6]">
-                      <div className={`w-5 h-5 rounded-lg shrink-0 flex items-center justify-center text-[10px] font-bold mt-px ${
-                        req.level === "required"
-                          ? "bg-gradient-to-br from-[#34D399] to-[#059669] text-white shadow-[0_2px_6px_rgba(5,150,105,0.25)]"
-                          : "bg-[#E6F7FA] text-[#0991B2]"
-                      }`}>✓</div>
+                      <CheckCircle2
+                        size={18}
+                        className={`shrink-0 mt-px ${req.level === "required" ? "text-[#059669]" : "text-[#0991B2]"}`}
+                      />
                       {req.text}
                     </div>
                   ))}
@@ -225,14 +233,16 @@ export function JdDetailPage() {
             {/* 우대 사항 */}
             <div className={`${cardCls} p-[28px_32px] max-sm:p-[20px_16px]`}>
               <div className="text-base font-black text-[#0A0A0A] mb-[18px] flex items-center gap-2">
-                <span className="w-8 h-8 rounded-lg flex items-center justify-center text-[15px] shrink-0" style={{ background: "linear-gradient(135deg,#FCD34D,#D97706)" }}>⭐</span>
+                <span className="w-8 h-8 rounded-lg bg-[#FFFBEB] flex items-center justify-center shrink-0">
+                  <Star size={16} className="text-[#F59E0B]" />
+                </span>
                 우대 사항
               </div>
               {jd.preferences.length > 0 ? (
-                <div className="grid grid-cols-2 gap-2 max-[900px]:grid-cols-1">
+                <div className="flex flex-col gap-2">
                   {jd.preferences.map((pref, i) => (
-                    <div key={i} className="p-[10px_14px] bg-white border border-[#E5E7EB] rounded-lg text-[12px] font-semibold text-[#6B7280] flex items-center gap-2">
-                      <div className="w-2 h-2 rounded-full bg-[#D97706] shrink-0" />
+                    <div key={i} className="flex items-start gap-2.5 p-[10px_14px] bg-white border border-[#E5E7EB] rounded-lg text-[13px] text-[#0A0A0A] leading-[1.6]">
+                      <Star size={16} className="text-[#F59E0B] shrink-0 mt-px" />
                       {pref}
                     </div>
                   ))}
@@ -252,7 +262,7 @@ export function JdDetailPage() {
             {/* 지원 상태 변경 */}
             <div className={`${cardCls} p-[22px_20px]`}>
               <div className="text-sm font-black text-[#0A0A0A] mb-4 flex items-center gap-2">
-                <span style={{ fontSize: 18 }}>📌</span> 지원 상태 변경
+                <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center shrink-0"><Pin size={14} className="text-[#0991B2]" /></span> 지원 상태 변경
                 {isUpdating && <span className="text-[11px] text-[#6B7280] font-normal ml-auto">저장 중...</span>}
               </div>
               <div className="flex flex-col gap-2">
@@ -267,14 +277,14 @@ export function JdDetailPage() {
                     disabled={isUpdating}
                     aria-pressed={jd.status === opt.value}
                   >
-                    <span className="text-[18px] shrink-0">{opt.icon}</span>
                     <div className={`w-[18px] h-[18px] rounded-full border-2 flex items-center justify-center shrink-0 transition-all ${
                       jd.status === opt.value ? "border-[#0991B2] bg-[#0991B2]" : "border-[#E5E7EB]"
                     }`}>
                       {jd.status === opt.value && <div className="w-1.5 h-1.5 rounded-full bg-white" />}
                     </div>
+                    <span className="shrink-0">{opt.icon}</span>
                     <div>
-                      <div className="text-[13px] font-bold text-[#0A0A0A]">{opt.label}</div>
+                      <div className="text-[13px] font-extrabold text-[#0A0A0A]">{opt.label}</div>
                       <div className="text-[11px] text-[#6B7280] mt-px">{opt.sub}</div>
                     </div>
                   </button>
@@ -285,22 +295,26 @@ export function JdDetailPage() {
             {/* 빠른 액션 */}
             <div className={`${cardCls} p-[22px_20px]`}>
               <div className="text-sm font-black text-[#0A0A0A] mb-4 flex items-center gap-2">
-                <span style={{ fontSize: 18 }}>🚀</span> 빠른 액션
+                <span className="w-7 h-7 rounded-lg bg-[#FFFBEB] flex items-center justify-center shrink-0"><Zap size={14} className="text-[#F59E0B]" /></span> 빠른 액션
               </div>
               <div className="flex flex-col gap-2">
                 <Link to="/interview" className="flex items-center gap-2.5 p-[12px_14px] rounded-lg border border-[#E5E7EB] bg-white cursor-pointer text-[13px] font-semibold text-[#0A0A0A] transition-all no-underline hover:bg-[#F9FAFB] hover:-translate-y-px hover:shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)]">
-                  <div className="w-8 h-8 rounded-lg flex items-center justify-center text-[15px] shrink-0" style={{ background: "linear-gradient(135deg,#67E8F9,#0891B2)" }}>🎤</div>
+                  <div className="w-8 h-8 rounded-lg bg-[#E6F7FA] flex items-center justify-center shrink-0">
+                    <Mic size={16} className="text-[#0991B2]" />
+                  </div>
                   <div className="flex-1">
                     <div className="text-[13px] font-extrabold">꼬리질문 면접</div>
-                    <div className="text-[11px] text-[#6B7280] mt-px">심화 질문 집중 연습</div>
+                    <div className="text-[11px] font-normal text-[#6B7280] mt-px">심화 질문 집중 연습</div>
                   </div>
                   <span className="text-[#9CA3AF] text-base">›</span>
                 </Link>
                 <Link to="/interview" className="flex items-center gap-2.5 p-[12px_14px] rounded-lg border border-[#E5E7EB] bg-white cursor-pointer text-[13px] font-semibold text-[#0A0A0A] transition-all no-underline hover:bg-[#F9FAFB] hover:-translate-y-px hover:shadow-[0_1px_3px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)]">
-                  <div className="w-8 h-8 rounded-lg flex items-center justify-center text-[15px] shrink-0" style={{ background: "linear-gradient(135deg,#34D399,#059669)" }}>📋</div>
+                  <div className="w-8 h-8 rounded-lg bg-[#ECFDF5] flex items-center justify-center shrink-0">
+                    <ClipboardList size={16} className="text-[#059669]" />
+                  </div>
                   <div className="flex-1">
                     <div className="text-[13px] font-extrabold">전체 프로세스</div>
-                    <div className="text-[11px] text-[#6B7280] mt-px">처음부터 끝까지 연습</div>
+                    <div className="text-[11px] font-normal text-[#6B7280] mt-px">처음부터 끝까지 연습</div>
                   </div>
                   <span className="text-[#9CA3AF] text-base">›</span>
                 </Link>
@@ -310,7 +324,7 @@ export function JdDetailPage() {
             {/* 등록 정보 */}
             <div className={`${cardCls} p-[22px_20px]`}>
               <div className="text-sm font-black text-[#0A0A0A] mb-4 flex items-center gap-2">
-                <span style={{ fontSize: 18 }}>ℹ️</span> 등록 정보
+                <span className="w-7 h-7 rounded-lg bg-[#F3F4F6] flex items-center justify-center shrink-0"><Info size={14} className="text-[#6B7280]" /></span> 등록 정보
               </div>
               <div className="flex items-center justify-between py-2.5 border-b border-[#F3F4F6] text-[13px]">
                 <span className="text-[#6B7280] font-semibold">등록일</span>
@@ -320,7 +334,7 @@ export function JdDetailPage() {
                 <span className="text-[#6B7280] font-semibold">분석 완료</span>
                 <span className="text-[#0A0A0A] font-medium text-right">
                   {jd.analyzed
-                    ? <span className="inline-flex items-center gap-1 text-[11px] font-bold py-[3px] px-2.5 rounded-full bg-[#D1FAE5] text-[#047857]">✓ 완료</span>
+                    ? <span className="inline-flex items-center gap-1 text-[11px] font-bold py-[3px] px-2.5 rounded-full bg-[#D1FAE5] text-[#047857]"><Check size={10} strokeWidth={3} /> 완료</span>
                     : <span className="inline-flex items-center gap-1 text-[11px] font-bold py-[3px] px-2.5 rounded-full bg-[#FEF3C7] text-[#D97706]">분석 중</span>}
                 </span>
               </div>

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -128,7 +128,7 @@ function JdCard({ item }: { item: JdListItem }) {
       {/* Company */}
       <div className="flex items-center gap-2.5 mb-2.5">
         <div className="w-[38px] h-[38px] rounded-lg shrink-0 shadow-[0_3px_8px_rgba(0,0,0,0.06)] overflow-hidden">
-          <CompanyIcon platform={item.raw.jobDescription.platform || ""} title={item.title} size={18} />
+          <CompanyIcon categoryId={item.categoryId} size={18} />
         </div>
         <div className="text-[13px] text-[#6B7280] font-semibold">{item.company}</div>
       </div>

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useRef, useState, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useJdListStore, type JdListItem } from "@/features/jd";
 import { useUserJobDescriptionScrapingSse } from "@/features/user-job-description";
+import { ClipboardList, Search } from "lucide-react";
 import { CompanyIcon } from "@/shared/ui/CompanyIcon";
 
 type FilterKey = "all" | "planned" | "applied" | "saved";
@@ -224,7 +225,7 @@ export function JdListPage() {
         {/* PAGE HEADER */}
         <div className="flex items-start justify-between mb-8 gap-4">
           <div>
-            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">📋 채용공고</div>
+            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5"><ClipboardList size={12} />채용공고</div>
             <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">내 채용공고</h1>
             <p className="text-sm text-[#6B7280] mt-1.5">지원할 채용공고를 등록하고 AI 면접 준비를 시작하세요</p>
           </div>
@@ -275,7 +276,7 @@ export function JdListPage() {
         {/* FILTER */}
         <div className="flex items-center gap-2.5 mb-6 flex-wrap max-sm:flex-col max-sm:items-stretch">
           <div className="flex-1 min-w-[220px] relative max-sm:min-w-0">
-            <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-base pointer-events-none">🔍</span>
+            <Search size={14} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-[#9CA3AF] pointer-events-none" />
             <input
               type="text"
               className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg py-3 pr-4 pl-11 text-sm font-medium text-[#0A0A0A] shadow-[0_1px_3px_rgba(0,0,0,0.08)] outline-none transition-[border-color] focus:border-[#0991B2] focus:shadow-[0_1px_3px_rgba(0,0,0,0.1)] placeholder:text-[#9CA3AF]"

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useRef, useState, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useJdListStore, type JdListItem } from "@/features/jd";
 import { useUserJobDescriptionScrapingSse } from "@/features/user-job-description";
+import { CompanyIcon } from "@/shared/ui/CompanyIcon";
 
 type FilterKey = "all" | "planned" | "applied" | "saved";
 
@@ -126,11 +127,8 @@ function JdCard({ item }: { item: JdListItem }) {
 
       {/* Company */}
       <div className="flex items-center gap-2.5 mb-2.5">
-        <div
-          className="w-[38px] h-[38px] rounded-lg flex items-center justify-center text-base font-black text-white shrink-0 shadow-[0_3px_8px_rgba(0,0,0,0.1)]"
-          style={{ background: item.companyColor }}
-        >
-          {item.companyInitial}
+        <div className="w-[38px] h-[38px] rounded-lg shrink-0 shadow-[0_3px_8px_rgba(0,0,0,0.06)] overflow-hidden">
+          <CompanyIcon platform={item.raw.jobDescription.platform || ""} title={item.title} size={18} />
         </div>
         <div className="text-[13px] text-[#6B7280] font-semibold">{item.company}</div>
       </div>
@@ -249,7 +247,7 @@ export function JdListPage() {
           const badges = [
             { dot: "#0EA5E9", text: `지원 예정 ${stats.planned}개` },
             { dot: "#10B981", text: `지원 완료 ${stats.applied}개` },
-            { dot: null,      text: `⭐ 관심 저장 ${stats.saved}개` },
+            { dot: "#ffff73ff", text: `관심 저장 ${stats.saved}개` },
           ];
           return (
             <div className="relative overflow-hidden bg-gradient-to-br from-[#065F79] to-[#0991B2] rounded-lg px-6 py-[22px] mb-7 shadow-[0_12px_32px_rgba(9,145,178,.35)] animate-[jdl-fadeUp_.5s_ease_.05s_both] flex items-center gap-[18px] flex-wrap before:content-[''] before:absolute before:top-[-40px] before:right-[-40px] before:w-[160px] before:h-[160px] before:rounded-full before:bg-[rgba(255,255,255,.07)] md:px-9 md:py-7 md:gap-8">

--- a/src/pages/resume-list/ui/ResumeListHeader.tsx
+++ b/src/pages/resume-list/ui/ResumeListHeader.tsx
@@ -1,3 +1,5 @@
+import { Search } from "lucide-react";
+
 interface ResumeListHeaderProps {
   totalCount: number;
   searchQuery: string;
@@ -11,7 +13,7 @@ export function ResumeListHeader({ totalCount, searchQuery, onSearchChange }: Re
         전체 이력서 <span className="text-[#0991B2]">{totalCount}</span>개
       </h2>
       <div className="flex-1 min-w-[220px] relative max-sm:min-w-0">
-        <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-base pointer-events-none">🔍</span>
+        <Search size={14} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-[#9CA3AF] pointer-events-none" />
         <input
           type="text"
           className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg py-2.5 pr-4 pl-11 text-sm font-medium text-[#0A0A0A] shadow-[0_1px_3px_rgba(0,0,0,0.08)] outline-none transition-[border-color] focus:border-[#0991B2] focus:shadow-[0_1px_3px_rgba(0,0,0,0.1)] placeholder:text-[#9CA3AF]"

--- a/src/pages/resume-list/ui/ResumeListPage.tsx
+++ b/src/pages/resume-list/ui/ResumeListPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Loader2 } from "lucide-react";
+import { FileText, Loader2 } from "lucide-react";
 import { useInfiniteList } from "@/shared/hooks/useInfiniteList";
 import { openSseStream } from "@/shared/api/sse";
 import {
@@ -147,7 +147,7 @@ export function ResumeListPage() {
         {/* 페이지 타이틀 */}
         <div className="flex items-start justify-between mb-8 gap-4">
           <div>
-            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">📄 이력서</div>
+            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5"><FileText size={12} />이력서</div>
             <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">내 이력서</h1>
             <p className="text-sm text-[#6B7280] mt-1.5">면접 연습에 사용할 이력서를 관리하세요.</p>
           </div>

--- a/src/pages/resume-new/ui/ResumeNewPage.tsx
+++ b/src/pages/resume-new/ui/ResumeNewPage.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { ArrowLeft, FileUp, FileText, Sparkles } from "lucide-react";
+import { ArrowLeft, FilePlus, FileUp, FileText, Sparkles } from "lucide-react";
 import { FileUploadTab } from "./mode-tabs/FileUploadTab";
 import { TextUploadTab } from "./mode-tabs/TextUploadTab";
 import { StructuredFormTab } from "./mode-tabs/StructuredFormTab";
@@ -25,7 +25,7 @@ export function ResumeNewPage() {
         {/* PAGE HEADER */}
         <div className="flex items-start justify-between mb-8 gap-4">
           <div>
-            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">+ 이력서 추가</div>
+            <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5"><FilePlus size={12} /> 이력서 추가</div>
             <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">새 이력서</h1>
             <p className="text-sm text-[#6B7280] mt-1.5">작성 방식을 선택하세요. 어떤 방식이든 결과는 동일한 정규화 형식으로 저장됩니다.</p>
           </div>

--- a/src/pages/resume-new/ui/mode-tabs/FileUploadTab.tsx
+++ b/src/pages/resume-new/ui/mode-tabs/FileUploadTab.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Loader2 } from "lucide-react";
+import { FileCheck, Loader2, Upload, XCircle } from "lucide-react";
 import { resumeApi } from "@/features/resume";
 
 export function FileUploadTab() {
@@ -84,7 +84,7 @@ export function FileUploadTab() {
           />
           {file ? (
             <>
-              <div className="w-12 h-12 rounded-xl bg-[#D1FAE5] flex items-center justify-center text-2xl">📄</div>
+              <div className="w-12 h-12 rounded-xl bg-[#D1FAE5] flex items-center justify-center"><FileCheck size={24} className="text-[#059669]" /></div>
               <div className="text-center">
                 <div className="text-[13px] font-extrabold text-[#059669]">{file.name}</div>
                 <div className="text-[11px] text-[#6B7280] mt-0.5">{(file.size / 1024 / 1024).toFixed(2)} MB</div>
@@ -99,7 +99,7 @@ export function FileUploadTab() {
             </>
           ) : (
             <>
-              <div className="w-12 h-12 rounded-xl bg-[#E6F7FA] flex items-center justify-center text-2xl">📎</div>
+              <div className="w-12 h-12 rounded-xl bg-[#E6F7FA] flex items-center justify-center"><Upload size={24} className="text-[#0991B2]" /></div>
               <div className="text-center">
                 <div className="text-[13px] font-extrabold text-[#0A0A0A]">PDF 파일을 드래그하거나 클릭해서 선택</div>
                 <div className="text-[11px] text-[#9CA3AF] mt-1">PDF 형식만 지원 · 최대 10MB</div>
@@ -128,7 +128,7 @@ export function FileUploadTab() {
       {/* 에러 */}
       {error && (
         <div className="flex items-center gap-2 text-[12px] font-semibold text-[#DC2626] bg-[#FEF2F2] border border-[#FECACA] rounded-lg px-3.5 py-2.5">
-          ✗ {error}
+          <XCircle size={14} className="shrink-0" /> {error}
         </div>
       )}
 

--- a/src/pages/resume-new/ui/mode-tabs/StructuredFormTab.tsx
+++ b/src/pages/resume-new/ui/mode-tabs/StructuredFormTab.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Sparkles, Loader2, Plus, Trash2 } from "lucide-react";
+import {
+  AlignLeft, Award, Briefcase, Clock, Globe,
+  GraduationCap, Loader2, Plus, Search, Sparkles, Tag, Trash2,
+  Trophy, Upload, User, XCircle, Zap,
+} from "lucide-react";
 import {
   resumeApi,
   type ParsedData,
@@ -36,19 +40,25 @@ const JOB_CATEGORY_OPTIONS = [
   "인사", "기획", "CS", "디지털 마케팅", "기타",
 ];
 
-const SECTION_ICONS: Record<string, string> = {
-  "기본 정보": "👤",
-  "요약": "📝",
-  "총 경력": "⏱️",
-  "직군": "🏷️",
-  "스킬": "⚡",
-  "경력": "💼",
-  "학력": "🎓",
-  "자격증": "📜",
-  "수상 이력": "🏆",
-  "프로젝트": "🚀",
-  "구사 언어": "🌐",
-  "산업 도메인 / 키워드": "🔍",
+const ic = (Icon: React.ComponentType<{ size?: number; className?: string }>, color: string, bg: string) => (
+  <div className={`w-6 h-6 rounded-md flex items-center justify-center ${bg}`}>
+    <Icon size={13} className={color} />
+  </div>
+);
+
+const SECTION_ICONS: Record<string, React.ReactNode> = {
+  "기본 정보":              ic(User,          "text-[#0991B2]", "bg-[#E6F7FA]"),
+  "요약":                   ic(AlignLeft,     "text-[#6B7280]", "bg-[#F3F4F6]"),
+  "총 경력":                ic(Clock,         "text-[#D97706]", "bg-[#FFFBEB]"),
+  "직군":                   ic(Tag,           "text-[#8B5CF6]", "bg-[#F5F3FF]"),
+  "스킬":                   ic(Zap,           "text-[#D97706]", "bg-[#FFFBEB]"),
+  "경력":                   ic(Briefcase,     "text-[#0991B2]", "bg-[#E6F7FA]"),
+  "학력":                   ic(GraduationCap, "text-[#059669]", "bg-[#ECFDF5]"),
+  "자격증":                 ic(Award,         "text-[#0991B2]", "bg-[#E6F7FA]"),
+  "수상 이력":              ic(Trophy,        "text-[#D97706]", "bg-[#FFFBEB]"),
+  "프로젝트":               ic(Upload,        "text-[#8B5CF6]", "bg-[#F5F3FF]"),
+  "구사 언어":              ic(Globe,         "text-[#0991B2]", "bg-[#E6F7FA]"),
+  "산업 도메인 / 키워드":   ic(Search,        "text-[#6B7280]", "bg-[#F3F4F6]"),
 };
 
 const csvToList = (csv: string): string[] =>
@@ -310,7 +320,7 @@ export function StructuredFormTab() {
       {/* 에러 */}
       {error && (
         <div className="flex items-center gap-2 text-[12px] font-semibold text-[#DC2626] bg-[#FEF2F2] border border-[#FECACA] rounded-lg px-3.5 py-2.5">
-          ✗ {error}
+          <XCircle size={14} className="shrink-0" /> {error}
         </div>
       )}
 
@@ -337,14 +347,14 @@ function Section({
   title,
   children,
 }: {
-  icon?: string;
+  icon?: React.ReactNode;
   title: string;
   children: React.ReactNode;
 }) {
   return (
     <div className="border border-[#E5E7EB] rounded-xl bg-[#FAFAFA] overflow-hidden">
       <div className="flex items-center gap-2 px-4 py-3 border-b border-[#E5E7EB] bg-white">
-        {icon && <span className="text-base">{icon}</span>}
+        {icon}
         <span className="text-[12px] font-extrabold text-[#0A0A0A]">{title}</span>
       </div>
       <div className="p-4 flex flex-col gap-3">{children}</div>
@@ -408,7 +418,7 @@ function RepeaterSection<T extends RepeatableItem>({
   onChange,
   renderRow,
 }: {
-  icon?: string;
+  icon?: React.ReactNode;
   title: string;
   items: T[];
   empty: T;
@@ -427,7 +437,7 @@ function RepeaterSection<T extends RepeatableItem>({
     <div className="border border-[#E5E7EB] rounded-xl bg-[#FAFAFA] overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#E5E7EB] bg-white">
         <div className="flex items-center gap-2">
-          {icon && <span className="text-base">{icon}</span>}
+          {icon}
           <span className="text-[12px] font-extrabold text-[#0A0A0A]">{title}</span>
           {items.length > 0 && (
             <span className="text-[10px] font-bold text-[#0991B2] bg-[#E6F7FA] px-2 py-0.5 rounded-full">

--- a/src/pages/resume-new/ui/mode-tabs/TextUploadTab.tsx
+++ b/src/pages/resume-new/ui/mode-tabs/TextUploadTab.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FileText, LayoutTemplate } from "lucide-react";
-import { Alert, Button, Input, Textarea } from "@/shared/ui";
+import { Alert, Button } from "@/shared/ui";
 import { TemplatePickerModal } from "./text-upload/TemplatePickerModal";
 import { useResumeTextForm } from "./text-upload/useResumeTextForm";
 import { useTemplatePicker } from "./text-upload/useTemplatePicker";
@@ -36,21 +36,26 @@ export function TextUploadTab() {
           </Button>
         </div>
 
-        <Input
-          label="제목"
-          value={form.title}
-          onChange={(e) => form.setTitle(e.target.value)}
-          placeholder="예: 2026 백엔드 개발자 이력서"
-        />
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[12px] font-bold text-[#0A0A0A]">제목 <span className="text-[#DC2626]">*</span></span>
+          <input
+            value={form.title}
+            onChange={(e) => form.setTitle(e.target.value)}
+            placeholder="예: 2026 백엔드 개발자 이력서"
+            className="border border-[#E5E7EB] rounded-lg px-3.5 py-2.5 text-[13px] outline-none transition-[border-color,box-shadow] focus:border-[#0991B2] focus:shadow-[0_0_0_3px_rgba(9,145,178,0.1)] placeholder:text-[#9CA3AF]"
+          />
+        </label>
 
-        <Textarea
-          label="이력서 본문"
-          value={form.content}
-          onChange={(e) => form.setContent(e.target.value)}
-          rows={14}
-          placeholder="자유 형식 텍스트로 이력서 내용을 입력하세요. 분석 후 자동으로 정규화됩니다."
-          className="font-mono leading-[1.6]"
-        />
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[12px] font-bold text-[#0A0A0A]">이력서 본문 <span className="text-[#DC2626]">*</span></span>
+          <textarea
+            value={form.content}
+            onChange={(e) => form.setContent(e.target.value)}
+            rows={14}
+            placeholder="자유 형식 텍스트로 이력서 내용을 입력하세요. 분석 후 자동으로 정규화됩니다."
+            className="border border-[#E5E7EB] rounded-lg px-3.5 py-2.5 text-[13px] outline-none transition-[border-color,box-shadow] focus:border-[#0991B2] focus:shadow-[0_0_0_3px_rgba(9,145,178,0.1)] placeholder:text-[#9CA3AF] resize-y"
+          />
+        </label>
 
         {form.error && <Alert variant="error">{form.error}</Alert>}
 

--- a/src/pages/resume-new/ui/mode-tabs/text-upload/TemplatePickerList.tsx
+++ b/src/pages/resume-new/ui/mode-tabs/text-upload/TemplatePickerList.tsx
@@ -2,6 +2,8 @@
 
 import { Loader2 } from "lucide-react";
 import { Alert, Button, Spinner } from "@/shared/ui";
+import { CompanyIcon } from "@/shared/ui/CompanyIcon";
+import { inferCategoryId } from "@/shared/ui/inferCategoryId";
 import type { ResumeTemplateListItem } from "@/features/resume";
 
 interface TemplatePickerListProps {
@@ -74,8 +76,8 @@ export function TemplatePickerList(props: TemplatePickerListProps) {
                   disabled={pickerLoadingUuid !== null}
                   className="flex items-start gap-3 p-3 rounded-lg border border-[#E5E7EB] bg-white text-left transition-all hover:border-[#0991B2] hover:bg-[#F0FDFE] disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  <div className="w-8 h-8 rounded-lg bg-[#E6F7FA] flex items-center justify-center text-[14px] shrink-0">
-                    📄
+                  <div className="w-8 h-8 rounded-lg shrink-0 overflow-hidden">
+                    <CompanyIcon categoryId={inferCategoryId(category, t.job.name)} size={16} />
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="text-[13px] font-bold text-[#0A0A0A] truncate">{t.title}</div>

--- a/src/pages/settings/ui/JobCategorySelector.tsx
+++ b/src/pages/settings/ui/JobCategorySelector.tsx
@@ -1,21 +1,11 @@
 import { useState, useRef, useEffect } from "react";
-import {
-  ChevronDown, Check,
-  DollarSign, Handshake, Megaphone, Users, Code2, MoreHorizontal,
-} from "lucide-react";
+import { ChevronDown, Check } from "lucide-react";
 import type { JobCategory, Job } from "@/shared/api/profileApi";
-
-/* 직군 ID → lucide 아이콘 + 색상 매핑 */
-const CATEGORY_ICON: Record<number, { icon: React.ReactNode }> = {
-  3: { icon: <DollarSign size={16} className="text-[#F59E0B]" /> },  // 금융/회계
-  4: { icon: <Handshake  size={16} className="text-[#0991B2]" /> },  // 영업/서비스
-  2: { icon: <Megaphone  size={16} className="text-[#EC4899]" /> },  // 마케팅
-  5: { icon: <Users      size={16} className="text-[#8B5CF6]" /> },  // 인사/HR
-  1: { icon: <Code2      size={16} className="text-[#059669]" /> },  // IT/개발
-};
+import { CATEGORY_STYLE } from "@/shared/ui/categoryIconStyle";
 
 function getCategoryIcon(id: number) {
-  return CATEGORY_ICON[id]?.icon ?? <MoreHorizontal size={16} className="text-[#9CA3AF]" />;
+  const { Icon, color } = CATEGORY_STYLE[id] ?? CATEGORY_STYLE[0];
+  return <Icon size={16} className={color} />;
 }
 
 interface CategoryProps {

--- a/src/shared/ui/CompanyIcon.tsx
+++ b/src/shared/ui/CompanyIcon.tsx
@@ -1,0 +1,77 @@
+/**
+ * 회사/JD 아이콘 컴포넌트.
+ * platform·title 키워드로 직군 카테고리를 추론하고,
+ * categoryIconStyle 의 CATEGORY_STYLE 과 동일한 아이콘·색상을 렌더링한다.
+ */
+import { CATEGORY_STYLE } from "./categoryIconStyle";
+
+export type CompanyIconSize = 14 | 16 | 18 | 20 | 22 | 24;
+
+interface CompanyIconProps {
+  platform?: string;
+  title?: string;
+  /** 카테고리 id를 직접 지정할 경우 platform/title 추론보다 우선 */
+  categoryId?: number;
+  size?: CompanyIconSize;
+}
+
+/** platform·title 키워드 → 카테고리 id 추론 */
+function inferCategoryId(platform: string, title: string): number {
+  const src = `${platform} ${title}`.toLowerCase();
+
+  // IT/개발 (1)
+  if (
+    src.includes("tech") || src.includes("software") || src.includes("개발") ||
+    src.includes("engineer") || src.includes("it") || src.includes("dev") ||
+    src.includes("backend") || src.includes("frontend") || src.includes("fullstack") ||
+    src.includes("data") || src.includes("ai") || src.includes("ml") ||
+    src.includes("naver") || src.includes("kakao") || src.includes("google") ||
+    src.includes("meta") || src.includes("nexon") || src.includes("ncsoft")
+  ) return 1;
+
+  // 마케팅 (2)
+  if (
+    src.includes("market") || src.includes("마케팅") || src.includes("광고") ||
+    src.includes("brand") || src.includes("브랜드") || src.includes("content") ||
+    src.includes("콘텐츠") || src.includes("design") || src.includes("디자인")
+  ) return 2;
+
+  // 금융/회계 (3)
+  if (
+    src.includes("bank") || src.includes("은행") || src.includes("금융") ||
+    src.includes("finance") || src.includes("pay") || src.includes("toss") ||
+    src.includes("카드") || src.includes("결제") || src.includes("회계") ||
+    src.includes("accounting")
+  ) return 3;
+
+  // 영업/서비스 (4)
+  if (
+    src.includes("sales") || src.includes("영업") || src.includes("service") ||
+    src.includes("서비스") || src.includes("cs") || src.includes("고객") ||
+    src.includes("delivery") || src.includes("배달") || src.includes("물류") ||
+    src.includes("shop") || src.includes("쇼핑") || src.includes("commerce")
+  ) return 4;
+
+  // 인사/HR (5)
+  if (
+    src.includes("hr") || src.includes("인사") || src.includes("recruit") ||
+    src.includes("채용") || src.includes("people") || src.includes("talent")
+  ) return 5;
+
+  return 0; // 기타
+}
+
+/**
+ * 회사/JD 아이콘.
+ * categoryId를 직접 넘기면 JobCategorySelector 와 완전히 동일한 아이콘·색상을 사용한다.
+ */
+export function CompanyIcon({ platform = "", title = "", categoryId, size = 16 }: CompanyIconProps) {
+  const id = categoryId ?? inferCategoryId(platform, title);
+  const { Icon, color, bgColor } = CATEGORY_STYLE[id] ?? CATEGORY_STYLE[0];
+
+  return (
+    <div className={`w-full h-full flex items-center justify-center rounded-lg ${bgColor}`}>
+      <Icon size={size} className={color} />
+    </div>
+  );
+}

--- a/src/shared/ui/CompanyIcon.tsx
+++ b/src/shared/ui/CompanyIcon.tsx
@@ -4,6 +4,7 @@
  * categoryIconStyle 의 CATEGORY_STYLE 과 동일한 아이콘·색상을 렌더링한다.
  */
 import { CATEGORY_STYLE } from "./categoryIconStyle";
+import { inferCategoryId } from "./inferCategoryId";
 
 export type CompanyIconSize = 14 | 16 | 18 | 20 | 22 | 24;
 
@@ -13,52 +14,6 @@ interface CompanyIconProps {
   /** 카테고리 id를 직접 지정할 경우 platform/title 추론보다 우선 */
   categoryId?: number;
   size?: CompanyIconSize;
-}
-
-/** platform·title 키워드 → 카테고리 id 추론 */
-function inferCategoryId(platform: string, title: string): number {
-  const src = `${platform} ${title}`.toLowerCase();
-
-  // IT/개발 (1)
-  if (
-    src.includes("tech") || src.includes("software") || src.includes("개발") ||
-    src.includes("engineer") || src.includes("it") || src.includes("dev") ||
-    src.includes("backend") || src.includes("frontend") || src.includes("fullstack") ||
-    src.includes("data") || src.includes("ai") || src.includes("ml") ||
-    src.includes("naver") || src.includes("kakao") || src.includes("google") ||
-    src.includes("meta") || src.includes("nexon") || src.includes("ncsoft")
-  ) return 1;
-
-  // 마케팅 (2)
-  if (
-    src.includes("market") || src.includes("마케팅") || src.includes("광고") ||
-    src.includes("brand") || src.includes("브랜드") || src.includes("content") ||
-    src.includes("콘텐츠") || src.includes("design") || src.includes("디자인")
-  ) return 2;
-
-  // 금융/회계 (3)
-  if (
-    src.includes("bank") || src.includes("은행") || src.includes("금융") ||
-    src.includes("finance") || src.includes("pay") || src.includes("toss") ||
-    src.includes("카드") || src.includes("결제") || src.includes("회계") ||
-    src.includes("accounting")
-  ) return 3;
-
-  // 영업/서비스 (4)
-  if (
-    src.includes("sales") || src.includes("영업") || src.includes("service") ||
-    src.includes("서비스") || src.includes("cs") || src.includes("고객") ||
-    src.includes("delivery") || src.includes("배달") || src.includes("물류") ||
-    src.includes("shop") || src.includes("쇼핑") || src.includes("commerce")
-  ) return 4;
-
-  // 인사/HR (5)
-  if (
-    src.includes("hr") || src.includes("인사") || src.includes("recruit") ||
-    src.includes("채용") || src.includes("people") || src.includes("talent")
-  ) return 5;
-
-  return 0; // 기타
 }
 
 /**

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -1,11 +1,12 @@
 /** label과 error 메시지를 포함하는 텍스트 입력 필드. */
+import type React from "react";
 import type { InputHTMLAttributes } from "react";
 
 interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "className"> {
   label?: string;
   error?: string;
   helperText?: string;
-  icon?: string;
+  icon?: React.ReactNode;
   required?: boolean;
   fullWidth?: boolean;
 }
@@ -33,7 +34,7 @@ export function Input({
       )}
       <div className="relative">
         {icon && (
-          <span className="absolute left-[14px] top-1/2 -translate-y-1/2 text-base pointer-events-none">
+          <span className="absolute left-[14px] top-1/2 -translate-y-1/2 pointer-events-none flex items-center text-[#9CA3AF]">
             {icon}
           </span>
         )}

--- a/src/shared/ui/OptionCard.tsx
+++ b/src/shared/ui/OptionCard.tsx
@@ -5,7 +5,7 @@ interface OptionCardProps {
   selected: boolean;
   disabled?: boolean;
   onClick: () => void;
-  icon?: string;
+  icon?: ReactNode;
   title: string;
   description?: string;
   badge?: ReactNode;
@@ -33,7 +33,7 @@ export function OptionCard({
     >
       {(icon || badge) && (
         <div className="flex items-center justify-between mb-2">
-          {icon && <span className="text-xl">{icon}</span>}
+          {icon && <span className="flex items-center">{icon}</span>}
           {badge}
         </div>
       )}

--- a/src/shared/ui/SectionHeader.tsx
+++ b/src/shared/ui/SectionHeader.tsx
@@ -2,25 +2,17 @@
 import type { ReactNode } from "react";
 
 interface SectionHeaderProps {
-  icon?: string;
+  icon?: ReactNode;
   title: string;
   description?: string;
-  gradient?: string;
   children?: ReactNode;
 }
 
-export function SectionHeader({ icon, title, description, gradient, children }: SectionHeaderProps) {
+export function SectionHeader({ icon, title, description, children }: SectionHeaderProps) {
   return (
     <div className="mb-4">
       <div className="text-md font-extrabold text-mefit-black mb-1 flex items-center gap-2">
-        {icon && (
-          <span
-            className="w-7 h-7 rounded-lg flex items-center justify-center text-sm shrink-0"
-            style={gradient ? { background: gradient } : undefined}
-          >
-            {icon}
-          </span>
-        )}
+        {icon && <span className="shrink-0">{icon}</span>}
         {title}
       </div>
       {description && <p className="text-sm text-mefit-gray-500 mb-[18px] ml-9">{description}</p>}

--- a/src/shared/ui/StatusCard.tsx
+++ b/src/shared/ui/StatusCard.tsx
@@ -1,7 +1,9 @@
 /** 아이콘과 라벨과 설명이 있는 옵션 목록에서 하나를 선택하는 카드 그룹. */
+import type { ReactNode } from "react";
+
 interface StatusCardOption<T = string> {
   value: T;
-  icon: string;
+  icon: ReactNode;
   label: string;
   desc: string;
 }
@@ -34,7 +36,7 @@ export function StatusCard<T extends string | number = string>({ options, select
           onClick={() => onSelect(opt.value)}
           aria-pressed={selected === opt.value}
         >
-          <span className="text-[22px] mb-1.5 block">{opt.icon}</span>
+          <span className="flex justify-center mb-1.5">{opt.icon}</span>
           <div className={`text-xs font-extrabold ${selected === opt.value ? "text-mefit-primary" : "text-mefit-black"}`}>
             {opt.label}
           </div>

--- a/src/shared/ui/categoryIconStyle.ts
+++ b/src/shared/ui/categoryIconStyle.ts
@@ -1,0 +1,37 @@
+/**
+ * 직군 카테고리 id → lucide 아이콘 + 색상 매핑.
+ * JobCategorySelector 와 CompanyIcon 이 동일한 스타일을 공유한다.
+ *
+ *   1 → IT/개발    (Code2,      #059669 green)
+ *   2 → 마케팅     (Megaphone,  #EC4899 pink)
+ *   3 → 금융/회계  (DollarSign, #F59E0B amber)
+ *   4 → 영업/서비스(Handshake,  #0991B2 teal)
+ *   5 → 인사/HR    (Users,      #8B5CF6 violet)
+ *   0 → 기타       (Building2,  #9CA3AF gray)
+ */
+import {
+  Code2,
+  Megaphone,
+  DollarSign,
+  Handshake,
+  Users,
+  Building2,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export interface CategoryStyle {
+  Icon: LucideIcon;
+  /** tailwind text-[...] 클래스 */
+  color: string;
+  /** tailwind bg-[...] 클래스 */
+  bgColor: string;
+}
+
+export const CATEGORY_STYLE: Record<number, CategoryStyle> = {
+  1: { Icon: Code2,      color: "text-[#059669]", bgColor: "bg-[#ECFDF5]" }, // IT/개발
+  2: { Icon: Megaphone,  color: "text-[#EC4899]", bgColor: "bg-[#FDF2F8]" }, // 마케팅
+  3: { Icon: DollarSign, color: "text-[#F59E0B]", bgColor: "bg-[#FFFBEB]" }, // 금융/회계
+  4: { Icon: Handshake,  color: "text-[#0991B2]", bgColor: "bg-[#E6F7FA]" }, // 영업/서비스
+  5: { Icon: Users,      color: "text-[#8B5CF6]", bgColor: "bg-[#F5F3FF]" }, // 인사/HR
+  0: { Icon: Building2,  color: "text-[#9CA3AF]", bgColor: "bg-[#F3F4F6]" }, // 기타
+};

--- a/src/shared/ui/inferCategoryId.ts
+++ b/src/shared/ui/inferCategoryId.ts
@@ -10,8 +10,7 @@ const PLATFORM_MAP: [string[], number][] = [
 
 const KEYWORD_MAP: [string[], number][] = [
   [["tech", "software", "개발", "engineer", "it", "dev",
-    "backend", "frontend", "fullstack", "data", "ai", "ml",
-    "naver", "kakao", "google", "meta", "nexon", "ncsoft"], 1],
+    "backend", "frontend", "fullstack", "data", "ai", "ml"], 1],
   [["market", "마케팅", "광고", "brand", "브랜드",
     "content", "콘텐츠", "design", "디자인"],              2],
   [["bank", "은행", "금융", "finance", "pay", "toss",

--- a/src/shared/ui/inferCategoryId.ts
+++ b/src/shared/ui/inferCategoryId.ts
@@ -1,0 +1,45 @@
+/** platform·title 키워드 → 카테고리 id 추론 */
+export function inferCategoryId(platform: string, title: string): number {
+  const src = `${platform} ${title}`.toLowerCase();
+
+  // IT/개발 (1)
+  if (
+    src.includes("tech") || src.includes("software") || src.includes("개발") ||
+    src.includes("engineer") || src.includes("it") || src.includes("dev") ||
+    src.includes("backend") || src.includes("frontend") || src.includes("fullstack") ||
+    src.includes("data") || src.includes("ai") || src.includes("ml") ||
+    src.includes("naver") || src.includes("kakao") || src.includes("google") ||
+    src.includes("meta") || src.includes("nexon") || src.includes("ncsoft")
+  ) return 1;
+
+  // 마케팅 (2)
+  if (
+    src.includes("market") || src.includes("마케팅") || src.includes("광고") ||
+    src.includes("brand") || src.includes("브랜드") || src.includes("content") ||
+    src.includes("콘텐츠") || src.includes("design") || src.includes("디자인")
+  ) return 2;
+
+  // 금융/회계 (3)
+  if (
+    src.includes("bank") || src.includes("은행") || src.includes("금융") ||
+    src.includes("finance") || src.includes("pay") || src.includes("toss") ||
+    src.includes("카드") || src.includes("결제") || src.includes("회계") ||
+    src.includes("accounting")
+  ) return 3;
+
+  // 영업/서비스 (4)
+  if (
+    src.includes("sales") || src.includes("영업") || src.includes("service") ||
+    src.includes("서비스") || src.includes("cs") || src.includes("고객") ||
+    src.includes("delivery") || src.includes("배달") || src.includes("물류") ||
+    src.includes("shop") || src.includes("쇼핑") || src.includes("commerce")
+  ) return 4;
+
+  // 인사/HR (5)
+  if (
+    src.includes("hr") || src.includes("인사") || src.includes("recruit") ||
+    src.includes("채용") || src.includes("people") || src.includes("talent")
+  ) return 5;
+
+  return 0; // 기타
+}

--- a/src/shared/ui/inferCategoryId.ts
+++ b/src/shared/ui/inferCategoryId.ts
@@ -1,5 +1,13 @@
 /** platform·title 키워드 → 카테고리 id 추론 */
 export function inferCategoryId(platform: string, title: string): number {
+  // 그룹/카테고리명이 직접 넘어온 경우 우선 매핑 (키워드 오탐 방지)
+  const p = platform.toLowerCase();
+  if (p.includes("인사") || p.includes("hr")) return 5;
+  if (p.includes("영업") || p.includes("서비스")) return 4;
+  if (p.includes("금융") || p.includes("회계")) return 3;
+  if (p.includes("마케팅") || p.includes("광고")) return 2;
+  if (p.includes("it") || p.includes("개발")) return 1;
+
   const src = `${platform} ${title}`.toLowerCase();
 
   // IT/개발 (1)

--- a/src/shared/ui/inferCategoryId.ts
+++ b/src/shared/ui/inferCategoryId.ts
@@ -1,53 +1,35 @@
 /** platform·title 키워드 → 카테고리 id 추론 */
+
+const PLATFORM_MAP: [string[], number][] = [
+  [["인사", "hr"],              5],
+  [["영업", "서비스"],          4],
+  [["금융", "회계"],            3],
+  [["마케팅", "광고"],          2],
+  [["it", "개발"],              1],
+];
+
+const KEYWORD_MAP: [string[], number][] = [
+  [["tech", "software", "개발", "engineer", "it", "dev",
+    "backend", "frontend", "fullstack", "data", "ai", "ml",
+    "naver", "kakao", "google", "meta", "nexon", "ncsoft"], 1],
+  [["market", "마케팅", "광고", "brand", "브랜드",
+    "content", "콘텐츠", "design", "디자인"],              2],
+  [["bank", "은행", "금융", "finance", "pay", "toss",
+    "카드", "결제", "회계", "accounting"],                  3],
+  [["sales", "영업", "service", "서비스", "cs", "고객",
+    "delivery", "배달", "물류", "shop", "쇼핑", "commerce"], 4],
+  [["hr", "인사", "recruit", "채용", "people", "talent"],  5],
+];
+
+function matchKeywords(src: string, map: [string[], number][]): number {
+  for (const [keywords, id] of map) {
+    if (keywords.some((k) => src.includes(k))) return id;
+  }
+  return 0;
+}
+
 export function inferCategoryId(platform: string, title: string): number {
-  // 그룹/카테고리명이 직접 넘어온 경우 우선 매핑 (키워드 오탐 방지)
-  const p = platform.toLowerCase();
-  if (p.includes("인사") || p.includes("hr")) return 5;
-  if (p.includes("영업") || p.includes("서비스")) return 4;
-  if (p.includes("금융") || p.includes("회계")) return 3;
-  if (p.includes("마케팅") || p.includes("광고")) return 2;
-  if (p.includes("it") || p.includes("개발")) return 1;
-
-  const src = `${platform} ${title}`.toLowerCase();
-
-  // IT/개발 (1)
-  if (
-    src.includes("tech") || src.includes("software") || src.includes("개발") ||
-    src.includes("engineer") || src.includes("it") || src.includes("dev") ||
-    src.includes("backend") || src.includes("frontend") || src.includes("fullstack") ||
-    src.includes("data") || src.includes("ai") || src.includes("ml") ||
-    src.includes("naver") || src.includes("kakao") || src.includes("google") ||
-    src.includes("meta") || src.includes("nexon") || src.includes("ncsoft")
-  ) return 1;
-
-  // 마케팅 (2)
-  if (
-    src.includes("market") || src.includes("마케팅") || src.includes("광고") ||
-    src.includes("brand") || src.includes("브랜드") || src.includes("content") ||
-    src.includes("콘텐츠") || src.includes("design") || src.includes("디자인")
-  ) return 2;
-
-  // 금융/회계 (3)
-  if (
-    src.includes("bank") || src.includes("은행") || src.includes("금융") ||
-    src.includes("finance") || src.includes("pay") || src.includes("toss") ||
-    src.includes("카드") || src.includes("결제") || src.includes("회계") ||
-    src.includes("accounting")
-  ) return 3;
-
-  // 영업/서비스 (4)
-  if (
-    src.includes("sales") || src.includes("영업") || src.includes("service") ||
-    src.includes("서비스") || src.includes("cs") || src.includes("고객") ||
-    src.includes("delivery") || src.includes("배달") || src.includes("물류") ||
-    src.includes("shop") || src.includes("쇼핑") || src.includes("commerce")
-  ) return 4;
-
-  // 인사/HR (5)
-  if (
-    src.includes("hr") || src.includes("인사") || src.includes("recruit") ||
-    src.includes("채용") || src.includes("people") || src.includes("talent")
-  ) return 5;
-
-  return 0; // 기타
+  const platformId = matchKeywords(platform.toLowerCase(), PLATFORM_MAP);
+  if (platformId !== 0) return platformId;
+  return matchKeywords(`${platform} ${title}`.toLowerCase(), KEYWORD_MAP);
 }


### PR DESCRIPTION
## 관련 이슈
Closes #114

## 변경 사항

- 전체 페이지(채용공고 목록/상세/추가, 이력서 목록/추가, 면접 설정)의 이모지 아이콘을 lucide-react 컬러
   아이콘으로 교체
- `CompanyIcon` 공유 컴포넌트 및 `CATEGORY_STYLE` 상수 추가 — 직군 카테고리(IT/개발, 마케팅, 금융, 영업,
   인사/기타)별 아이콘·색상 통일
- `inferCategoryId` 함수를 별도 파일로 분리하여 플랫폼명 우선 매칭으로 카테고리 오분류 수정
- 채용공고 데이터 변환 시점에 `categoryId` 계산 → 모든 페이지에서 동일한 아이콘 표시
- JdDetailPage 섹션 헤더(직무 요약/필수 자격 요건/우대 사항) 아이콘 고정 색상으로 변경 (파랑/초록/주황)
- 면접 시작 버튼 및 빠른 액션 링크를 `/interview/setup`으로 연결, 빠른 액션에서 꼬리질문 항목 제거
- TextUploadTab 폰트 크기·플레이스홀더 색상을 FileUploadTab과 통일

## 변경 유형

- [x] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)

## 테스트 방법

- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome

테스트 시나리오:
1. 채용공고 목록/상세/추가 페이지에서 동일한 JD가 모든 페이지에 동일한 카테고리 아이콘으로 표시되는지 확인
2. 이력서 추가 페이지의 파일 업로드 / 텍스트 입력 탭 폰트 크기 및 색상이 동일한지 확인
3. JD 상세 페이지 "면접 시작하기" 및 "전체 프로세스" 클릭 시 `/interview/setup`으로 이동하는지 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 반응형 디자인을 확인했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.

