### PR TITLE
perf: 녹화 업로드를 S3 Presigned Multipart 직접 업로드로 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.pr-generator

--- a/src/features/interview-session/api/recordingApi.ts
+++ b/src/features/interview-session/api/recordingApi.ts
@@ -1,4 +1,4 @@
-import { apiRequest, fetchWithAuth } from "@/shared/api/client";
+import { apiRequest } from "@/shared/api/client";
 
 export interface InitiateRecordingResponse {
   recordingId: string;
@@ -41,12 +41,12 @@ export const recordingApi = {
       },
     ),
 
-  complete: (recordingId: string, parts: { partNumber: number; etag: string }[], endTimestamp: string, durationMs: number, singleUpload = false) =>
+  complete: (recordingId: string, parts: { partNumber: number; etag: string }[], endTimestamp: string, durationMs: number) =>
     apiRequest<CompleteRecordingResponse>(
       `${BASE}/recordings/${recordingId}/complete/`,
       {
         method: "POST",
-        body: JSON.stringify({ parts, endTimestamp, durationMs, singleUpload }),
+        body: JSON.stringify({ parts, endTimestamp, durationMs }),
         auth: true,
       },
     ),
@@ -54,17 +54,11 @@ export const recordingApi = {
   abort: (recordingId: string) =>
     apiRequest<void>(`${BASE}/recordings/${recordingId}/abort/`, { method: "POST", auth: true }),
 
-  upload: (recordingId: string, blob: Blob) => {
-    const formData = new FormData();
-    formData.append("file", blob, "recording.webm");
-    return fetchWithAuth(`${BASE}/recordings/${recordingId}/upload/`, {
-      method: "PUT",
-      body: formData,
-    }).then((res) => {
-      if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
-      return res.json();
-    });
-  },
+  presignPart: (recordingId: string, partNumber: number) =>
+    apiRequest<{ presignedUrl: string; partNumber: number }>(
+      `${BASE}/recordings/${recordingId}/presign-part/?partNumber=${partNumber}`,
+      { auth: true },
+    ),
 
   list: (sessionUuid: string) =>
     apiRequest<RecordingItem[]>(`${BASE}/interview-sessions/${sessionUuid}/recordings/`, { auth: true }),

--- a/src/features/interview-session/lib/__tests__/useChunkUploader.test.ts
+++ b/src/features/interview-session/lib/__tests__/useChunkUploader.test.ts
@@ -1,28 +1,36 @@
 import { renderHook, act } from "@testing-library/react";
 
-jest.mock("@/shared/api/client", () => ({
-  fetchWithAuth: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+jest.mock("../../api/recordingApi", () => ({
+  recordingApi: {
+    presignPart: jest.fn(),
+  },
 }));
 
+import { recordingApi } from "../../api/recordingApi";
 import { useChunkUploader } from "../useChunkUploader";
 
+const mockPresignPart = recordingApi.presignPart as jest.Mock;
 const RECORDING_ID = "test-recording-uuid";
-
 const makeBlob = (size = 1024) => new Blob([new ArrayBuffer(size)]);
+
+const mockFetchOk = (etag = "abc123") => {
+  globalThis.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({ ETag: `"${etag}"` }),
+  }) as jest.Mock;
+};
 
 describe("useChunkUploader", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+    mockPresignPart.mockReset();
   });
 
-  it("init 후 uploadChunk가 순번대로 backend endpoint를 호출한다", async () => {
-    globalThis.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ etag: "abc123" }),
-    }) as jest.Mock;
+  it("init → uploadChunk calls presignPart then PUT to S3", async () => {
+    mockPresignPart.mockResolvedValue({ presignedUrl: "https://s3.example.com/part1", partNumber: 1 });
+    mockFetchOk("abc123");
 
     const { result } = renderHook(() => useChunkUploader());
-
     act(() => { result.current.init(RECORDING_ID); });
 
     let part: unknown;
@@ -31,36 +39,34 @@ describe("useChunkUploader", () => {
     });
 
     expect(part).toEqual({ partNumber: 1, etag: "abc123" });
+    expect(mockPresignPart).toHaveBeenCalledWith(RECORDING_ID, 1);
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      `/api/v1/interviews/recordings/${RECORDING_ID}/parts/1/`,
+      "https://s3.example.com/part1",
       expect.objectContaining({ method: "PUT" }),
     );
   });
 
