### PR TITLE
feat: 홈 대시보드 API 통계 연동 및 UI 개선

### DIFF
--- a/src/features/home/api/dashboardApi.ts
+++ b/src/features/home/api/dashboardApi.ts
@@ -1,13 +1,5 @@
 import { apiRequest } from "@/shared/api/client";
 
-interface DashboardStatisticsResponse {
-  totalCompletedInterviews: number;
-  averageScore: number | null;
-  averageScoreSampleSize: number;
-  currentStreakDays: number;
-  totalPracticeTimeSeconds: number;
-}
-
 export interface DashboardStatistics {
   totalCompletedInterviews: number;
   averageScore: number | null;
@@ -17,14 +9,14 @@ export interface DashboardStatistics {
 }
 
 export async function fetchDashboardStatisticsApi(): Promise<DashboardStatistics> {
-  const data = await apiRequest<DashboardStatisticsResponse>(
+  const data = await apiRequest<DashboardStatistics>(
     "/api/v1/dashboard/statistics/",
     { method: "GET", auth: true },
   );
 
   return {
     totalCompletedInterviews: data.totalCompletedInterviews ?? 0,
-    averageScore: data.averageScore,
+    averageScore: data.averageScore ?? null,
     averageScoreSampleSize: data.averageScoreSampleSize ?? 0,
     currentStreakDays: data.currentStreakDays ?? 0,
     totalPracticeTimeSeconds: data.totalPracticeTimeSeconds ?? 0,

--- a/src/features/home/api/dashboardApi.ts
+++ b/src/features/home/api/dashboardApi.ts
@@ -1,0 +1,32 @@
+import { apiRequest } from "@/shared/api/client";
+
+interface DashboardStatisticsResponse {
+  totalCompletedInterviews: number;
+  averageScore: number | null;
+  averageScoreSampleSize: number;
+  currentStreakDays: number;
+  totalPracticeTimeSeconds: number;
+}
+
+export interface DashboardStatistics {
+  totalCompletedInterviews: number;
+  averageScore: number | null;
+  averageScoreSampleSize: number;
+  currentStreakDays: number;
+  totalPracticeTimeSeconds: number;
+}
+
+export async function fetchDashboardStatisticsApi(): Promise<DashboardStatistics> {
+  const data = await apiRequest<DashboardStatisticsResponse>(
+    "/api/v1/dashboard/statistics/",
+    { method: "GET", auth: true },
+  );
+
+  return {
+    totalCompletedInterviews: data.totalCompletedInterviews ?? 0,
+    averageScore: data.averageScore,
+    averageScoreSampleSize: data.averageScoreSampleSize ?? 0,
+    currentStreakDays: data.currentStreakDays ?? 0,
+    totalPracticeTimeSeconds: data.totalPracticeTimeSeconds ?? 0,
+  };
+}

--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -1,56 +1,7 @@
-// Home API - Real backend integration with mock fallback
-
-import { apiRequest } from "@/shared/api/client";
 import { userApi } from "@/shared/api/userApi";
 import { getTimeBasedGreeting } from "@/shared/lib/format/greeting";
 
-const USE_MOCK = false; // Set to false when backend is ready
-
-// Backend response types
-interface BackendUser {
-  name?: string;
-  greeting?: string;
-  last_interview_days_ago?: number;
-}
-
-interface BackendStat {
-  icon?: string;
-  value?: number;
-  unit?: string;
-  label?: string;
-  delta?: string;
-  delta_type?: string;
-}
-
-interface BackendSession {
-  id?: string;
-  icon?: string;
-  company?: string;
-  badge_label?: string;
-  badge_type?: string;
-  role?: string;
-  round?: string;
-  date?: string;
-  score?: number;
-}
-
-interface BackendJob {
-  id?: string;
-  company?: string;
-  role?: string;
-  stage?: string;
-  dday?: number;
-  dot_color?: string;
-}
-
-interface BackendHomeData {
-  user?: BackendUser;
-  stats?: BackendStat[];
-  recent_sessions?: BackendSession[];
-  streak_data?: number[];
-  current_streak?: number;
-  jobs?: BackendJob[];
-}
+import { fetchDashboardStatisticsApi, type DashboardStatistics } from "./dashboardApi";
 
 export interface HomeUser {
   name: string;
@@ -63,8 +14,6 @@ export interface HomeStat {
   value: string | number;
   unit?: string;
   label: string;
-  delta: string;
-  deltaType: "up" | "down" | "neutral";
 }
 
 export interface HomeSession {
@@ -92,39 +41,32 @@ export interface HomeData {
   user: HomeUser;
   stats: HomeStat[];
   recentSessions: HomeSession[];
-  streakData: number[];       // 0~4 intensity, 28 cells
+  streakData: number[];
   currentStreak: number;
   jobs: HomeJob[];
 }
 
-// Mock data fallback
-function labelToIconKey(label: string): string {
-  if (label.includes("면접")) return "target";
-  if (label.includes("점수")) return "trending-up";
-  if (label.includes("스트릭")) return "flame";
-  if (label.includes("시간")) return "timer";
-  return "bar-chart";
-}
+const PLACEHOLDER_STATS: HomeStat[] = [
+  { icon: "target", value: 0, label: "총 면접 횟수" },
+  { icon: "trending-up", value: "-", unit: "점", label: "평균 점수" },
+  { icon: "flame", value: 0, unit: "일", label: "현재 스트릭" },
+  { icon: "timer", value: 0, unit: "h", label: "총 연습 시간" },
+];
 
 const MOCK_DATA: HomeData = {
   user: {
-    name: "김현준",
+    name: "사용자",
     greeting: getTimeBasedGreeting(),
-    lastInterviewDaysAgo: 2,
+    lastInterviewDaysAgo: 0,
   },
-  stats: [
-    { icon: "target",      value: 24,            label: "총 면접 횟수",  delta: "↑ 이번 주 +3",     deltaType: "up" },
-    { icon: "trending-up", value: 82, unit: "점", label: "평균 점수",     delta: "↑ 지난주 대비 +7", deltaType: "up" },
-    { icon: "flame",       value: 12, unit: "일", label: "현재 스트릭",   delta: "🏆 최장 기록!",     deltaType: "neutral" },
-    { icon: "timer",       value: 8,  unit: "h",  label: "총 연습 시간",  delta: "↓ 목표 -2h",        deltaType: "down" },
-  ],
+  stats: PLACEHOLDER_STATS,
   recentSessions: [
     { id: "s1", icon: "🏦", company: "카카오뱅크", badgeLabel: "꼬리질문",    badgeType: "accent",  role: "백엔드 개발자",    round: "1차 면접", date: "어제 오후 3:24",    score: 88 },
     { id: "s2", icon: "🛒", company: "쿠팡",       badgeLabel: "전체 프로세스", badgeType: "neutral", role: "서버 개발자",     round: "임원 면접", date: "3일 전 오전 11:10", score: 74 },
     { id: "s3", icon: "🟢", company: "네이버",     badgeLabel: "꼬리질문",    badgeType: "accent",  role: "플랫폼 개발",     round: "2차 면접", date: "5일 전 오후 7:45",   score: 79 },
   ],
   streakData: [0,0,1,0,2,1,0,3,2,1,3,4,0,0,3,4,4,3,2,1,4,4,3,0,0,1,2,3],
-  currentStreak: 12,
+  currentStreak: 0,
   jobs: [
     { id: "j1", company: "카카오뱅크", role: "백엔드 개발자",  stage: "1차 면접 준비 중", dday: 3,  dotColor: "cyan" },
     { id: "j2", company: "토스",       role: "서버 개발자",    stage: "서류 심사 중",     dday: 7,  dotColor: "dark" },
@@ -132,96 +74,78 @@ const MOCK_DATA: HomeData = {
   ],
 };
 
-/**
- * Fetch home dashboard data from backend
- * GET /api/v1/home/dashboard/
- */
+function formatPracticeTime(seconds: number): { value: number; unit: string } {
+  if (seconds <= 0) return { value: 0, unit: "h" };
+  if (seconds < 3600) {
+    return { value: Math.round(seconds / 60), unit: "분" };
+  }
+  return { value: Math.round((seconds / 3600) * 10) / 10, unit: "h" };
+}
+
+function buildStatsFromDashboard(stats: DashboardStatistics): HomeStat[] {
+  const practice = formatPracticeTime(stats.totalPracticeTimeSeconds);
+
+  return [
+    {
+      icon: "target",
+      value: stats.totalCompletedInterviews,
+      label: "총 면접 횟수",
+    },
+    {
+      icon: "trending-up",
+      value: stats.averageScore ?? "-",
+      unit: "점",
+      label: "평균 점수",
+    },
+    {
+      icon: "flame",
+      value: stats.currentStreakDays,
+      unit: "일",
+      label: "현재 스트릭",
+    },
+    {
+      icon: "timer",
+      value: practice.value,
+      unit: practice.unit,
+      label: "총 연습 시간",
+    },
+  ];
+}
+
 export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: HomeData; error?: string }> {
-  // Early return for mock mode
-  if (USE_MOCK) {
-    await new Promise((r) => setTimeout(r, 400));
-    
-    try {
-      const userData = await userApi.getMe();
-      return { 
-        success: true, 
-        data: {
-          ...MOCK_DATA,
-          user: {
-            ...MOCK_DATA.user,
-            name: userData.name || "사용자",
-          }
-        }
-      };
-    } catch (error) {
-      console.error("Failed to fetch user data in mock mode:", error);
-      return { success: true, data: MOCK_DATA };
-    }
+  let userName = MOCK_DATA.user.name;
+  let stats: HomeStat[] = PLACEHOLDER_STATS;
+  let currentStreak = 0;
+  let allSucceeded = true;
+  let errorMessage: string | undefined;
+
+  try {
+    const userData = await userApi.getMe();
+    userName = userData.name || MOCK_DATA.user.name;
+  } catch (error) {
+    console.error("Failed to fetch user data:", error);
+    allSucceeded = false;
+    errorMessage = error instanceof Error ? error.message : "사용자 정보를 불러오지 못했습니다.";
   }
 
-  // Real API mode
   try {
-    const data = await apiRequest<BackendHomeData>(
-      "/api/v1/home/dashboard/",
-      { method: "GET", auth: true }
-    );
-    
-    return {
-      success: true,
-      data: {
-        user: {
-          name: data.user?.name || "사용자",
-          greeting: data.user?.greeting || getTimeBasedGreeting(),
-          lastInterviewDaysAgo: data.user?.last_interview_days_ago ?? 0,
-        },
-        stats: (data.stats || []).map((stat) => ({
-          icon: labelToIconKey(stat.label || ""),
-          value: stat.value ?? 0,
-          unit: stat.unit,
-          label: stat.label || "",
-          delta: stat.delta || "",
-          deltaType: (stat.delta_type as "up" | "down" | "neutral") || "neutral",
-        })),
-        recentSessions: (data.recent_sessions || []).map((session) => ({
-          id: session.id || "",
-          icon: session.icon || "🏢",
-          company: session.company || "",
-          badgeLabel: session.badge_label || "",
-          badgeType: (session.badge_type as "accent" | "neutral") || "neutral",
-          role: session.role || "",
-          round: session.round || "",
-          date: session.date || "",
-          score: session.score ?? 0,
-        })),
-        streakData: data.streak_data || Array(28).fill(0),
-        currentStreak: data.current_streak ?? 0,
-        jobs: (data.jobs || []).map((job) => ({
-          id: job.id || "",
-          company: job.company || "",
-          role: job.role || "",
-          stage: job.stage || "",
-          dday: job.dday ?? 0,
-          dotColor: (job.dot_color as "cyan" | "dark" | "gray") || "gray",
-        })),
-      },
-    };
+    const dashboardStats = await fetchDashboardStatisticsApi();
+    stats = buildStatsFromDashboard(dashboardStats);
+    currentStreak = dashboardStats.currentStreakDays;
   } catch (error) {
-    console.error("Failed to fetch home data:", error);
-    // API 미구현(404 등) 시 mock 데이터로 fallback, 실제 유저 이름 반영
-    // success: false + fallback 데이터를 함께 반환해 호출부에서 에러 여부를 구분할 수 있도록 함
-    try {
-      const userData = await userApi.getMe();
-      return {
-        success: false,
-        data: { ...MOCK_DATA, user: { ...MOCK_DATA.user, name: userData.name || "사용자" } },
-        error: error instanceof Error ? error.message : "홈 데이터를 불러오지 못했습니다.",
-      };
-    } catch {
-      return {
-        success: false,
-        data: MOCK_DATA,
-        error: error instanceof Error ? error.message : "홈 데이터를 불러오지 못했습니다.",
-      };
-    }
+    console.error("Failed to fetch dashboard statistics:", error);
+    allSucceeded = false;
+    errorMessage = error instanceof Error ? error.message : "대시보드 통계를 불러오지 못했습니다.";
   }
+
+  return {
+    success: allSucceeded,
+    data: {
+      ...MOCK_DATA,
+      user: { ...MOCK_DATA.user, name: userName },
+      stats,
+      currentStreak,
+    },
+    error: errorMessage,
+  };
 }

--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -116,16 +116,14 @@ export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: Hom
   let userName = MOCK_DATA.user.name;
   let stats: HomeStat[] = PLACEHOLDER_STATS;
   let currentStreak = 0;
-  let allSucceeded = true;
-  let errorMessage: string | undefined;
+  const errorMessages: string[] = [];
 
   try {
     const userData = await userApi.getMe();
     userName = userData.name || MOCK_DATA.user.name;
   } catch (error) {
     console.error("Failed to fetch user data:", error);
-    allSucceeded = false;
-    errorMessage = error instanceof Error ? error.message : "사용자 정보를 불러오지 못했습니다.";
+    errorMessages.push(error instanceof Error ? error.message : "사용자 정보를 불러오지 못했습니다.");
   }
 
   try {
@@ -134,18 +132,17 @@ export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: Hom
     currentStreak = dashboardStats.currentStreakDays;
   } catch (error) {
     console.error("Failed to fetch dashboard statistics:", error);
-    allSucceeded = false;
-    errorMessage = error instanceof Error ? error.message : "대시보드 통계를 불러오지 못했습니다.";
+    errorMessages.push(error instanceof Error ? error.message : "대시보드 통계를 불러오지 못했습니다.");
   }
 
   return {
-    success: allSucceeded,
+    success: errorMessages.length === 0,
     data: {
       ...MOCK_DATA,
       user: { ...MOCK_DATA.user, name: userName },
       stats,
       currentStreak,
     },
-    error: errorMessage,
+    error: errorMessages.length > 0 ? errorMessages.join(" / ") : undefined,
   };
 }

--- a/src/pages/home/ui/components/StatsGrid.tsx
+++ b/src/pages/home/ui/components/StatsGrid.tsx
@@ -29,21 +29,10 @@ export function StatsGrid({ stats, revealed }: StatsGridProps) {
           <div className="hp-stat-num">
             {stat.value}
             {stat.unit && (
-              <small style={{ fontSize: 14, opacity: 0.5 }}>{stat.unit}</small>
+              <small style={{ fontSize: 14, opacity: 0.5, marginLeft: 6 }}>{stat.unit}</small>
             )}
           </div>
           <div className="hp-stat-label">{stat.label}</div>
-          <span
-            className={`hp-stat-delta ${
-              stat.deltaType === "up"
-                ? "hp-delta-up"
-                : stat.deltaType === "down"
-                ? "hp-delta-dn"
-                : "hp-delta-neutral"
-            }`}
-          >
-            {stat.delta}
-          </span>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## 관련 이슈
Closes #(이슈 번호)

## 변경 사항
- `features/home/api/dashboardApi.ts` 신설 — 백엔드 `GET /api/v1/dashboard/statistics/` 호출 함수 + 응답 타입 정의 (camelCase)
- `features/home/api/homeApi.ts` 재작성
  - 미사용 `BackendHomeData/Stat/Session/Job` 인터페이스 및 `USE_MOCK` 분기 제거
  - 사용자 정보(`/api/v1/users/me/`) + 대시보드 통계 두 API만 실제 호출, 나머지(recent_sessions/streak/jobs)는 placeholder 유지
  - 4개 통계를 실제 API 응답으로 변환(`buildStatsFromDashboard`), 연습 시간은 1시간 기준으로 분/시간 단위 자동 분기 표시(`formatPracticeTime`)
  - 평균 점수가 `null` 일 때 `- 점` 으로 표시 (ASCII hyphen + 단위 유지)
- `pages/home/ui/components/StatsGrid.tsx`
  - 숫자와 단위 사이 간격 추가 (`marginLeft: 6`)
  - label 아래 `delta` 영역 (`hp-stat-delta` span) 전체 제거
- `HomeStat` 인터페이스에서 `delta`, `deltaType` 필드 제거 → 가상 데이터 노출 방지

## 변경 유형
- [x] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)

## 테스트 방법
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome

테스트 시나리오:
1. 로그인 후 `/` 진입 → 4개 통계 카드(총 면접 횟수 / 평균 점수 / 현재 스트릭 / 총 연습 시간)가 실제 백엔드 값으로 표시되는지 확인
2. 면접 데이터 없는 신규 사용자 → `0`, `- 점` placeholder 정상 표시
3. 백엔드 API 실패 → placeholder fallback 표시 + 콘솔 에러 로그
4. 단위 표시 확인: `9`, `46 점`, `0 일`, `18 분` 또는 `4.1 h`

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다 (FSD, camelCase, `apiRequest` 사용)
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다 (자기설명적 코드 위주)
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다 (`bunx tsc --noEmit` EXIT=0)
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다 (수동 테스트만 진행)
- [x] 반응형 디자인을 확인했습니다 (StatsGrid 레이아웃 동일)
- [x] 브라우저 호환성을 확인했습니다 (Chrome)
- [x] 접근성 가이드라인을 준수했습니다 (기존 마크업 유지)

## 스크린샷
### Before
<!-- 4개 카드에 가상 delta 텍스트("↑ 이번 주 +3", "↓ 목표 -2h" 등) 표시되던 화면 -->

### After
<!-- 실제 통계 값 + label 아래 delta 영역이 제거된 깔끔한 카드 -->

## 추가 정보
- **백엔드 의존성**: `kmu-aws-capstone-team-4/backend` 의 `feature/dashboard-statistics-api` PR 머지/배포 후 정상 동작.
- 다른 홈 데이터(최근 면접 / 스트릭 캘린더 / 지원 현황)는 별도 작업 범위라 mock 유지. 단 `currentStreak` 은 dashboard API 응답으로 갱신.
- 백엔드 응답이 DRF `CamelCaseJSONRenderer` 로 camelCase 직렬화되므로 `dashboardApi.ts` 도 camelCase 인터페이스로 정의 (`streakApi.ts` 패턴과 일치).