### PR TITLE
[144] 자잘한 수정

### DIFF
--- a/src/features/auth/model/store.ts
+++ b/src/features/auth/model/store.ts
@@ -12,6 +12,15 @@ import {
   getAccessToken,
   refreshAccessToken,
 } from "@/shared/api/client";
+import { profileApi } from "@/shared/api/profileApi";
+
+function fetchAndSetAvatar(set: (partial: object) => void) {
+  profileApi.getAvatar().then((avatar) => {
+    if (avatar?.avatarUrl) {
+      set((s: { user: UserMe | null }) => s.user ? { user: { ...s.user, avatarUrl: avatar.avatarUrl } } : {});
+    }
+  }).catch(() => {});
+}
 
 interface LoginResult {
   success: boolean;
@@ -77,6 +86,7 @@ export const useAuthStore = create<AuthState>()((set) => ({
     // 로그인 성공 시 사용자 정보 즉시 조회 (isProfileCompleted, isEmailConfirmed 확인)
     const me = await getMeApi();
     set({ isLoading: false, pendingEmail: email, user: me });
+    if (me) fetchAndSetAvatar(set);
     return {
       success: true,
       isEmailConfirmed: me?.isEmailConfirmed ?? res.isEmailConfirmed,
@@ -140,6 +150,7 @@ export const useAuthStore = create<AuthState>()((set) => ({
 
     const me = await getMeApi({ noRetry: true });
     set({ user: me ?? null, authReady: true });
+    if (me) fetchAndSetAvatar(set);
   },
 
   setPendingEmail: (email) => set({ pendingEmail: email }),

--- a/src/features/home/api/dashboardApi.ts
+++ b/src/features/home/api/dashboardApi.ts
@@ -6,6 +6,7 @@ export interface DashboardStatistics {
   averageScoreSampleSize: number;
   currentStreakDays: number;
   totalPracticeTimeSeconds: number;
+  lastParticipatedDate: string | null;
 }
 
 export async function fetchDashboardStatisticsApi(): Promise<DashboardStatistics> {
@@ -20,5 +21,6 @@ export async function fetchDashboardStatisticsApi(): Promise<DashboardStatistics
     averageScoreSampleSize: data.averageScoreSampleSize ?? 0,
     currentStreakDays: data.currentStreakDays ?? 0,
     totalPracticeTimeSeconds: data.totalPracticeTimeSeconds ?? 0,
+    lastParticipatedDate: data.lastParticipatedDate ?? null,
   };
 }

--- a/src/features/home/api/dashboardApi.ts
+++ b/src/features/home/api/dashboardApi.ts
@@ -10,17 +10,17 @@ export interface DashboardStatistics {
 }
 
 export async function fetchDashboardStatisticsApi(): Promise<DashboardStatistics> {
-  const data = await apiRequest<DashboardStatistics>(
+  const data = await apiRequest<Record<string, unknown>>(
     "/api/v1/dashboard/statistics/",
     { method: "GET", auth: true },
   );
 
   return {
-    totalCompletedInterviews: data.totalCompletedInterviews ?? 0,
-    averageScore: data.averageScore ?? null,
-    averageScoreSampleSize: data.averageScoreSampleSize ?? 0,
-    currentStreakDays: data.currentStreakDays ?? 0,
-    totalPracticeTimeSeconds: data.totalPracticeTimeSeconds ?? 0,
-    lastParticipatedDate: data.lastParticipatedDate ?? null,
+    totalCompletedInterviews: (data.totalCompletedInterviews ?? data.total_completed_interviews ?? 0) as number,
+    averageScore: (data.averageScore ?? data.average_score ?? null) as number | null,
+    averageScoreSampleSize: (data.averageScoreSampleSize ?? data.average_score_sample_size ?? 0) as number,
+    currentStreakDays: (data.currentStreakDays ?? data.current_streak_days ?? 0) as number,
+    totalPracticeTimeSeconds: (data.totalPracticeTimeSeconds ?? data.total_practice_time_seconds ?? 0) as number,
+    lastParticipatedDate: (data.lastParticipatedDate ?? data.last_participated_date ?? null) as string | null,
   };
 }

--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -82,6 +82,12 @@ function formatPracticeTime(seconds: number): { value: number; unit: string } {
   return { value: Math.round((seconds / 3600) * 10) / 10, unit: "h" };
 }
 
+function calcDaysAgo(dateStr: string | null): number {
+  if (!dateStr) return 0;
+  const diff = Date.now() - new Date(dateStr).getTime();
+  return Math.max(0, Math.floor(diff / (1000 * 60 * 60 * 24)));
+}
+
 function buildStatsFromDashboard(stats: DashboardStatistics): HomeStat[] {
   const practice = formatPracticeTime(stats.totalPracticeTimeSeconds);
 
@@ -116,6 +122,7 @@ export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: Hom
   let userName = MOCK_DATA.user.name;
   let stats: HomeStat[] = PLACEHOLDER_STATS;
   let currentStreak = 0;
+  let lastInterviewDaysAgo = 0;
   const errorMessages: string[] = [];
 
   try {
@@ -130,6 +137,7 @@ export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: Hom
     const dashboardStats = await fetchDashboardStatisticsApi();
     stats = buildStatsFromDashboard(dashboardStats);
     currentStreak = dashboardStats.currentStreakDays;
+    lastInterviewDaysAgo = calcDaysAgo(dashboardStats.lastParticipatedDate);
   } catch (error) {
     console.error("Failed to fetch dashboard statistics:", error);
     errorMessages.push(error instanceof Error ? error.message : "대시보드 통계를 불러오지 못했습니다.");
@@ -139,7 +147,7 @@ export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: Hom
     success: errorMessages.length === 0,
     data: {
       ...MOCK_DATA,
-      user: { ...MOCK_DATA.user, name: userName },
+      user: { ...MOCK_DATA.user, name: userName, lastInterviewDaysAgo },
       stats,
       currentStreak,
     },

--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -6,7 +6,7 @@ import { fetchDashboardStatisticsApi, type DashboardStatistics } from "./dashboa
 export interface HomeUser {
   name: string;
   greeting: string;
-  lastInterviewDaysAgo: number;
+  lastInterviewDaysAgo: number | null;
 }
 
 export interface HomeStat {
@@ -82,8 +82,8 @@ function formatPracticeTime(seconds: number): { value: number; unit: string } {
   return { value: Math.round((seconds / 3600) * 10) / 10, unit: "h" };
 }
 
-function calcDaysAgo(dateStr: string | null): number {
-  if (!dateStr) return 0;
+function calcDaysAgo(dateStr: string | null): number | null {
+  if (!dateStr) return null;
   const diff = Date.now() - new Date(dateStr).getTime();
   return Math.max(0, Math.floor(diff / (1000 * 60 * 60 * 24)));
 }

--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -122,7 +122,7 @@ export async function fetchHomeDataApi(): Promise<{ success: boolean; data?: Hom
   let userName = MOCK_DATA.user.name;
   let stats: HomeStat[] = PLACEHOLDER_STATS;
   let currentStreak = 0;
-  let lastInterviewDaysAgo = 0;
+  let lastInterviewDaysAgo: number | null = null;
   const errorMessages: string[] = [];
 
   try {

--- a/src/features/interview-session/api/interviewApi.ts
+++ b/src/features/interview-session/api/interviewApi.ts
@@ -54,8 +54,11 @@ export const interviewApi = {
       auth: true,
     }),
 
-  getMyInterviews: (page = 1) =>
-    apiRequest<PaginatedResponse<InterviewSessionListItem>>(`/api/v1/interviews/interview-sessions/?page=${page}`, { auth: true }),
+  getMyInterviews: (page = 1, status?: string) => {
+    const params = new URLSearchParams({ page: String(page) });
+    if (status) params.set("status", status);
+    return apiRequest<PaginatedResponse<InterviewSessionListItem>>(`/api/v1/interviews/interview-sessions/?${params}`, { auth: true });
+  },
 
   generateReport: (interviewSessionUuid: string) =>
     apiRequest<InterviewAnalysisReport>(`${BASE}/${interviewSessionUuid}/generate-report/`, {

--- a/src/features/jd/model/store.ts
+++ b/src/features/jd/model/store.ts
@@ -38,8 +38,12 @@ interface JdAddState {
   clearError: () => void;
   /** 성공 시 생성된 UserJobDescription.uuid 반환. 실패 시 null. */
   submit: () => Promise<string | null>;
-  /** 임시저장 — 아직 backend 엔드포인트가 없어 no-op 성공으로 둔다. */
+  /** 임시저장 — localStorage에 저장. */
   saveDraft: () => Promise<boolean>;
+  /** localStorage 임시저장 복원. */
+  loadDraft: () => boolean;
+  /** localStorage 임시저장 삭제 후 reset. */
+  clearDraft: () => void;
   reset: () => void;
 }
 
@@ -128,12 +132,36 @@ export const useJdAddStore = create<JdAddState>()((set, get) => ({
     }
   },
 
-  // 임시저장 기능은 backend 에 아직 없음. 로컬 성공으로만 처리.
   saveDraft: async () => {
+    const { url, customTitle, status } = get();
     set({ isSaving: true, error: null });
-    await new Promise((r) => setTimeout(r, 120));
-    set({ isSaving: false });
-    return true;
+    try {
+      localStorage.setItem("jd_draft", JSON.stringify({ url, customTitle, status }));
+      await new Promise((r) => setTimeout(r, 120));
+      set({ isSaving: false });
+      return true;
+    } catch {
+      set({ isSaving: false });
+      return false;
+    }
+  },
+
+  loadDraft: () => {
+    try {
+      const raw = localStorage.getItem("jd_draft");
+      if (!raw) return false;
+      const { url, customTitle, status } = JSON.parse(raw) as { url: string; customTitle: string; status: JdStatus };
+      get().setUrl(url);
+      set({ customTitle, status });
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  clearDraft: () => {
+    localStorage.removeItem("jd_draft");
+    set(INITIAL);
   },
 
   reset: () => set(INITIAL),

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -161,8 +161,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   toggleJobId: (jobId) => {
     set((s) => {
       const ids = s.profileDraft.jobIds;
-      const next = ids.includes(jobId) ? ids.filter((id) => id !== jobId) : [...ids, jobId];
-      return { profileDraft: { ...s.profileDraft, jobIds: next } };
+      if (ids.includes(jobId)) {
+        return { profileDraft: { ...s.profileDraft, jobIds: ids.filter((id) => id !== jobId) } };
+      }
+      if (ids.length >= 3) return s;
+      return { profileDraft: { ...s.profileDraft, jobIds: [...ids, jobId] } };
     });
   },
 

--- a/src/features/streak/api/streakApi.ts
+++ b/src/features/streak/api/streakApi.ts
@@ -32,8 +32,8 @@ export interface StreakData {
   totalDays: number;
   rewardsCount: number;
   todayCompleted: boolean;
-  /** key: "YYYY-M", value: array of completed day numbers */
-  calendarDoneMap: Record<string, number[]>;
+  /** key: "YYYY-M", value: { day: interviewCount } */
+  calendarDoneMap: Record<string, Record<number, number>>;
   nextReward: StreakNextReward;
   milestones: StreakMilestone[];
   rewardHistory: StreakRewardHistory[];
@@ -59,14 +59,14 @@ interface StreakLogEntry {
 }
 
 /* ── Helpers ── */
-function buildCalendarDoneMap(logs: StreakLogEntry[]): Record<string, number[]> {
-  const map: Record<string, number[]> = {};
+function buildCalendarDoneMap(logs: StreakLogEntry[]): Record<string, Record<number, number>> {
+  const map: Record<string, Record<number, number>> = {};
   for (const log of logs) {
     if (log.interviewResultsCount < 1) continue;
     const [year, month, day] = log.date.split("-").map(Number);
     const key = `${year}-${month}`;
-    if (!map[key]) map[key] = [];
-    map[key].push(day);
+    if (!map[key]) map[key] = {};
+    map[key][day] = log.interviewResultsCount;
   }
   return map;
 }

--- a/src/pages/home/ui/HomeContent.tsx
+++ b/src/pages/home/ui/HomeContent.tsx
@@ -53,7 +53,7 @@ export function HomeContent() {
 
           <StatsGrid stats={data.stats} revealed={revealed} />
 
-          <RecentSessions sessions={data.recentSessions} revealed={revealed} />
+          <RecentSessions revealed={revealed} />
 
           {streakData && (
             <div className="hp-streak-wrapper">

--- a/src/pages/home/ui/components/HomeHeader.tsx
+++ b/src/pages/home/ui/components/HomeHeader.tsx
@@ -1,19 +1,23 @@
 interface HomeHeaderProps {
   greeting: string;
   userName: string;
-  lastInterviewDaysAgo: number;
+  lastInterviewDaysAgo: number | null;
 }
 
 export function HomeHeader({ greeting, userName, lastInterviewDaysAgo }: HomeHeaderProps) {
+  const subText = lastInterviewDaysAgo === null
+    ? "아직 면접 기록이 없어요. 첫 면접을 시작해보세요!"
+    : lastInterviewDaysAgo === 0
+      ? "오늘 면접을 진행했어요. 스트릭을 이어가세요!"
+      : `마지막 면접으로부터 ${lastInterviewDaysAgo}일이 지났어요. 스트릭을 이어가세요!`;
+
   return (
     <div className="hp-header">
       <div className="hp-eyebrow">{greeting}</div>
       <h1 className="hp-title">
         안녕하세요, {userName} 님.<br />오늘도 핏을 맞춰볼까요?
       </h1>
-      <p className="hp-sub">
-        마지막 면접으로부터 {lastInterviewDaysAgo}일이 지났어요. 스트릭을 이어가세요!
-      </p>
+      <p className="hp-sub">{subText}</p>
     </div>
   );
 }

--- a/src/pages/home/ui/components/HomeNavbar.tsx
+++ b/src/pages/home/ui/components/HomeNavbar.tsx
@@ -15,6 +15,7 @@ interface HomeNavbarProps {
 export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
   const navigate = useNavigate();
   const { user, logout } = useAuthStore();
+  const avatarUrl = user?.avatarUrl;
   const { notifications, markAllRead, markRead } = useNotificationStore();
   const unreadCount = notifications.filter((n) => !n.isRead).length;
   const { tickets } = useTicketCount();
@@ -152,8 +153,8 @@ export function HomeNavbar({ menuOpen, onMenuToggle }: HomeNavbarProps) {
           aria-label="프로필 메뉴"
         >
           <div className="w-8 h-8 rounded-full bg-gradient-to-br from-[#0991B2] to-[#06B6D4] flex items-center justify-center text-white text-sm font-bold overflow-hidden">
-            {user?.avatarUrl ? (
-              <img src={user.avatarUrl} alt="프로필" className="w-full h-full object-cover" />
+            {avatarUrl ? (
+              <img src={avatarUrl} alt="프로필" className="w-full h-full object-cover" />
             ) : (
               user?.name?.[0]?.toUpperCase() || "U"
             )}

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -1,12 +1,46 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import type { HomeSession } from "@/features/home/api/homeApi";
+import { interviewApi } from "@/features/interview-session";
+import type { InterviewSessionListItem } from "@/features/interview-session";
+
+const SESSION_TYPE_LABEL: Record<string, string> = {
+  followup: "꼬리질문",
+  full_process: "전체 프로세스",
+};
+
+const DIFFICULTY_LABEL: Record<string, string> = {
+  friendly: "편안한",
+  normal: "일반",
+  pressure: "압박",
+};
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return "오늘";
+  if (diffDays === 1) return "어제";
+  if (diffDays < 7) return `${diffDays}일 전`;
+  return date.toLocaleDateString("ko-KR", { month: "short", day: "numeric" });
+}
 
 interface RecentSessionsProps {
-  sessions: HomeSession[];
   revealed: boolean;
 }
 
-export function RecentSessions({ sessions, revealed }: RecentSessionsProps) {
+export function RecentSessions({ revealed }: RecentSessionsProps) {
+  const [sessions, setSessions] = useState<InterviewSessionListItem[]>([]);
+
+  useEffect(() => {
+    interviewApi.getMyInterviews(1).then((data) => {
+      const completed = data.results
+        .filter((s) => s.interviewSessionStatus === "completed")
+        .slice(0, 3);
+      setSessions(completed);
+    }).catch(() => {});
+  }, []);
+
   return (
     <>
       <div className={`hp-sec-head hp-rv${revealed ? " hp-rv-in" : ""}`} style={{ transitionDelay: "275ms" }}>
@@ -14,34 +48,30 @@ export function RecentSessions({ sessions, revealed }: RecentSessionsProps) {
         <Link to="/interview/results" className="hp-sec-link">전체 보기 →</Link>
       </div>
       <div className="hp-session-list">
-        {sessions.map((session, i) => (
-          <Link
-            key={session.id}
-            to={`/interview/review/${session.id}`}
-            className={`hp-session-item hp-rv${revealed ? " hp-rv-in" : ""}`}
-            style={{ transitionDelay: `${330 + i * 55}ms` }}
-          >
-            <div className="hp-si-icon">{session.icon}</div>
-            <div className="hp-si-body">
-              <div className="hp-si-company">
-                {session.company}
-                <span
-                  className={`hp-badge${session.badgeType === "neutral" ? " hp-badge-neutral" : ""}`}
-                  style={{ fontSize: 10 }}
-                >
-                  {session.badgeLabel}
-                </span>
+        {sessions.length === 0 ? (
+          <p className="text-[13px] text-[#9CA3AF] py-2">아직 완료된 면접이 없어요</p>
+        ) : (
+          sessions.map((session, i) => (
+            <Link
+              key={session.uuid}
+              to={`/interview/session/${session.uuid}/report`}
+              className={`hp-session-item hp-rv${revealed ? " hp-rv-in" : ""}`}
+              style={{ transitionDelay: `${330 + i * 55}ms` }}
+            >
+              <div className="hp-si-body">
+                <div className="hp-si-company">
+                  {session.jobDescriptionLabel}
+                  <span className="hp-badge" style={{ fontSize: 10 }}>
+                    {SESSION_TYPE_LABEL[session.interviewSessionType] ?? session.interviewSessionType}
+                  </span>
+                </div>
+                <div className="hp-si-meta">
+                  {session.resumeTitle} · {DIFFICULTY_LABEL[session.interviewDifficultyLevel] ?? session.interviewDifficultyLevel} · {formatDate(session.createdAt)}
+                </div>
               </div>
-              <div className="hp-si-meta">
-                {session.role} · {session.round} · {session.date}
-              </div>
-            </div>
-            <div className="hp-si-score">
-              <div className="hp-si-num">{session.score}</div>
-              <div className="hp-si-num-label">종합 점수</div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          ))
+        )}
       </div>
     </>
   );

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { BarChart2, ClipboardList } from "lucide-react";
 import { interviewApi } from "@/features/interview-session";
 import type { InterviewSessionListItem } from "@/features/interview-session";
 
@@ -58,6 +59,11 @@ export function RecentSessions({ revealed }: RecentSessionsProps) {
               className={`hp-session-item hp-rv${revealed ? " hp-rv-in" : ""}`}
               style={{ transitionDelay: `${330 + i * 55}ms` }}
             >
+              <div className="w-9 h-9 rounded-lg bg-white border border-[#E5E7EB] flex items-center justify-center shrink-0">
+                {session.reportStatus === "completed"
+                  ? <BarChart2 size={16} className="text-[#0991B2]" />
+                  : <ClipboardList size={16} className="text-[#9CA3AF]" />}
+              </div>
               <div className="hp-si-body">
                 <div className="hp-si-company">
                   {session.jobDescriptionLabel}

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -32,14 +32,12 @@ interface RecentSessionsProps {
 
 export function RecentSessions({ revealed }: RecentSessionsProps) {
   const [sessions, setSessions] = useState<InterviewSessionListItem[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    interviewApi.getMyInterviews(1).then((data) => {
-      const completed = data.results
-        .filter((s) => s.interviewSessionStatus === "completed")
-        .slice(0, 3);
-      setSessions(completed);
-    }).catch(() => {});
+    interviewApi.getMyInterviews(1, "completed").then((data) => {
+      setSessions(data.results.filter((s) => s.interviewSessionStatus === "completed").slice(0, 3));
+    }).catch(() => {}).finally(() => setLoading(false));
   }, []);
 
   return (
@@ -49,7 +47,13 @@ export function RecentSessions({ revealed }: RecentSessionsProps) {
         <Link to="/interview/results" className="hp-sec-link">전체 보기 →</Link>
       </div>
       <div className="hp-session-list">
-        {sessions.length === 0 ? (
+        {loading ? (
+          <div className="flex flex-col gap-2">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="h-[52px] rounded-lg bg-[#F3F4F6] animate-pulse" />
+            ))}
+          </div>
+        ) : sessions.length === 0 ? (
           <p className="text-[13px] text-[#9CA3AF] py-2">아직 완료된 면접이 없어요</p>
         ) : (
           sessions.map((session, i) => (

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -35,7 +35,7 @@ export function RecentSessions({ revealed }: RecentSessionsProps) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    interviewApi.getMyInterviews(1, "completed").then((data) => {
+    interviewApi.getMyInterviews(1).then((data) => {
       setSessions(data.results.filter((s) => s.interviewSessionStatus === "completed").slice(0, 3));
     }).catch(() => {}).finally(() => setLoading(false));
   }, []);

--- a/src/pages/home/ui/components/SettingsSidebar.tsx
+++ b/src/pages/home/ui/components/SettingsSidebar.tsx
@@ -26,9 +26,13 @@ export function SettingsSidebar({ menuOpen }: SettingsSidebarProps) {
     <aside className={cls}>
       {/* 유저 프로필 카드 */}
       <div className="bg-[#0A0A0A] rounded-lg px-4 py-[14px] mb-4 flex items-center gap-[10px]">
-        <div className="w-9 h-9 rounded-full bg-[#0991B2] flex items-center justify-center font-black text-[14px] text-white shrink-0">
-          {(data?.profile.avatarInitial ?? user?.name?.[0] ?? "U").toUpperCase()}
-        </div>
+        {user?.avatarUrl ? (
+          <img src={user.avatarUrl} alt="프로필" className="w-9 h-9 rounded-full object-cover shrink-0" />
+        ) : (
+          <div className="w-9 h-9 rounded-full bg-[#0991B2] flex items-center justify-center font-black text-[14px] text-white shrink-0">
+            {(data?.profile.avatarInitial ?? user?.name?.[0] ?? "U").toUpperCase()}
+          </div>
+        )}
         <div className="min-w-0">
           <div className="font-plex-sans-kr text-[13px] font-extrabold text-white truncate">
             {data?.profile.name ?? user?.name ?? "사용자"}

--- a/src/pages/home/ui/components/SettingsSidebar.tsx
+++ b/src/pages/home/ui/components/SettingsSidebar.tsx
@@ -51,7 +51,7 @@ export function SettingsSidebar({ menuOpen }: SettingsSidebarProps) {
           className={`hp-sb-item w-full text-left border-none bg-transparent${location.pathname === "/settings" && activePanel === item.key ? " active" : ""}`}
           onClick={() => {
             setActivePanel(item.key);
-            if (location.pathname !== "/settings") navigate("/settings");
+            navigate(`/settings?panel=${item.key}`);
           }}
         >
           <span className="hp-sb-icon">{item.icon}</span>
@@ -66,7 +66,7 @@ export function SettingsSidebar({ menuOpen }: SettingsSidebarProps) {
       <div className="hp-sb-sep">알림</div>
       <button
         className={`hp-sb-item w-full text-left border-none bg-transparent${location.pathname === "/settings" && activePanel === "notifications" ? " active" : ""}`}
-        onClick={() => { setActivePanel("notifications"); if (location.pathname !== "/settings") navigate("/settings"); }}
+        onClick={() => { setActivePanel("notifications"); navigate("/settings?panel=notifications"); }}
       >
         <span className="hp-sb-icon"><Bell size={18} /></span>알림 설정
       </button>

--- a/src/pages/interview-results/ui/InterviewResultsPage.tsx
+++ b/src/pages/interview-results/ui/InterviewResultsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus, BarChart2 } from "lucide-react";
 import { interviewApi } from "@/features/interview-session";
 import type { InterviewSessionListItem, InterviewAnalysisReportStatus } from "@/features/interview-session";
 import { Pagination } from "@/shared/ui/Pagination";
@@ -78,7 +78,7 @@ export function InterviewResultsPage() {
       <div className="w-full px-8 pt-[28px] pb-[60px] max-sm:px-4 max-sm:pt-5">
       {/* Header */}
       <div className="mb-8">
-        <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">📊 분석</div>
+        <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5"><BarChart2 size={12} /> 분석</div>
         <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">면접 결과</h1>
         <p className="text-sm text-[#6B7280] mt-1.5">
           지금까지 진행한 면접 세션과 분석 리포트를 확인하세요.

--- a/src/pages/interview-results/ui/SessionCard.tsx
+++ b/src/pages/interview-results/ui/SessionCard.tsx
@@ -1,4 +1,4 @@
-import { Loader2, FileText, Plus, ChevronRight, Play } from "lucide-react";
+import { Loader2, FileText, Plus, ChevronRight, Play, Mic, BarChart2, ClipboardList } from "lucide-react";
 import { SESSION_TYPE_LABEL, DIFFICULTY_LABEL, REPORT_STATUS_BADGE } from "@/features/interview-session";
 import type { InterviewSessionListItem } from "@/features/interview-session";
 import { formatDateTime } from "@/shared/lib/format/date";
@@ -24,8 +24,12 @@ export function SessionCard({ session: s, isGenerating, onContinue, onViewReport
       }`}
     >
       <div className="flex items-start gap-3">
-        <div className="w-10 h-10 rounded-lg bg-white border border-[#E5E7EB] flex items-center justify-center text-lg shrink-0">
-          {isInProgress ? "🎙️" : hasReport ? "📊" : "🗒️"}
+        <div className="w-10 h-10 rounded-lg bg-white border border-[#E5E7EB] flex items-center justify-center shrink-0">
+          {isInProgress
+            ? <Mic size={18} className="text-[#D97706]" />
+            : hasReport
+              ? <BarChart2 size={18} className="text-[#0991B2]" />
+              : <ClipboardList size={18} className="text-[#9CA3AF]" />}
         </div>
 
         <div className="flex-1 min-w-0">

--- a/src/pages/interview-results/ui/SessionCard.tsx
+++ b/src/pages/interview-results/ui/SessionCard.tsx
@@ -73,7 +73,7 @@ export function SessionCard({ session: s, isGenerating, onContinue, onViewReport
 
         <div className="shrink-0 flex items-center gap-2">
           {isInProgress ? (
-            <button onClick={() => onContinue(s.uuid)} className="flex items-center gap-1 text-[12px] font-bold text-white bg-[#0991B2] rounded-lg px-3 py-1.5 hover:opacity-85 transition-opacity">
+            <button onClick={() => onContinue(s.uuid)} className="flex items-center gap-1 text-[12px] font-bold text-white bg-[#0A0A0A] rounded-lg px-3 py-1.5 hover:opacity-85 transition-opacity">
               <Play size={12} /> 이어서 진행
             </button>
           ) : hasReport ? (

--- a/src/pages/interview-setup/ui/InterviewSetupPage.tsx
+++ b/src/pages/interview-setup/ui/InterviewSetupPage.tsx
@@ -78,11 +78,6 @@ export function InterviewSetupPage() {
           <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">▶ 면접 시작</div>
           <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">가상 면접 설정</h1>
           <p className="text-sm text-[#6B7280] mt-1.5">채용공고와 면접 방식을 선택하고 맞춤 가상 면접을 시작하세요.</p>
-          {preferredJdNotice && (
-            <div className="mt-3 rounded-lg border border-[#FED7AA] bg-[#FFF7ED] px-3 py-2 text-[12px] text-[#9A3412]">
-              {preferredJdNotice}
-            </div>
-          )}
         </div>
 
         {/* ══════ STEP 1: 지원 컨텍스트 ══════ */}
@@ -110,6 +105,7 @@ export function InterviewSetupPage() {
                     jdListLoading={jdListLoading}
                     selectedJdId={selectedJdId}
                     onSelectJd={selectJd}
+                    notice={preferredJdNotice}
                   />
                 </div>
               }

--- a/src/pages/interview-setup/ui/JdSavedTab.tsx
+++ b/src/pages/interview-setup/ui/JdSavedTab.tsx
@@ -22,6 +22,14 @@ interface JdSavedTabProps {
 export function JdSavedTab({ jdList, jdListLoading, selectedJdId, onSelectJd }: JdSavedTabProps) {
   if (jdListLoading) return <div className="p-4 text-center text-[13px] text-[#9CA3AF]">불러오는 중...</div>;
 
+  if (jdList.length === 0) {
+    return (
+      <div className="p-4 text-center text-[13px] text-[#6B7280] border border-dashed border-[#E5E7EB] rounded-lg">
+        등록된 채용공고가 없어요. 먼저 채용공고를 업로드해 주세요.
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-[7px] flex-1 overflow-y-auto min-h-0">
       {jdList.map((jd) => (

--- a/src/pages/interview-setup/ui/JdSection.tsx
+++ b/src/pages/interview-setup/ui/JdSection.tsx
@@ -17,9 +17,10 @@ interface JdSectionProps {
   jdListLoading: boolean;
   selectedJdId: string | null;
   onSelectJd: (uuid: string) => void;
+  notice?: string | null;
 }
 
-export function JdSection({ jdList, jdListLoading, selectedJdId, onSelectJd }: JdSectionProps) {
+export function JdSection({ jdList, jdListLoading, selectedJdId, onSelectJd, notice }: JdSectionProps) {
   return (
     <SetupSection
       eyebrow="채용공고"
@@ -27,6 +28,9 @@ export function JdSection({ jdList, jdListLoading, selectedJdId, onSelectJd }: J
       description="등록된 채용공고 중 면접에 사용할 항목을 선택하세요."
       className="flex-1 min-h-0"
     >
+      {notice && (
+        <div className="mb-2.5 p-2.5 rounded-lg border border-[#FECACA] bg-[#FEF2F2] text-[12px] text-[#B91C1C]">{notice}</div>
+      )}
       <JdSavedTab
         jdList={jdList}
         jdListLoading={jdListLoading}

--- a/src/pages/jd-add/ui/JdAddPage.tsx
+++ b/src/pages/jd-add/ui/JdAddPage.tsx
@@ -149,7 +149,7 @@ export function JdAddPage() {
                   label="내 식별 제목 (선택)"
                   helperText="미입력 시 공고 원제목 사용"
                   type="text"
-                  placeholder="예: 네이버 백엔드 — 2차 지원"
+                  placeholder="예: 홍길동 채용공고"
                   value={customTitle}
                   onChange={(e) => setCustomTitle(e.target.value)}
                   aria-label="내 식별 제목"

--- a/src/pages/jd-add/ui/JdAddPage.tsx
+++ b/src/pages/jd-add/ui/JdAddPage.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import {
   Building2, Calendar, CheckCircle2, ClipboardList,
@@ -47,12 +48,23 @@ export function JdAddPage() {
     clearError,
     submit,
     saveDraft,
+    loadDraft,
+    clearDraft,
+    reset,
   } = useJdAddStore();
+
+  useEffect(() => {
+    loadDraft();
+    return () => { reset(); };
+  }, [loadDraft, reset]);
 
   const handleSubmit = async () => {
     clearError();
     const jdUuid = await submit();
-    if (jdUuid) navigate(`/jd/${jdUuid}`);
+    if (jdUuid) {
+      clearDraft();
+      navigate(`/jd/${jdUuid}`);
+    }
   };
 
   const handleSaveDraft = async () => {
@@ -173,7 +185,7 @@ export function JdAddPage() {
 
               {/* ACTIONS */}
               <div className="flex items-center justify-end gap-3 mt-7 pt-6 border-t border-[#E5E7EB]">
-                <Button variant="ghost" onClick={() => navigate("/jd")}>
+                <Button variant="ghost" onClick={() => { clearDraft(); navigate("/jd"); }}>
                   취소
                 </Button>
                 <Button variant="secondary" onClick={handleSaveDraft} disabled={isSaving}>

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -1,8 +1,8 @@
 import { Fragment, useEffect, useRef, useState, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useJdListStore, type JdListItem } from "@/features/jd";
-import { useUserJobDescriptionScrapingSse } from "@/features/user-job-description";
-import { ClipboardList, Search } from "lucide-react";
+import { useUserJobDescriptionScrapingSse, userJobDescriptionApi } from "@/features/user-job-description";
+import { ClipboardList, Search, Trash2 } from "lucide-react";
 import { CompanyIcon } from "@/shared/ui/CompanyIcon";
 
 type FilterKey = "all" | "planned" | "applied" | "saved";
@@ -39,8 +39,7 @@ const TAG_COLOR_CLS: Record<string, string> = {
 };
 
 /* ── More-menu dropdown ── */
-function MoreMenu({ id, onClose }: { id: string; onClose: () => void }) {
-  const navigate = useNavigate();
+function MoreMenu({ onDelete, onClose }: { onDelete: () => void; onClose: () => void }) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -57,10 +56,10 @@ function MoreMenu({ id, onClose }: { id: string; onClose: () => void }) {
       className="absolute top-[calc(100%+6px)] right-0 bg-white border border-[#E5E7EB] rounded-lg shadow-[0_8px_24px_rgba(0,0,0,0.1)] min-w-[140px] overflow-hidden z-50 animate-[jdl-fadeUp_.15s_ease]"
     >
       <button
-        className="flex items-center gap-2 w-full py-[10px] px-3.5 border-none bg-transparent text-[13px] font-semibold text-[#374151] cursor-pointer text-left transition-[background] hover:bg-[#F9FAFB] hover:text-[#0991B2]"
-        onClick={() => { navigate(`/jd/${id}`); onClose(); }}
+        className="flex items-center gap-2 w-full py-[10px] px-3.5 border-none bg-transparent text-[13px] font-semibold text-[#EF4444] cursor-pointer text-left transition-[background] hover:bg-[#FEF2F2]"
+        onClick={() => { onDelete(); onClose(); }}
       >
-        📄 상세 보기
+        <Trash2 size={14} /> 채용공고 삭제
       </button>
     </div>
   );
@@ -71,6 +70,11 @@ function JdCard({ item }: { item: JdListItem }) {
   const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
   const { fetchList } = useJdListStore();
+
+  const handleDelete = useCallback(async () => {
+    await userJobDescriptionApi.remove(item.uuid);
+    fetchList();
+  }, [item.uuid, fetchList]);
   const cfg = STATUS_CONFIG[item.status];
   const isAnalyzing = item.status === "analyzing";
   const tagColorCls = (color: string) => TAG_COLOR_CLS[color] ?? TAG_COLOR_CLS.default;
@@ -122,7 +126,7 @@ function JdCard({ item }: { item: JdListItem }) {
           >
             ⋯
           </button>
-          {menuOpen && <MoreMenu id={item.uuid} onClose={() => setMenuOpen(false)} />}
+          {menuOpen && <MoreMenu onDelete={handleDelete} onClose={() => setMenuOpen(false)} />}
         </div>
       </div>
 

--- a/src/pages/jd-list/ui/JdListPage.tsx
+++ b/src/pages/jd-list/ui/JdListPage.tsx
@@ -57,7 +57,7 @@ function MoreMenu({ onDelete, onClose }: { onDelete: () => void; onClose: () => 
     >
       <button
         className="flex items-center gap-2 w-full py-[10px] px-3.5 border-none bg-transparent text-[13px] font-semibold text-[#EF4444] cursor-pointer text-left transition-[background] hover:bg-[#FEF2F2]"
-        onClick={() => { onDelete(); onClose(); }}
+        onClick={(e) => { e.stopPropagation(); onDelete(); onClose(); }}
       >
         <Trash2 size={14} /> 채용공고 삭제
       </button>

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { Check, Sparkles, Rocket } from "lucide-react";
 import { useAuthStore } from "@/features/auth";
 import { useOnboardingStore, JOB_STATUS_OPTIONS } from "@/features/onboarding";
+import { CATEGORY_STYLE } from "@/shared/ui/categoryIconStyle";
 
 export function OnboardingPage() {
   const navigate = useNavigate();
@@ -115,11 +117,8 @@ export function OnboardingPage() {
 
           {/* Email verified card */}
           <div className="flex items-center justify-center gap-[14px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-[22px] py-[18px] mb-6 shadow-[var(--sc)] w-full md:justify-start">
-            <div className="shrink-0">
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
-                <rect width="24" height="24" rx="6" fill="#059669" />
-                <polyline points="7 13 10 16 17 9" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
-              </svg>
+            <div className="w-[22px] h-[22px] rounded-md bg-[#059669] flex items-center justify-center shrink-0">
+              <Check size={14} stroke="#fff" strokeWidth={2.5} />
             </div>
             <div className="flex flex-col gap-0.5 overflow-hidden">
               <span className="text-[14px] font-bold text-[#059669]">이메일 인증 완료!</span>
@@ -135,7 +134,7 @@ export function OnboardingPage() {
             ].map((step, i) => (
               <div key={i} className="flex flex-row items-center gap-[14px] text-left px-5 py-[14px] rounded-lg opacity-60">
                 <div className="w-9 h-9 rounded-full flex items-center justify-center text-[14px] font-bold text-white bg-[#059669] shrink-0">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+                  <Check size={16} stroke="#fff" strokeWidth={3} />
                 </div>
                 <div className="flex flex-col gap-0.5">
                   <span className="text-[14px] font-semibold text-[#0A0A0A]">{step.name}</span>
@@ -156,7 +155,7 @@ export function OnboardingPage() {
         {/* ── Right: Profile Card ── */}
         <section className="flex justify-center w-full md:flex-1">
           <div className="w-full max-w-[560px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-10 shadow-[var(--sc)] sm:px-7 sm:py-12">
-            <h2 className="font-plex-sans-kr text-[22px] font-extrabold text-[#0A0A0A] mb-1.5">나를 알려주세요 👋</h2>
+            <h2 className="font-plex-sans-kr text-[22px] font-extrabold text-[#0A0A0A] mb-1.5 flex items-center gap-2">나를 알려주세요 <Sparkles size={20} className="text-[#F59E0B]" /></h2>
             <p className="text-[14px] text-[#6B7280] leading-[1.6] mb-6">
               면접 질문 맞춤화를 위해 딱 3가지만 입력하면 돼요.
             </p>
@@ -191,7 +190,7 @@ export function OnboardingPage() {
                     onClick={() => selectJobCategory(cat.id)}
                     aria-pressed={selectedJobCategoryId === cat.id}
                   >
-                    <span className="text-[14px]">{cat.emoji}</span>
+                    {(() => { const s = CATEGORY_STYLE[cat.id] ?? CATEGORY_STYLE[0]; return <s.Icon size={14} className={s.color} />; })()}
                     {cat.name}
                   </button>
                 ))}
@@ -297,7 +296,7 @@ export function OnboardingPage() {
               onClick={handleSubmit}
               disabled={isLoading}
             >
-              {isLoading ? "저장 중..." : "면접 시작하러 가기 🚀"}
+              {isLoading ? "저장 중..." : <span className="flex items-center justify-center gap-2">면접 시작하러 가기 <Rocket size={16} /></span>}
             </button>
           </div>
         </section>

--- a/src/pages/resume-new/ui/mode-tabs/FileUploadTab.tsx
+++ b/src/pages/resume-new/ui/mode-tabs/FileUploadTab.tsx
@@ -54,7 +54,7 @@ export function FileUploadTab() {
         <input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          placeholder="예: 2026 백엔드 개발자 이력서"
+          placeholder="예: 2026 홍길동 이력서"
           className="border border-[#E5E7EB] rounded-lg px-3.5 py-2.5 text-[13px] outline-none transition-[border-color,box-shadow] focus:border-[#0991B2] focus:shadow-[0_0_0_3px_rgba(9,145,178,0.1)] placeholder:text-[#9CA3AF]"
         />
       </label>

--- a/src/pages/resume-new/ui/mode-tabs/StructuredFormTab.tsx
+++ b/src/pages/resume-new/ui/mode-tabs/StructuredFormTab.tsx
@@ -132,7 +132,7 @@ export function StructuredFormTab() {
         <input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          placeholder="예: 백엔드 시니어 이력서"
+          placeholder="예: 2026 홍길동 이력서"
           className={inputCls}
         />
       </div>
@@ -153,7 +153,7 @@ export function StructuredFormTab() {
           value={data.summary}
           onChange={(e) => patch({ summary: e.target.value })}
           rows={2}
-          placeholder="예: 5년차 백엔드 개발자, MSA 와 데이터 파이프라인 설계 전문"
+          placeholder="예: 3년차 마케터, 브랜드 캠페인 기획 및 성과 분석 전문"
           className={inputCls}
         />
       </Section>
@@ -195,10 +195,10 @@ export function StructuredFormTab() {
       {/* 스킬 */}
       <Section icon={SECTION_ICONS["스킬"]} title="스킬 (콤마로 구분)">
         <div className="grid grid-cols-2 gap-3 max-sm:grid-cols-1">
-          <LabeledInput label="기술 스택" value={techCsv} onChange={setTechCsv} placeholder="Python, Django, FastAPI" />
-          <LabeledInput label="도구" value={toolCsv} onChange={setToolCsv} placeholder="Docker, Jira, Figma" />
-          <LabeledInput label="소프트 스킬" value={softCsv} onChange={setSoftCsv} placeholder="협업, 리더십, 커뮤니케이션" />
-          <LabeledInput label="외국어" value={skillLangCsv} onChange={setSkillLangCsv} placeholder="영어, 일본어" />
+          <LabeledInput label="기술 스택" value={techCsv} onChange={setTechCsv} placeholder="Excel, PowerPoint, Google Analytics" />
+          <LabeledInput label="도구" value={toolCsv} onChange={setToolCsv} placeholder="Notion, Slack, Google Workspace" />
+          <LabeledInput label="소프트 스킬" value={softCsv} onChange={setSoftCsv} placeholder="문제 해결, 리더십, 커뮤니케이션" />
+          <LabeledInput label="외국어" value={skillLangCsv} onChange={setSkillLangCsv} placeholder="영어, 중국어" />
         </div>
       </Section>
 
@@ -213,11 +213,11 @@ export function StructuredFormTab() {
           <div className="grid grid-cols-1 gap-2">
             <div className="grid grid-cols-3 gap-2 max-sm:grid-cols-1">
               <LabeledInput label="회사명" value={item.company} onChange={(v) => update({ ...item, company: v })} placeholder="(주)회사명" />
-              <LabeledInput label="직함" value={item.role} onChange={(v) => update({ ...item, role: v })} placeholder="백엔드 개발자" />
+              <LabeledInput label="직함" value={item.role} onChange={(v) => update({ ...item, role: v })} placeholder="마케팅 담당자" />
               <LabeledInput label="기간" value={item.period} onChange={(v) => update({ ...item, period: v })} placeholder="2022.03 ~ 2024.06" />
             </div>
-            <LabeledInput label="주요 업무 (한 줄에 하나)" value={(item.responsibilities ?? []).join("\n")} onChange={(v) => update({ ...item, responsibilities: v.split("\n").filter(Boolean) })} placeholder="API 설계 및 개발&#10;DB 쿼리 최적화" textarea rows={2} />
-            <LabeledInput label="주요 성과 (한 줄에 하나)" value={(item.highlights ?? []).join("\n")} onChange={(v) => update({ ...item, highlights: v.split("\n").filter(Boolean) })} placeholder="응답속도 40% 개선&#10;MAU 10만 달성" textarea rows={2} />
+            <LabeledInput label="주요 업무 (한 줄에 하나)" value={(item.responsibilities ?? []).join("\n")} onChange={(v) => update({ ...item, responsibilities: v.split("\n").filter(Boolean) })} placeholder="신규 캠페인 기획 및 운영&#10;데이터 분석 및 보고서 작성" textarea rows={2} />
+            <LabeledInput label="주요 성과 (한 줄에 하나)" value={(item.highlights ?? []).join("\n")} onChange={(v) => update({ ...item, highlights: v.split("\n").filter(Boolean) })} placeholder="전년 대비 매출 20% 증가&#10;팀 프로세스 개선으로 업무 효율 향상" textarea rows={2} />
           </div>
         )}
       />
@@ -231,10 +231,10 @@ export function StructuredFormTab() {
         onChange={(v) => patch({ educations: v })}
         renderRow={(item, update) => (
           <div className="grid grid-cols-2 gap-2 max-sm:grid-cols-1">
-            <LabeledInput label="학교명" value={item.school} onChange={(v) => update({ ...item, school: v })} placeholder="한국대학교" />
+            <LabeledInput label="학교명" value={item.school} onChange={(v) => update({ ...item, school: v })} placeholder="○○대학교" />
             <LabeledInput label="학위" value={item.degree} onChange={(v) => update({ ...item, degree: v })} placeholder="학사" />
-            <LabeledInput label="전공" value={item.major} onChange={(v) => update({ ...item, major: v })} placeholder="컴퓨터공학" />
-            <LabeledInput label="재학 기간" value={item.period} onChange={(v) => update({ ...item, period: v })} placeholder="2018.03 ~ 2022.02" />
+            <LabeledInput label="전공" value={item.major} onChange={(v) => update({ ...item, major: v })} placeholder="경영학" />
+            <LabeledInput label="재학 기간" value={item.period} onChange={(v) => update({ ...item, period: v })} placeholder="2020.03 ~ 2024.02" />
           </div>
         )}
       />
@@ -248,9 +248,9 @@ export function StructuredFormTab() {
         onChange={(v) => patch({ certifications: v })}
         renderRow={(item, update) => (
           <div className="grid grid-cols-3 gap-2 max-sm:grid-cols-1">
-            <LabeledInput label="자격증명" value={item.name} onChange={(v) => update({ ...item, name: v })} placeholder="정보처리기사" />
-            <LabeledInput label="발급기관" value={item.issuer} onChange={(v) => update({ ...item, issuer: v })} placeholder="한국산업인력공단" />
-            <LabeledInput label="취득일" value={item.date} onChange={(v) => update({ ...item, date: v })} placeholder="2022.05" />
+            <LabeledInput label="자격증명" value={item.name} onChange={(v) => update({ ...item, name: v })} placeholder="TOEIC 900" />
+            <LabeledInput label="발급기관" value={item.issuer} onChange={(v) => update({ ...item, issuer: v })} placeholder="YBM" />
+            <LabeledInput label="취득일" value={item.date} onChange={(v) => update({ ...item, date: v })} placeholder="2023.06" />
           </div>
         )}
       />
@@ -265,11 +265,11 @@ export function StructuredFormTab() {
         renderRow={(item, update) => (
           <div className="grid grid-cols-1 gap-2">
             <div className="grid grid-cols-3 gap-2 max-sm:grid-cols-1">
-              <LabeledInput label="수상명" value={item.name} onChange={(v) => update({ ...item, name: v })} placeholder="우수상" />
-              <LabeledInput label="주최" value={item.organization} onChange={(v) => update({ ...item, organization: v })} placeholder="과학기술정보통신부" />
-              <LabeledInput label="연도" value={item.year} onChange={(v) => update({ ...item, year: v })} placeholder="2023" />
+              <LabeledInput label="수상명" value={item.name} onChange={(v) => update({ ...item, name: v })} placeholder="최우수상" />
+              <LabeledInput label="주최" value={item.organization} onChange={(v) => update({ ...item, organization: v })} placeholder="○○대학교" />
+              <LabeledInput label="연도" value={item.year} onChange={(v) => update({ ...item, year: v })} placeholder="2024" />
             </div>
-            <LabeledInput label="상세 설명" value={item.description} onChange={(v) => update({ ...item, description: v })} placeholder="해커톤 최우수상 수상" textarea rows={2} />
+            <LabeledInput label="상세 설명" value={item.description} onChange={(v) => update({ ...item, description: v })} placeholder="교내 경진대회 최우수상 수상" textarea rows={2} />
           </div>
         )}
       />
@@ -284,12 +284,12 @@ export function StructuredFormTab() {
         renderRow={(item, update) => (
           <div className="grid grid-cols-1 gap-2">
             <div className="grid grid-cols-3 gap-2 max-sm:grid-cols-1">
-              <LabeledInput label="프로젝트명" value={item.name} onChange={(v) => update({ ...item, name: v })} placeholder="meFit 서비스" />
-              <LabeledInput label="역할" value={item.role} onChange={(v) => update({ ...item, role: v })} placeholder="백엔드 리드" />
+              <LabeledInput label="프로젝트명" value={item.name} onChange={(v) => update({ ...item, name: v })} placeholder="브랜드 SNS 마케팅 캠페인" />
+              <LabeledInput label="역할" value={item.role} onChange={(v) => update({ ...item, role: v })} placeholder="콘텐츠 기획 담당" />
               <LabeledInput label="기간" value={item.period} onChange={(v) => update({ ...item, period: v })} placeholder="2023.01 ~ 2023.06" />
             </div>
-            <LabeledInput label="개요 / 기여" value={item.description} onChange={(v) => update({ ...item, description: v })} placeholder="AI 면접 서비스 백엔드 설계 및 개발" textarea rows={2} />
-            <LabeledInput label="기술 스택 (콤마 구분)" value={(item.techStack ?? []).join(", ")} onChange={(v) => update({ ...item, techStack: csvToList(v) })} placeholder="FastAPI, PostgreSQL, Redis" />
+            <LabeledInput label="개요 / 기여" value={item.description} onChange={(v) => update({ ...item, description: v })} placeholder="인스타그램·유튜브 콘텐츠 기획 및 운영으로 팔로워 30% 증가" textarea rows={2} />
+            <LabeledInput label="기술 스택 (콤마 구분)" value={(item.techStack ?? []).join(", ")} onChange={(v) => update({ ...item, techStack: csvToList(v) })} placeholder="Canva, Google Analytics, Meta Ads" />
           </div>
         )}
       />
@@ -312,8 +312,8 @@ export function StructuredFormTab() {
       {/* 산업 도메인 / 키워드 */}
       <Section icon={SECTION_ICONS["산업 도메인 / 키워드"]} title="산업 도메인 / 키워드 (콤마 구분)">
         <div className="grid grid-cols-2 gap-3 max-sm:grid-cols-1">
-          <LabeledInput label="산업 도메인" value={domainsCsv} onChange={setDomainsCsv} placeholder="핀테크, 이커머스" />
-          <LabeledInput label="키워드" value={keywordsCsv} onChange={setKeywordsCsv} placeholder="microservices, pgvector" />
+          <LabeledInput label="산업 도메인" value={domainsCsv} onChange={setDomainsCsv} placeholder="유통, 소비재, 서비스업" />
+          <LabeledInput label="키워드" value={keywordsCsv} onChange={setKeywordsCsv} placeholder="데이터 분석, 프로젝트 관리, 고객 응대" />
         </div>
       </Section>
 

--- a/src/pages/resume-new/ui/mode-tabs/TextUploadTab.tsx
+++ b/src/pages/resume-new/ui/mode-tabs/TextUploadTab.tsx
@@ -41,7 +41,7 @@ export function TextUploadTab() {
           <input
             value={form.title}
             onChange={(e) => form.setTitle(e.target.value)}
-            placeholder="예: 2026 백엔드 개발자 이력서"
+            placeholder="예: 2026 홍길동 이력서"
             className="border border-[#E5E7EB] rounded-lg px-3.5 py-2.5 text-[13px] outline-none transition-[border-color,box-shadow] focus:border-[#0991B2] focus:shadow-[0_0_0_3px_rgba(9,145,178,0.1)] placeholder:text-[#9CA3AF]"
           />
         </label>

--- a/src/pages/settings/ui/JobCategorySelector.tsx
+++ b/src/pages/settings/ui/JobCategorySelector.tsx
@@ -116,7 +116,7 @@ export function JobCategorySelector({
         <div className="flex flex-col gap-[5px]">
           <label className="font-plex-sans-kr text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px]">
             직업 선택{" "}
-            <span className="text-[11px] font-normal text-[#6B7280]">(복수 선택 가능)</span>
+            <span className="text-[11px] font-normal text-[#6B7280]">(최대 3개 선택)</span>
           </label>
 
           {jobsLoading ? (

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -167,7 +167,7 @@ export function SettingsPage() {
                       <div className="flex flex-col gap-[5px] mt-4">
                         <label className="font-plex-sans-kr text-[12px] font-bold text-[#0A0A0A] tracking-[0.1px]">현재 직업 상태</label>
                         <div className="relative">
-                          <select className={inputClass} value={profileDraft.careerStage} onChange={(e) => setProfileDraftField("careerStage", e.target.value)} aria-label="현재 직업 상태">
+                          <select className={`${inputClass} appearance-none`} value={profileDraft.careerStage} onChange={(e) => setProfileDraftField("careerStage", e.target.value)} aria-label="현재 직업 상태">
                             {JOB_STATUS_OPTIONS.map((opt) => (
                               <option key={opt.value} value={opt.value}>{opt.label}</option>
                             ))}

--- a/src/pages/streak/ui/components/StreakCalendar.tsx
+++ b/src/pages/streak/ui/components/StreakCalendar.tsx
@@ -33,7 +33,7 @@ interface DayCell {
 }
 
 function buildYearGrid(
-  calendarDoneMap: Record<string, number[]>,
+  calendarDoneMap: Record<string, Record<number, number>>,
   todayYear: number,
   todayMonth: number,
   todayDay: number

--- a/src/pages/streak/ui/components/StreakCalendar.tsx
+++ b/src/pages/streak/ui/components/StreakCalendar.tsx
@@ -149,7 +149,7 @@ export function StreakCalendar({
         <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center">
           <Calendar size={14} className="text-[#0991B2]" />
         </span>
-        <Link to="/streak" className="text-[14px] font-bold text-[#0A0A0A] no-underline hover:text-[#0991B2] transition-colors">참여 기록</Link>
+        <Link to="/streak" className="text-[14px] font-bold text-[#0A0A0A] no-underline hover:text-[#0991B2] transition-colors">스트릭</Link>
         <span className="text-[11px] text-[#9CA3AF] font-medium ml-auto">
           {visibleWeeks < MAX_WEEKS ? `최근 ${visibleWeeks}주` : "최근 52주"} ·{" "}
           <strong className="text-[#0991B2]">{totalDone}일</strong> 참여

--- a/src/pages/streak/ui/components/StreakCalendar.tsx
+++ b/src/pages/streak/ui/components/StreakCalendar.tsx
@@ -18,7 +18,7 @@ const CELL_COLORS = [
 ];
 
 interface StreakCalendarProps {
-  calendarDoneMap: Record<string, number[]>;
+  calendarDoneMap: Record<string, Record<number, number>>;
   revealed: boolean;
   todayYear: number;
   todayMonth: number;
@@ -27,7 +27,7 @@ interface StreakCalendarProps {
 
 interface DayCell {
   date: Date | null;
-  done: boolean;
+  count: number;
   today: boolean;
   label?: string;
 }
@@ -42,12 +42,6 @@ function buildYearGrid(
   const startDate = new Date(today);
   startDate.setDate(today.getDate() - (MAX_WEEKS - 1) * 7 - today.getDay());
 
-  const doneSet = new Set<string>();
-  for (const [key, days] of Object.entries(calendarDoneMap)) {
-    const [y, m] = key.split("-").map(Number);
-    for (const d of days) doneSet.add(`${y}-${m}-${d}`);
-  }
-
   const weeks: DayCell[][] = [];
   const monthPositions: { label: string; col: number }[] = [];
   let lastMonth = -1;
@@ -59,20 +53,23 @@ function buildYearGrid(
       cur.setDate(startDate.getDate() + w * NUM_DAYS + d);
 
       if (cur > today) {
-        week.push({ date: null, done: false, today: false });
+        week.push({ date: null, count: 0, today: false });
         continue;
       }
 
       const y   = cur.getFullYear();
       const mo  = cur.getMonth() + 1;
       const day = cur.getDate();
-      const key = `${y}-${mo}-${day}`;
+      const monthKey = `${y}-${mo}`;
+      const count = calendarDoneMap[monthKey]?.[day] ?? 0;
 
       week.push({
         date: cur,
-        done: doneSet.has(key),
+        count,
         today: y === todayYear && mo === todayMonth && day === todayDay,
-        label: `${y}년 ${mo}월 ${day}일${doneSet.has(key) ? " — 면접 참여 ✓" : ""}`,
+        label: count > 0
+          ? `${y}년 ${mo}월 ${day}일 — 면접 ${count}회 ✓`
+          : `${y}년 ${mo}월 ${day}일`,
       });
 
       if (d === 0 && mo !== lastMonth) {
@@ -133,7 +130,7 @@ export function StreakCalendar({
 
   const totalDone = useMemo(() => {
     let n = 0;
-    for (const days of Object.values(calendarDoneMap)) n += days.length;
+    for (const dayMap of Object.values(calendarDoneMap)) n += Object.keys(dayMap).length;
     return n;
   }, [calendarDoneMap]);
 
@@ -189,8 +186,9 @@ export function StreakCalendar({
             {weeks.map((week, col) => {
               const cell = week[row];
               const isEmpty = !cell?.date;
-              const isDone  = cell?.done  ?? false;
+              const count   = cell?.count  ?? 0;
               const isToday = cell?.today ?? false;
+              const colorIdx = count === 0 ? 0 : Math.min(count, CELL_COLORS.length - 1);
               return (
                 <div
                   key={col}
@@ -201,11 +199,11 @@ export function StreakCalendar({
                     flexShrink: 0,
                     borderRadius: Math.max(2, Math.floor(cellSize / 4)),
                     marginRight: col < visibleWeeks - 1 ? CELL_GAP : 0,
-                    background: isEmpty ? "transparent" : isDone ? CELL_COLORS[3] : CELL_COLORS[0],
+                    background: isEmpty ? "transparent" : CELL_COLORS[colorIdx],
                     outline: "none",
                     outlineOffset: 0,
                     boxShadow: isToday
-                      ? isDone
+                      ? count > 0
                         ? "0 0 0 2px #0991B2, 0 0 6px rgba(9,145,178,0.5)"
                         : "0 0 0 2px #0991B2"
                       : undefined,
@@ -235,6 +233,8 @@ export function StreakCalendar({
         ))}
         <span className="text-[10px] text-[#9CA3AF] ml-0.5">More</span>
       </div>
+
+
     </div>
   );
 }

--- a/src/pages/verify-email/ui/VerifyEmailPage.tsx
+++ b/src/pages/verify-email/ui/VerifyEmailPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import { LogIn, LogOut } from "lucide-react";
 import { useAuthStore } from "@/features/auth";
 import { Link, useNavigate } from "react-router-dom";
 
@@ -68,10 +69,10 @@ export function VerifyEmailPage() {
         </Link>
         <button
           type="button"
-          className="text-[13px] font-medium text-[#6B7280] px-4 py-2 bg-none border border-[#E5E7EB] rounded-lg cursor-pointer font-plex-sans-kr transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F9FAFB]"
+          className="text-[13px] font-medium text-[#6B7280] px-4 py-2 bg-none border border-[#E5E7EB] rounded-lg cursor-pointer font-plex-sans-kr transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F9FAFB] flex items-center gap-1.5"
           onClick={handleLogout}
         >
-          🚪 로그아웃
+          <LogOut size={14} /> 로그아웃
         </button>
       </header>
 
@@ -220,10 +221,10 @@ export function VerifyEmailPage() {
             {/* Action buttons */}
             <button
               type="button"
-              className="w-full py-[14px] bg-white text-[#374151] font-plex-sans-kr text-[14px] font-semibold border border-[#E5E7EB] rounded-lg cursor-pointer transition-[color,background] duration-200 mb-2 hover:text-[#0A0A0A] hover:bg-[#F3F4F6]"
+              className="w-full py-[14px] bg-white text-[#374151] font-plex-sans-kr text-[14px] font-semibold border border-[#E5E7EB] rounded-lg cursor-pointer transition-[color,background] duration-200 mb-2 hover:text-[#0A0A0A] hover:bg-[#F3F4F6] flex items-center justify-center gap-2"
               onClick={handleLogout}
             >
-              🚪 다른 계정으로 로그인
+              <LogIn size={15} /> 다른 계정으로 로그인
             </button>
 
             <p className="text-[13px] text-[#6B7280] mt-4 leading-[1.6]">


### PR DESCRIPTION
## 관련 이슈
Closes #144 

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

  - 홈 캘린더 타이틀 "참여 기록" → "스트릭" 변경 및 클릭 시 스트릭 페이지로 이동
  - 홈 최근 면접 기록 실제 API 연결 및 Lucide 아이콘 추가
  - 마지막 면접 경과일 mock 데이터 → last_participated_date API 실데이터로 교체
  - 스트릭 캘린더 면접 횟수 기반 5단계 색상 적용 (0~4회+)
  - 채용공고 카드 더보기 메뉴: "상세 보기" 제거 → "채용공고 삭제" 기능 추가
  - 면접 결과 페이지 이모지 아이콘 전체 Lucide 아이콘으로 교체
  - 이어서 진행 버튼 색상 검은색으로 변경
  - 설정 페이지 직업 선택 최대 3개로 제한 및 라벨 수정
  - 현재 직업 상태 select 화살표 중복 표시 수정
  - 이력서/JD 추가 페이지 placeholder 예시 문구 범용적으로 수정
  
## 변경 유형
해당하는 항목에 체크해주세요.

- [x] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
  1. 홈 화면에서 스트릭 캘린더 타이틀 클릭 시 /streak 페이지로 이동 확인
  2. 홈 최근 면접 기록이 실제 완료된 면접 목록으로 표시되는지 확인
  3. 채용공고 목록에서 ⋯ 메뉴 클릭 후 삭제 기능 동작 및 목록 갱신 확인
  4. 설정 페이지에서 직업 선택 4개 이상 선택 불가 확인
  5. 현재 직업 상태 드롭다운 화살표 하나만 표시되는지 확인


## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [x] 코드에 적절한 주석을 추가했습니다
- [x] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [x] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.