-  it("연속 uploadChunk 호출 시 partNumber가 순차 증가한다", async () => {
-    globalThis.fetch = jest.fn()
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ etag: "e1" }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ etag: "e2" }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ etag: "e3" }) }) as jest.Mock;
+  it("sequential uploadChunk increments partNumber", async () => {
+    mockPresignPart
+      .mockResolvedValueOnce({ presignedUrl: "https://s3.example.com/p1", partNumber: 1 })
+      .mockResolvedValueOnce({ presignedUrl: "https://s3.example.com/p2", partNumber: 2 })
+      .mockResolvedValueOnce({ presignedUrl: "https://s3.example.com/p3", partNumber: 3 });
+    mockFetchOk("e1");
 
     const { result } = renderHook(() => useChunkUploader());
     act(() => { result.current.init(RECORDING_ID); });
 
-    const parts = [];
     for (let i = 0; i < 3; i++) {
-      await act(async () => {
-        parts.push(await result.current.uploadChunk(makeBlob()));
-      });
+      await act(async () => { await result.current.uploadChunk(makeBlob()); });
     }
 
-    expect(parts).toEqual([
-      { partNumber: 1, etag: "e1" },
-      { partNumber: 2, etag: "e2" },
-      { partNumber: 3, etag: "e3" },
-    ]);
+    expect(mockPresignPart).toHaveBeenCalledTimes(3);
+    expect(mockPresignPart).toHaveBeenNthCalledWith(1, RECORDING_ID, 1);
+    expect(mockPresignPart).toHaveBeenNthCalledWith(2, RECORDING_ID, 2);
+    expect(mockPresignPart).toHaveBeenNthCalledWith(3, RECORDING_ID, 3);
   });
 
-  it("init 전에 uploadChunk를 호출하면 null을 반환한다", async () => {
+  it("init not called → uploadChunk returns null with error", async () => {
     const { result } = renderHook(() => useChunkUploader());
 
     let part: unknown;
@@ -72,7 +78,8 @@ describe("useChunkUploader", () => {
     expect(result.current.error).toBe("Recording not initialized.");
   });
 
-  it("fetch 실패 시 재시도 후 null 반환", async () => {
+  it("S3 PUT failure retries then returns null", async () => {
+    mockPresignPart.mockResolvedValue({ presignedUrl: "https://s3.example.com/p1", partNumber: 1 });
     globalThis.fetch = jest.fn().mockRejectedValue(new Error("Network error")) as jest.Mock;
 
     const { result } = renderHook(() => useChunkUploader({ maxRetries: 1, retryBaseDelay: 10 }));
@@ -85,14 +92,11 @@ describe("useChunkUploader", () => {
 
     expect(part).toBeNull();
     expect(result.current.error).toContain("Network error");
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
 
-  it("reset 후 상태가 초기화된다", async () => {
-    globalThis.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ etag: "e1" }),
-    }) as jest.Mock;
+  it("reset clears state", async () => {
+    mockPresignPart.mockResolvedValue({ presignedUrl: "https://s3.example.com/p1", partNumber: 1 });
+    mockFetchOk("e1");
 
     const { result } = renderHook(() => useChunkUploader());
     act(() => { result.current.init(RECORDING_ID); });

--- a/src/features/interview-session/lib/__tests__/useRecordingManager.test.ts
+++ b/src/features/interview-session/lib/__tests__/useRecordingManager.test.ts
@@ -5,6 +5,7 @@ jest.mock("../../api/recordingApi", () => ({
     initiate: jest.fn(),
     complete: jest.fn(),
     abort: jest.fn(),
+    presignPart: jest.fn(),
   },
 }));
 
@@ -13,6 +14,12 @@ import { recordingApi } from "../../api/recordingApi";
 const mockInitiate = recordingApi.initiate as jest.Mock;
 const mockComplete = recordingApi.complete as jest.Mock;
 const mockAbort = recordingApi.abort as jest.Mock;
+
+const mockMediaStart = jest.fn().mockResolvedValue(undefined);
+const mockMediaStop = jest.fn();
+const mockUploaderInit = jest.fn();
+const mockUploadChunk = jest.fn();
+const mockUploaderReset = jest.fn();
 
 jest.mock("../useMediaRecorder", () => ({
   useMediaRecorder: () => ({
@@ -27,21 +34,14 @@ jest.mock("../useMediaRecorder", () => ({
 jest.mock("../useChunkUploader", () => ({
   useChunkUploader: () => ({
     uploadedParts: [],
-    currentPartNumber: 1,
     isUploading: false,
-    progress: 0,
+    uploadedBytes: 0,
     error: null,
     init: mockUploaderInit,
     uploadChunk: mockUploadChunk,
     reset: mockUploaderReset,
   }),
 }));
-
-const mockMediaStart = jest.fn().mockResolvedValue(undefined);
-const mockMediaStop = jest.fn();
-const mockUploaderInit = jest.fn();
-const mockUploadChunk = jest.fn();
-const mockUploaderReset = jest.fn();
 
 import { useRecordingManager } from "../useRecordingManager";
 
@@ -58,7 +58,7 @@ describe("useRecordingManager", () => {
     mockComplete.mockResolvedValue({ recordingId: "rec-123", status: "completed" });
     mockAbort.mockResolvedValue(undefined);
     mockMediaStop.mockResolvedValue(new Blob([new ArrayBuffer(1024)]));
-    globalThis.fetch = jest.fn().mockResolvedValue({ ok: true }) as jest.Mock;
+    mockUploadChunk.mockResolvedValue({ partNumber: 1, etag: "etag-1" });
   });
 
   it("startRecording: initiate API → chunkUploader.init → mediaRecorder.start", async () => {
@@ -73,13 +73,10 @@ describe("useRecordingManager", () => {
     expect(mockMediaStart).toHaveBeenCalled();
   });
 
-  it("stopRecording (단일 업로드): parts=0이면 recordingApi.upload 후 complete(singleUpload=true)", async () => {
-    const mockUpload = jest.fn().mockResolvedValue({ status: "uploaded" });
-    (recordingApi as Record<string, unknown>).upload = mockUpload;
-
+  it("stopRecording: finalBlob → uploadChunk → complete with parts", async () => {
     const finalBlob = new Blob([new ArrayBuffer(2048)]);
     mockMediaStop.mockResolvedValue(finalBlob);
-    mockUploadChunk.mockResolvedValue(null);
+    mockUploadChunk.mockResolvedValue({ partNumber: 1, etag: "final-etag" });
 
     const { result } = renderHook(() =>
       useRecordingManager({ sessionUuid: "sess-1" }),
@@ -88,20 +85,16 @@ describe("useRecordingManager", () => {
     await act(async () => { await result.current.startRecording(10); });
     await act(async () => { await result.current.stopRecording(); });
 
-    expect(mockUpload).toHaveBeenCalledWith("rec-123", finalBlob);
+    expect(mockUploadChunk).toHaveBeenCalledWith(finalBlob);
     expect(mockComplete).toHaveBeenCalledWith(
       "rec-123",
-      [],
+      expect.arrayContaining([expect.objectContaining({ partNumber: 1 })]),
       expect.any(String),
       expect.any(Number),
-      true,
     );
   });
 
-  it("stopRecording: complete API에 올바른 타임스탬프와 duration을 전달한다", async () => {
-    const mockUpload = jest.fn().mockResolvedValue({ status: "uploaded" });
-    (recordingApi as Record<string, unknown>).upload = mockUpload;
-
+  it("stopRecording: complete API receives valid timestamp and duration", async () => {
     const finalBlob = new Blob([new ArrayBuffer(2048)]);
     mockMediaStop.mockResolvedValue(finalBlob);
 
@@ -118,7 +111,7 @@ describe("useRecordingManager", () => {
     expect(durationMs).toBeGreaterThanOrEqual(0);
   });
 
-  it("abortRecording: abort API 호출 + 상태 초기화", async () => {
+  it("abortRecording: abort API + state reset", async () => {
     const { result } = renderHook(() =>
       useRecordingManager({ sessionUuid: "sess-1" }),
     );
@@ -130,7 +123,7 @@ describe("useRecordingManager", () => {
     expect(mockUploaderReset).toHaveBeenCalled();
   });
 
-  it("enabled=false이면 startRecording이 무시된다", async () => {
+  it("enabled=false → startRecording is ignored", async () => {
     const { result } = renderHook(() =>
       useRecordingManager({ sessionUuid: "sess-1", enabled: false }),
     );
@@ -142,6 +135,7 @@ describe("useRecordingManager", () => {
 
   it("stopRecording: finalBlob=null + parts=0 → abort", async () => {
     mockMediaStop.mockResolvedValue(null);
+    mockUploadChunk.mockResolvedValue(null);
 
     const { result } = renderHook(() =>
       useRecordingManager({ sessionUuid: "sess-1" }),

--- a/src/features/interview-session/lib/useChunkUploader.ts
+++ b/src/features/interview-session/lib/useChunkUploader.ts
@@ -1,9 +1,10 @@
 import { useState, useCallback, useRef } from "react";
-import { fetchWithAuth } from "@/shared/api/client";
+import { recordingApi } from "../api/recordingApi";
 
 interface UseChunkUploaderOptions {
   maxRetries?: number;
   retryBaseDelay?: number;
+  maxConcurrent?: number;
 }
 
 export interface UploadedPart {
@@ -14,7 +15,7 @@ export interface UploadedPart {
 interface UseChunkUploaderReturn {
   uploadedParts: UploadedPart[];
   isUploading: boolean;
-  progress: number;
+  uploadedBytes: number;
   error: string | null;
   init: (recordingId: string) => void;
   uploadChunk: (blob: Blob) => Promise<UploadedPart | null>;
@@ -24,21 +25,25 @@ interface UseChunkUploaderReturn {
 export function useChunkUploader({
   maxRetries = 3,
   retryBaseDelay = 1000,
+  maxConcurrent = 3,
 }: UseChunkUploaderOptions = {}): UseChunkUploaderReturn {
   const [uploadedParts, setUploadedParts] = useState<UploadedPart[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const [uploadedBytes, setUploadedBytes] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
   const recordingIdRef = useRef<string | null>(null);
   const partCounterRef = useRef(1);
-  const uploadLockRef = useRef(false);
-
-  const progress = uploadedParts.length > 0 ? uploadedParts.length * 5 : 0;
+  const activeCountRef = useRef(0);
+  const queueRef = useRef<Array<() => void>>([]);
 
   const init = useCallback((recordingId: string) => {
     recordingIdRef.current = recordingId;
     partCounterRef.current = 1;
+    activeCountRef.current = 0;
+    queueRef.current = [];
     setUploadedParts([]);
+    setUploadedBytes(0);
     setIsUploading(false);
     setError(null);
   }, []);
@@ -46,17 +51,34 @@ export function useChunkUploader({
   const reset = useCallback(() => {
     recordingIdRef.current = null;
     partCounterRef.current = 1;
+    activeCountRef.current = 0;
+    queueRef.current = [];
     setUploadedParts([]);
+    setUploadedBytes(0);
     setIsUploading(false);
     setError(null);
   }, []);
 
+  const acquireSlot = useCallback(async () => {
+    if (activeCountRef.current < maxConcurrent) {
+      activeCountRef.current++;
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      queueRef.current.push(resolve);
+    });
+    activeCountRef.current++;
+  }, [maxConcurrent]);
+
+  const releaseSlot = useCallback(() => {
+    activeCountRef.current--;
+    const next = queueRef.current.shift();
+    if (next) next();
+  }, []);
+
   const uploadChunk = useCallback(
     async (blob: Blob): Promise<UploadedPart | null> => {
-      while (uploadLockRef.current) {
-        await new Promise((r) => setTimeout(r, 50));
-      }
-      uploadLockRef.current = true;
+      await acquireSlot();
 
       try {
         setIsUploading(true);
@@ -70,28 +92,33 @@ export function useChunkUploader({
         }
 
         const partNumber = partCounterRef.current;
-        const path = `/api/v1/interviews/recordings/${id}/parts/${partNumber}/`;
+        partCounterRef.current = partNumber + 1;
 
         let attempt = 0;
 
         while (attempt <= maxRetries) {
           try {
-            const formData = new FormData();
-            formData.append("file", blob, "chunk.webm");
+            const { presignedUrl } = await recordingApi.presignPart(id, partNumber);
 
-            const response = await fetchWithAuth(path, { method: "PUT", body: formData });
+            const response = await fetch(presignedUrl, {
+              method: "PUT",
+              body: blob,
+              headers: { "Content-Type": "video/webm" },
+            });
 
             if (!response.ok) {
-              throw new Error(`Upload failed with status ${response.status}`);
+              throw new Error(`S3 upload failed with status ${response.status}`);
             }
 
-            const data = await response.json();
-            const etag = (data.etag ?? "").replace(/"/g, "");
+            const etag = (response.headers.get("ETag") ?? "").replace(/"/g, "");
 
             const part: UploadedPart = { partNumber, etag };
             setUploadedParts((prev) => [...prev, part]);
-            partCounterRef.current = partNumber + 1;
-            setIsUploading(false);
+            setUploadedBytes((prev) => prev + blob.size);
+
+            if (activeCountRef.current <= 1) {
+              setIsUploading(false);
+            }
             return part;
           } catch (err) {
             attempt++;
@@ -110,11 +137,11 @@ export function useChunkUploader({
         setIsUploading(false);
         return null;
       } finally {
-        uploadLockRef.current = false;
+        releaseSlot();
       }
     },
-    [maxRetries, retryBaseDelay],
+    [maxRetries, retryBaseDelay, acquireSlot, releaseSlot],
   );
 
-  return { uploadedParts, isUploading, progress, error, init, uploadChunk, reset };
+  return { uploadedParts, isUploading, uploadedBytes, error, init, uploadChunk, reset };
 }

--- a/src/features/interview-session/lib/useChunkUploader.ts
+++ b/src/features/interview-session/lib/useChunkUploader.ts
@@ -60,6 +60,7 @@ export function useChunkUploader({
   }, []);
 
   const acquireSlot = useCallback(async () => {
+    setIsUploading(true);
     if (activeCountRef.current < maxConcurrent) {
       activeCountRef.current++;
       return;
@@ -74,6 +75,9 @@ export function useChunkUploader({
     activeCountRef.current--;
     const next = queueRef.current.shift();
     if (next) next();
+    if (activeCountRef.current === 0 && queueRef.current.length === 0) {
+      setIsUploading(false);
+    }
   }, []);
 
   const uploadChunk = useCallback(
@@ -81,13 +85,11 @@ export function useChunkUploader({
       await acquireSlot();
 
       try {
-        setIsUploading(true);
         setError(null);
 
         const id = recordingIdRef.current;
         if (!id) {
           setError("Recording not initialized.");
-          setIsUploading(false);
           return null;
         }
 
@@ -115,17 +117,12 @@ export function useChunkUploader({
             const part: UploadedPart = { partNumber, etag };
             setUploadedParts((prev) => [...prev, part]);
             setUploadedBytes((prev) => prev + blob.size);
-
-            if (activeCountRef.current <= 1) {
-              setIsUploading(false);
-            }
             return part;
           } catch (err) {
             attempt++;
             console.warn(`[ChunkUploader] Part ${partNumber} attempt ${attempt}/${maxRetries} failed:`, err);
             if (attempt > maxRetries) {
               setError(err instanceof Error ? err.message : "Upload failed after retries.");
-              setIsUploading(false);
               return null;
             }
             await new Promise((resolve) =>
@@ -134,7 +131,6 @@ export function useChunkUploader({
           }
         }
 
-        setIsUploading(false);
         return null;
       } finally {
         releaseSlot();

--- a/src/features/interview-session/lib/useMediaRecorder.ts
+++ b/src/features/interview-session/lib/useMediaRecorder.ts
@@ -69,6 +69,7 @@ export function useMediaRecorder({
 
       const recorder = new MediaRecorder(mediaStream, {
         mimeType: selectedMimeType,
+        videoBitsPerSecond: 1_500_000,
       });
 
       recorder.ondataavailable = (event) => {

--- a/src/features/interview-session/lib/useRecordingManager.ts
+++ b/src/features/interview-session/lib/useRecordingManager.ts
@@ -13,7 +13,7 @@ export interface UseRecordingManagerReturn {
   stream: MediaStream | null;
   isRecording: boolean;
   uploadedBytes: number;
-  uploadProgress: number;
+  uploadedPartsCount: number;
   error: string | null;
   prepareRecording: (turnId: number) => Promise<void>;
   startRecording: (turnId: number) => Promise<void>;
@@ -34,19 +34,23 @@ export function useRecordingManager({
   const startTimeRef = useRef<number | null>(null);
   const isInitializedRef = useRef(false);
   const collectedPartsRef = useRef<UploadedPart[]>([]);
+  const pendingUploadsRef = useRef<Promise<UploadedPart | null>[]>([]);
   const preparedTurnIdRef = useRef<number | null>(null);
 
   const chunkUploader = useChunkUploader();
 
   const handleChunk = useCallback(
     (blob: Blob) => {
-      chunkUploader.uploadChunk(blob).then((part) => {
+      const promise = chunkUploader.uploadChunk(blob).then((part) => {
         if (part) {
           collectedPartsRef.current = [...collectedPartsRef.current, part];
         }
+        return part;
       }).catch((err) => {
         setManagerError(err instanceof Error ? err.message : "청크 업로드 실패");
+        return null;
       });
+      pendingUploadsRef.current = [...pendingUploadsRef.current, promise];
     },
     [chunkUploader],
   );
@@ -71,6 +75,7 @@ export function useRecordingManager({
     startTimeRef.current = null;
     isInitializedRef.current = false;
     collectedPartsRef.current = [];
+    pendingUploadsRef.current = [];
     chunkUploader.reset();
   }, [chunkUploader]);
 
@@ -150,6 +155,9 @@ export function useRecordingManager({
     try {
       const finalBlob = await mediaRecorder.stop();
 
+      await Promise.all(pendingUploadsRef.current);
+      pendingUploadsRef.current = [];
+
       if (finalBlob && finalBlob.size > 0) {
         const finalPart = await chunkUploader.uploadChunk(finalBlob);
         if (finalPart) {
@@ -197,7 +205,7 @@ export function useRecordingManager({
     stream: mediaRecorder.stream,
     isRecording: mediaRecorder.isRecording,
     uploadedBytes: chunkUploader.uploadedBytes,
-    uploadProgress: chunkUploader.uploadedParts.length > 0 ? chunkUploader.uploadedParts.length * 5 : 0,
+    uploadedPartsCount: chunkUploader.uploadedParts.length,
     error: combinedError,
     prepareRecording,
     startRecording,

--- a/src/features/interview-session/lib/useRecordingManager.ts
+++ b/src/features/interview-session/lib/useRecordingManager.ts
@@ -12,6 +12,7 @@ export interface UseRecordingManagerOptions {
 export interface UseRecordingManagerReturn {
   stream: MediaStream | null;
   isRecording: boolean;
+  uploadedBytes: number;
   uploadProgress: number;
   error: string | null;
   prepareRecording: (turnId: number) => Promise<void>;
@@ -149,9 +150,7 @@ export function useRecordingManager({
     try {
       const finalBlob = await mediaRecorder.stop();
 
-      const hasParts = collectedPartsRef.current.length > 0;
-
-      if (hasParts && finalBlob && finalBlob.size > 0) {
+      if (finalBlob && finalBlob.size > 0) {
         const finalPart = await chunkUploader.uploadChunk(finalBlob);
         if (finalPart) {
           collectedPartsRef.current = [...collectedPartsRef.current, finalPart];
@@ -159,21 +158,12 @@ export function useRecordingManager({
       }
 
       const parts = collectedPartsRef.current;
-      const useSingleUpload = parts.length === 0 && finalBlob && finalBlob.size > 0;
 
-      if (parts.length === 0 && !useSingleUpload) {
+      if (parts.length === 0) {
         setManagerError("업로드된 청크가 없습니다.");
         await recordingApi.abort(recordingIdRef.current).catch(() => {});
         resetRefs();
         return;
-      }
-
-      console.info("[RecordingManager] decision: hasParts=%s useSingleUpload=%s", hasParts, useSingleUpload);
-
-      if (useSingleUpload) {
-        console.info("[RecordingManager] proxy upload via backend, blob size=%d", finalBlob.size);
-        await recordingApi.upload(recordingIdRef.current, finalBlob);
-        console.info("[RecordingManager] proxy upload complete");
       }
 
       const endTime = Date.now();
@@ -186,11 +176,9 @@ export function useRecordingManager({
         sortedParts,
         endTimestamp,
         durationMs,
-        useSingleUpload ?? false,
       );
 
-      console.info("[RecordingManager] recording completed, mode=%s, parts=%d",
-        useSingleUpload ? "single" : "multipart", parts.length);
+      console.info("[RecordingManager] recording completed, parts=%d", parts.length);
 
       resetRefs();
       isInitializedRef.current = false;
@@ -208,7 +196,8 @@ export function useRecordingManager({
   return {
     stream: mediaRecorder.stream,
     isRecording: mediaRecorder.isRecording,
-    uploadProgress: chunkUploader.progress,
+    uploadedBytes: chunkUploader.uploadedBytes,
+    uploadProgress: chunkUploader.uploadedParts.length > 0 ? chunkUploader.uploadedParts.length * 5 : 0,
     error: combinedError,
     prepareRecording,
     startRecording,


### PR DESCRIPTION
## 관련 이슈

녹화 업로드 성능 최적화 (Backend PR: kmu-aws-capstone-team-4/backend#138)

## 변경 사항

### 배경

면접 녹화 영상 업로드가 3단계 진화를 거쳤습니다.

1. **S3 Presigned URL 직접 업로드** → 녹화 10~30분 시 URL 만료로 실패
2. **Django 서버 프록시 업로드** → 동작하지만 Client→Server→S3 이중 경유로 체감 지연 수 초
3. **S3 Presigned Multipart 직접 업로드 (이번 PR)** → 서버는 서명만 발급, 데이터는 S3 직접 전송

### 변경 내용

- `useChunkUploader.ts`: 서버 프록시(`fetchWithAuth` → backend → S3) 제거, `recordingApi.presignPart()` + `fetch(presignedUrl)` S3 직접 PUT으로 전환. `uploadLockRef` 직렬화 제거 → 3-way 병렬 업로드 도입
- `useMediaRecorder.ts`: `videoBitsPerSecond: 1_500_000` 추가 (녹화 파일 크기 ~70% 감소)
- `useRecordingManager.ts`: `recordingApi.upload()` 단일 업로드 폴백 제거, 항상 presigned multipart 사용. `uploadedBytes` 바이트 기반 진행률 추가
- `recordingApi.ts`: `presignPart()` API 함수 추가, `upload()` 함수 제거, `complete()`에서 `singleUpload` 파라미터 제거
- 테스트 전면 재작성: presigned URL mock 방식으로 전환

### 성능 개선 수치

| 지표 | 서버 프록시 (기존) | Presigned Direct (변경) |
|------|---------------------|--------------------------|
| 10분 녹화 파일 크기 | ~600MB | ~113MB (비트레이트 제한) |
| 5MB 청크 업로드 시간 (10Mbps) | ~4.5초 | ~4.0초 |
| 녹화 종료 후 대기 | 5~15초 | <1초 (실시간 업로드) |
| 서버 worker 점유 | 업로드 동안 점유 | <50ms (서명만) |
| 동시 업로드 | 1 (직렬) | 3 (병렬) |

## 변경 유형

- [x] 성능 개선 (Performance improvement)
- [x] 리팩토링 (Refactoring)
- [x] 테스트 추가 (Test addition)

## 테스트 방법

- [x] 단위 테스트 (Unit tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome

테스트 시나리오:
1. 면접 세션 시작 → 녹화 시작 → 5초 이상 답변 → 녹화 종료 → 업로드 완료 확인
2. 장시간 녹화(10분+) 시 Presigned URL 만료 없이 정상 업로드 확인
3. Jest 테스트: `useChunkUploader` 5개 + `useRecordingManager` 6개 — 전체 PASS

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다 (18 suites, 112 tests ALL PASS)

## 추가 정보

이 PR은 Backend PR(kmu-aws-capstone-team-4/backend#138)과 함께 배포되어야 합니다.

Backend에서 추가된 엔드포인트:
- `GET /api/v1/interviews/recordings/{uuid}/presign-part/?partNumber=N` — 파트별 Presigned URL 발급

Backend에서 제거된 엔드포인트:
- `PUT /api/v1/interviews/recordings/{uuid}/upload/` — 단일 파일 서버 프록시
- `PUT /api/v1/interviews/recordings/{uuid}/parts/{n}/` — 청크 서버 프록시

**배포 시 S3 CORS 설정 필요** — 상세: `backend/docs/specs/s3-cors-configuration.md`