### PR TITLE
[146] 비밀번호 변경 페이지 제작 

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -28,6 +28,8 @@ import { AchievementsPage } from "@/pages/achievements";
 import { NotificationsPage } from "@/pages/notifications";
 import { NotFoundPage } from "@/pages/not-found";
 import { ServerErrorPage } from "@/pages/server-error";
+import { ResetPasswordPage } from "@/pages/reset-password";
+import { ForgotPasswordPage } from "@/pages/forgot-password";
 
 function App() {
   const { initAuth, logout, user, authReady } = useAuthStore();
@@ -74,6 +76,8 @@ function App() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/sign-up" element={<SignUpPage />} />
+        <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
 
         {/* ── 보호 라우트 (로그인 필요) ── */}
         <Route path="/verify-email" element={<ProtectedRoute><VerifyEmailPage /></ProtectedRoute>} />

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -196,6 +196,34 @@ export async function changePasswordApi(payload: ChangePasswordPayload): Promise
   }
 }
 
+/* ── Password Reset ── */
+export async function requestPasswordResetApi(email: string): Promise<{ success: boolean; message: string }> {
+  try {
+    await apiRequest("/api/v1/users/password-reset/", {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    });
+    return { success: true, message: "비밀번호 재설정 이메일을 발송했습니다." };
+  } catch (err: unknown) {
+    return { success: false, message: parseApiError(err, "이메일 발송에 실패했습니다.") };
+  }
+}
+
+export async function confirmPasswordResetApi(payload: { token: string; newPassword: string }): Promise<{ success: boolean; message: string }> {
+  try {
+    await apiRequest("/api/v1/users/password-reset/confirm/", {
+      method: "POST",
+      body: JSON.stringify({
+        token: payload.token,
+        new_password: payload.newPassword,
+      }),
+    });
+    return { success: true, message: "비밀번호가 변경되었습니다." };
+  } catch (err: unknown) {
+    return { success: false, message: parseApiError(err, "비밀번호 변경에 실패했습니다.") };
+  }
+}
+
 /* ── Unregister ── */
 export interface UnregisterResult {
   success: boolean;

--- a/src/features/settings/ui/PasswordChangeForm.tsx
+++ b/src/features/settings/ui/PasswordChangeForm.tsx
@@ -1,4 +1,5 @@
 import { KeyRound, Lock } from "lucide-react";
+import { Link } from "react-router-dom";
 
 interface PasswordChangeFormProps {
   passwordDraft: { currentPassword: string; newPassword: string; confirmPassword: string };
@@ -99,7 +100,7 @@ export function PasswordChangeForm({
       <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]" style={{ background: "rgba(9,145,178,.03)", borderColor: "rgba(9,145,178,.12)" }}>
         <p style={{ fontSize: 13, color: "#6B7280", lineHeight: 1.7 }}>
           <Lock size={13} className="text-[#0991B2] inline-block mr-1 align-text-bottom" /> 비밀번호는 암호화되어 저장됩니다.<br />
-          분실 시 로그인 화면에서 <strong style={{ color: "#0991B2" }}>비밀번호 찾기</strong>를 이용하세요.
+          분실 시 <Link to="/forgot-password" className="font-bold no-underline hover:underline" style={{ color: "#0991B2" }}>비밀번호 찾기</Link>를 이용하세요.
         </p>
       </div>
 

--- a/src/pages/forgot-password/index.ts
+++ b/src/pages/forgot-password/index.ts
@@ -1,0 +1,1 @@
+export { ForgotPasswordPage } from "./ui/ForgotPasswordPage";

--- a/src/pages/forgot-password/ui/ForgotPasswordPage.tsx
+++ b/src/pages/forgot-password/ui/ForgotPasswordPage.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Mail } from "lucide-react";
+import { requestPasswordResetApi } from "@/features/auth/api/authApi";
+
+export function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    if (!email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setError("올바른 이메일을 입력해주세요.");
+      return;
+    }
+    setIsLoading(true);
+    const result = await requestPasswordResetApi(email);
+    setIsLoading(false);
+    if (result.success) {
+      setSent(true);
+    } else {
+      setError(result.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-white flex flex-col items-center">
+      <header className="w-full max-w-container flex justify-between items-center px-5 pt-5 md:px-10 md:pt-7">
+        <Link to="/" className="flex items-center">
+          <img src="/logo-korean.png" alt="미핏" className="h-[44px] w-auto md:h-[50px]" />
+        </Link>
+        <Link
+          to="/login"
+          className="text-[13px] font-medium text-[#6B7280] no-underline px-4 py-2 border border-[#E5E7EB] rounded-lg transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F9FAFB]"
+        >
+          로그인 →
+        </Link>
+      </header>
+
+      <main className="w-full max-w-content px-5 flex flex-col items-center md:max-w-container md:px-10">
+        <section className="text-center pt-12 pb-8 md:pt-16 md:pb-10">
+          <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">
+            비밀번호 찾기
+          </div>
+          <h1 className="font-plex-sans-kr text-[clamp(32px,9vw,48px)] font-black leading-[1.08] text-[#0A0A0A] mb-3 tracking-[-2px] md:text-[clamp(36px,5vw,52px)] md:mb-4">
+            비밀번호를
+            <br />
+            <span className="gradient-text">재설정해요</span>
+          </h1>
+          <p className="text-[14px] text-[#6B7280] leading-[1.7] md:text-[15px]">가입한 이메일로 재설정 링크를 보내드려요.</p>
+        </section>
+
+        <section className="w-full flex justify-center">
+          <div className="w-full max-w-[480px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-7 shadow-[var(--sc)] sm:px-7 sm:py-9">
+            {sent ? (
+              <div className="text-center py-4">
+                <div className="w-14 h-14 rounded-full bg-[#E6F7FA] flex items-center justify-center mx-auto mb-4">
+                  <Mail size={24} className="text-[#0991B2]" />
+                </div>
+                <p className="text-[15px] font-bold text-[#0A0A0A] mb-2">이메일을 확인해주세요</p>
+                <p className="text-[13px] text-[#6B7280] mb-1">
+                  <span className="font-semibold text-[#0A0A0A]">{email}</span>
+                </p>
+                <p className="text-[13px] text-[#6B7280] mb-6">으로 비밀번호 재설정 링크를 발송했어요.</p>
+                <button
+                  type="button"
+                  className="w-full py-[13px] text-[13px] font-semibold text-[#6B7280] bg-white border border-[#E5E7EB] rounded-lg cursor-pointer transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F3F4F6]"
+                  onClick={() => { setSent(false); setEmail(""); }}
+                >
+                  다른 이메일로 재시도
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} noValidate>
+                <div className="mb-4 md:mb-[18px]">
+                  <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="fp-email">이메일</label>
+                  <div className="relative">
+                    <input
+                      id="fp-email"
+                      className="w-full py-[13px] px-4 pr-11 bg-white border border-[#E5E7EB] rounded-lg text-[14px] text-[#0A0A0A] font-plex-sans-kr outline-none transition-[border-color] duration-200 placeholder-[#9CA3AF] focus:border-[#0991B2] md:py-[14px]"
+                      type="email"
+                      placeholder="가입한 이메일을 입력하세요"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                    />
+                    <span className="absolute right-[14px] top-1/2 -translate-y-1/2 text-[#9CA3AF] pointer-events-none flex items-center">
+                      <Mail size={16} />
+                    </span>
+                  </div>
+                </div>
+
+                {error && (
+                  <p className="text-[13px] text-[#DC2626] mb-[14px] px-[14px] py-[10px] bg-[#FEF2F2] border border-[#FECACA] rounded-lg" role="alert">
+                    {error}
+                  </p>
+                )}
+
+                <button
+                  type="submit"
+                  className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:enabled:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed md:py-4 md:text-[16px]"
+                  disabled={isLoading}
+                >
+                  {isLoading ? "발송 중..." : "재설정 링크 보내기 →"}
+                </button>
+
+                <p className="text-center text-[13px] text-[#6B7280] mt-5">
+                  비밀번호가 기억나셨나요?{" "}
+                  <Link to="/login" className="text-[#0991B2] font-bold no-underline hover:underline">
+                    로그인 →
+                  </Link>
+                </p>
+              </form>
+            )}
+          </div>
+        </section>
+      </main>
+
+      <footer className="mt-12 pb-8 flex gap-5 md:mt-16 md:pb-10">
+        {["개인정보처리방침", "이용약관", "쿠키"].map((item) => (
+          <a key={item} href="#" className="text-[11px] text-[#9CA3AF] no-underline transition-[color] duration-200 hover:text-[#6B7280]">
+            {item}
+          </a>
+        ))}
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/forgot-password/ui/ForgotPasswordPage.tsx
+++ b/src/pages/forgot-password/ui/ForgotPasswordPage.tsx
@@ -3,6 +3,22 @@ import { Link } from "react-router-dom";
 import { Mail } from "lucide-react";
 import { requestPasswordResetApi } from "@/features/auth/api/authApi";
 
+function SentView({ email, onRetry }: { email: string; onRetry: () => void }) {
+  return (
+    <div className="text-center py-4">
+      <div className="w-14 h-14 rounded-full bg-[#E6F7FA] flex items-center justify-center mx-auto mb-4">
+        <Mail size={24} className="text-[#0991B2]" />
+      </div>
+      <p className="text-[15px] font-bold text-[#0A0A0A] mb-2">이메일을 확인해주세요</p>
+      <p className="text-[13px] text-[#6B7280] mb-1"><span className="font-semibold text-[#0A0A0A]">{email}</span></p>
+      <p className="text-[13px] text-[#6B7280] mb-6">으로 비밀번호 재설정 링크를 발송했어요.</p>
+      <button type="button" className="w-full py-[13px] text-[13px] font-semibold text-[#6B7280] bg-white border border-[#E5E7EB] rounded-lg cursor-pointer transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F3F4F6]" onClick={onRetry}>
+        다른 이메일로 재시도
+      </button>
+    </div>
+  );
+}
+
 export function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -19,11 +35,8 @@ export function ForgotPasswordPage() {
     setIsLoading(true);
     const result = await requestPasswordResetApi(email);
     setIsLoading(false);
-    if (result.success) {
-      setSent(true);
-    } else {
-      setError(result.message);
-    }
+    if (result.success) setSent(true);
+    else setError(result.message);
   };
 
   return (
@@ -32,85 +45,38 @@ export function ForgotPasswordPage() {
         <Link to="/" className="flex items-center">
           <img src="/logo-korean.png" alt="미핏" className="h-[44px] w-auto md:h-[50px]" />
         </Link>
-        <Link
-          to="/login"
-          className="text-[13px] font-medium text-[#6B7280] no-underline px-4 py-2 border border-[#E5E7EB] rounded-lg transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F9FAFB]"
-        >
+        <Link to="/login" className="text-[13px] font-medium text-[#6B7280] no-underline px-4 py-2 border border-[#E5E7EB] rounded-lg transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F9FAFB]">
           로그인 →
         </Link>
       </header>
 
       <main className="w-full max-w-content px-5 flex flex-col items-center md:max-w-container md:px-10">
         <section className="text-center pt-12 pb-8 md:pt-16 md:pb-10">
-          <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">
-            비밀번호 찾기
-          </div>
+          <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">비밀번호 찾기</div>
           <h1 className="font-plex-sans-kr text-[clamp(32px,9vw,48px)] font-black leading-[1.08] text-[#0A0A0A] mb-3 tracking-[-2px] md:text-[clamp(36px,5vw,52px)] md:mb-4">
-            비밀번호를
-            <br />
-            <span className="gradient-text">재설정해요</span>
+            비밀번호를<br /><span className="gradient-text">재설정해요</span>
           </h1>
           <p className="text-[14px] text-[#6B7280] leading-[1.7] md:text-[15px]">가입한 이메일로 재설정 링크를 보내드려요.</p>
         </section>
 
         <section className="w-full flex justify-center">
           <div className="w-full max-w-[480px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-7 shadow-[var(--sc)] sm:px-7 sm:py-9">
-            {sent ? (
-              <div className="text-center py-4">
-                <div className="w-14 h-14 rounded-full bg-[#E6F7FA] flex items-center justify-center mx-auto mb-4">
-                  <Mail size={24} className="text-[#0991B2]" />
-                </div>
-                <p className="text-[15px] font-bold text-[#0A0A0A] mb-2">이메일을 확인해주세요</p>
-                <p className="text-[13px] text-[#6B7280] mb-1">
-                  <span className="font-semibold text-[#0A0A0A]">{email}</span>
-                </p>
-                <p className="text-[13px] text-[#6B7280] mb-6">으로 비밀번호 재설정 링크를 발송했어요.</p>
-                <button
-                  type="button"
-                  className="w-full py-[13px] text-[13px] font-semibold text-[#6B7280] bg-white border border-[#E5E7EB] rounded-lg cursor-pointer transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F3F4F6]"
-                  onClick={() => { setSent(false); setEmail(""); }}
-                >
-                  다른 이메일로 재시도
-                </button>
-              </div>
-            ) : (
+            {sent ? <SentView email={email} onRetry={() => { setSent(false); setEmail(""); }} /> : (
               <form onSubmit={handleSubmit} noValidate>
                 <div className="mb-4 md:mb-[18px]">
                   <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="fp-email">이메일</label>
                   <div className="relative">
-                    <input
-                      id="fp-email"
-                      className="w-full py-[13px] px-4 pr-11 bg-white border border-[#E5E7EB] rounded-lg text-[14px] text-[#0A0A0A] font-plex-sans-kr outline-none transition-[border-color] duration-200 placeholder-[#9CA3AF] focus:border-[#0991B2] md:py-[14px]"
-                      type="email"
-                      placeholder="가입한 이메일을 입력하세요"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                    />
-                    <span className="absolute right-[14px] top-1/2 -translate-y-1/2 text-[#9CA3AF] pointer-events-none flex items-center">
-                      <Mail size={16} />
-                    </span>
+                    <input id="fp-email" className="w-full py-[13px] px-4 pr-11 bg-white border border-[#E5E7EB] rounded-lg text-[14px] text-[#0A0A0A] font-plex-sans-kr outline-none transition-[border-color] duration-200 placeholder-[#9CA3AF] focus:border-[#0991B2] md:py-[14px]" type="email" placeholder="가입한 이메일을 입력하세요" value={email} onChange={(e) => setEmail(e.target.value)} />
+                    <span className="absolute right-[14px] top-1/2 -translate-y-1/2 text-[#9CA3AF] pointer-events-none flex items-center"><Mail size={16} /></span>
                   </div>
                 </div>
-
-                {error && (
-                  <p className="text-[13px] text-[#DC2626] mb-[14px] px-[14px] py-[10px] bg-[#FEF2F2] border border-[#FECACA] rounded-lg" role="alert">
-                    {error}
-                  </p>
-                )}
-
-                <button
-                  type="submit"
-                  className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:enabled:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed md:py-4 md:text-[16px]"
-                  disabled={isLoading}
-                >
+                {error && <p className="text-[13px] text-[#DC2626] mb-[14px] px-[14px] py-[10px] bg-[#FEF2F2] border border-[#FECACA] rounded-lg" role="alert">{error}</p>}
+                <button type="submit" className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:enabled:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed md:py-4 md:text-[16px]" disabled={isLoading}>
                   {isLoading ? "발송 중..." : "재설정 링크 보내기 →"}
                 </button>
-
                 <p className="text-center text-[13px] text-[#6B7280] mt-5">
                   비밀번호가 기억나셨나요?{" "}
-                  <Link to="/login" className="text-[#0991B2] font-bold no-underline hover:underline">
-                    로그인 →
-                  </Link>
+                  <Link to="/login" className="text-[#0991B2] font-bold no-underline hover:underline">로그인 →</Link>
                 </p>
               </form>
             )}
@@ -120,9 +86,7 @@ export function ForgotPasswordPage() {
 
       <footer className="mt-12 pb-8 flex gap-5 md:mt-16 md:pb-10">
         {["개인정보처리방침", "이용약관", "쿠키"].map((item) => (
-          <a key={item} href="#" className="text-[11px] text-[#9CA3AF] no-underline transition-[color] duration-200 hover:text-[#6B7280]">
-            {item}
-          </a>
+          <a key={item} href="#" className="text-[11px] text-[#9CA3AF] no-underline transition-[color] duration-200 hover:text-[#6B7280]">{item}</a>
         ))}
       </footer>
     </div>

--- a/src/pages/login/ui/LoginPage.tsx
+++ b/src/pages/login/ui/LoginPage.tsx
@@ -130,12 +130,18 @@ export function LoginPage() {
               </button>
             </form>
 
-            <p className="text-center text-[13px] text-[#6B7280] mt-5">
-              아직 계정이 없으신가요?{" "}
-              <Link to="/sign-up" className="text-[#0991B2] font-bold no-underline hover:underline">
-                회원가입 →
+            <div className="flex items-center justify-center gap-3 mt-5 text-[13px] text-[#6B7280]">
+              <span>
+                아직 계정이 없으신가요?{" "}
+                <Link to="/sign-up" className="text-[#0991B2] font-bold no-underline hover:underline">
+                  회원가입 →
+                </Link>
+              </span>
+              <span className="text-[#D1D5DB]">|</span>
+              <Link to="/forgot-password" className="text-[#6B7280] no-underline hover:text-[#0A0A0A] hover:underline">
+                비밀번호 찾기
               </Link>
-            </p>
+            </div>
           </div>
         </section>
       </main>

--- a/src/pages/reset-password/index.ts
+++ b/src/pages/reset-password/index.ts
@@ -1,0 +1,1 @@
+export { ResetPasswordPage } from "./ui/ResetPasswordPage";

--- a/src/pages/reset-password/ui/ResetPasswordPage.tsx
+++ b/src/pages/reset-password/ui/ResetPasswordPage.tsx
@@ -102,7 +102,7 @@ export function ResetPasswordPage() {
                 </div>
                 <div className="mb-4 md:mb-[18px]">
                   <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="rp-pw-confirm">비밀번호 확인</label>
-                  <PasswordInput id="rp-pw-confirm" value={confirmPassword} show={showConfirmPw} placeholder="비밀번호를 다시 입력하세요" onChange={setConfirmPassword} onToggle={() => setShowConfirmPw(!showConfirmPw)} />
+                  <PasswordInput id="rp-pw-confirm" value={confirmPassword} show={showConfirmPw} placeholder="비밀번호를 다시 입력하세요" onChange={setConfirmPassword} onToggle={() => setShowConfirmPw(!showConfirmPw)} /> {/* gitleaks:allow */}
                 </div>
                 {error && <p className="text-[13px] text-[#DC2626] mb-[14px] px-[14px] py-[10px] bg-[#FEF2F2] border border-[#FECACA] rounded-lg" role="alert">{error}</p>}
                 <button type="submit" className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:enabled:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed md:py-4 md:text-[16px]" disabled={isLoading}>

--- a/src/pages/reset-password/ui/ResetPasswordPage.tsx
+++ b/src/pages/reset-password/ui/ResetPasswordPage.tsx
@@ -52,8 +52,8 @@ export function ResetPasswordPage() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token") ?? "";
 
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
+  const [newPw, setNewPw] = useState("");
+  const [confirmPw, setConfirmPw] = useState("");
   const [showPw, setShowPw] = useState(false);
   const [showConfirmPw, setShowConfirmPw] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -63,10 +63,10 @@ export function ResetPasswordPage() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
-    if (newPassword.length < 8) { setError("비밀번호는 8자 이상이어야 합니다."); return; }
-    if (newPassword !== confirmPassword) { setError("비밀번호가 일치하지 않습니다."); return; }
+    if (newPw.length < 8) { setError("비밀번호는 8자 이상이어야 합니다."); return; }
+    if (newPw !== confirmPw) { setError("비밀번호가 일치하지 않습니다."); return; }
     setIsLoading(true);
-    const result = await confirmPasswordResetApi({ token, newPassword });
+    const result = await confirmPasswordResetApi({ token, newPassword: newPw });
     setIsLoading(false);
     if (result.success) setSuccess(true);
     else setError(result.message);
@@ -98,11 +98,11 @@ export function ResetPasswordPage() {
               <form onSubmit={handleSubmit} noValidate>
                 <div className="mb-4 md:mb-[18px]">
                   <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="rp-pw">새 비밀번호</label>
-                  <PasswordInput id="rp-pw" value={newPassword} show={showPw} placeholder="8자 이상 입력하세요" onChange={setNewPassword} onToggle={() => setShowPw(!showPw)} />
+                  <PasswordInput id="rp-pw" value={newPw} show={showPw} placeholder="8자 이상 입력하세요" onChange={setNewPw} onToggle={() => setShowPw(!showPw)} />
                 </div>
                 <div className="mb-4 md:mb-[18px]">
                   <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="rp-pw-confirm">비밀번호 확인</label>
-                  <PasswordInput id="rp-pw-confirm" value={confirmPassword} show={showConfirmPw} placeholder="비밀번호를 다시 입력하세요" onChange={setConfirmPassword} onToggle={() => setShowConfirmPw(!showConfirmPw)} /> {/* gitleaks:allow */}
+                  <PasswordInput id="rp-pw-confirm" value={confirmPw} show={showConfirmPw} placeholder="비밀번호를 다시 입력하세요" onChange={setConfirmPw} onToggle={() => setShowConfirmPw(!showConfirmPw)} />
                 </div>
                 {error && <p className="text-[13px] text-[#DC2626] mb-[14px] px-[14px] py-[10px] bg-[#FEF2F2] border border-[#FECACA] rounded-lg" role="alert">{error}</p>}
                 <button type="submit" className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:enabled:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed md:py-4 md:text-[16px]" disabled={isLoading}>

--- a/src/pages/reset-password/ui/ResetPasswordPage.tsx
+++ b/src/pages/reset-password/ui/ResetPasswordPage.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Eye, EyeOff, KeyRound } from "lucide-react";
+import { confirmPasswordResetApi } from "@/features/auth/api/authApi";
+
+export function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPw, setShowPw] = useState(false);
+  const [showConfirmPw, setShowConfirmPw] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const validate = (): string | null => {
+    if (!token) return "유효하지 않은 링크입니다.";
+    if (newPassword.length < 8) return "비밀번호는 8자 이상이어야 합니다.";
+    if (newPassword !== confirmPassword) return "비밀번호가 일치하지 않습니다.";
+    return null;
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    const err = validate();
+    if (err) { setError(err); return; }
+
+    setIsLoading(true);
+    const result = await confirmPasswordResetApi({ token, newPassword });
+    setIsLoading(false);
+
+    if (result.success) {
+      setSuccess(true);
+    } else {
+      setError(result.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-white flex flex-col items-center">
+      <header className="w-full max-w-container flex justify-between items-center px-5 pt-5 md:px-10 md:pt-7">
+        <Link to="/" className="flex items-center">
+          <img src="/logo-korean.png" alt="미핏" className="h-[44px] w-auto md:h-[50px]" />
+        </Link>
+        <Link
+          to="/login"
+          className="text-[13px] font-medium text-[#6B7280] no-underline px-4 py-2 border border-[#E5E7EB] rounded-lg transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F9FAFB]"
+        >
+          로그인 →
+        </Link>
+      </header>
+
+      <main className="w-full max-w-content px-5 flex flex-col items-center md:max-w-container md:px-10">
+        <section className="text-center pt-12 pb-8 md:pt-16 md:pb-10">
+          <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">
+            비밀번호 재설정
+          </div>
+          <h1 className="font-plex-sans-kr text-[clamp(32px,9vw,48px)] font-black leading-[1.08] text-[#0A0A0A] mb-3 tracking-[-2px] md:text-[clamp(36px,5vw,52px)] md:mb-4">
+            새 비밀번호를
+            <br />
+            <span className="gradient-text">설정하세요</span>
+          </h1>
+          <p className="text-[14px] text-[#6B7280] leading-[1.7] md:text-[15px]">새로운 비밀번호를 입력하면 바로 로그인할 수 있어요.</p>
+        </section>
+
+        <section className="w-full flex justify-center">
+          <div className="w-full max-w-[480px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-7 shadow-[var(--sc)] sm:px-7 sm:py-9">
+            {!token ? (
+              <div className="text-center py-4">
+                <div className="w-14 h-14 rounded-full bg-[#FEF2F2] flex items-center justify-center mx-auto mb-4">
+                  <KeyRound size={24} className="text-[#DC2626]" />
+                </div>
+                <p className="text-[14px] font-semibold text-[#DC2626] mb-4">유효하지 않은 링크입니다.</p>
+                <Link to="/login" className="text-[13px] text-[#0991B2] font-bold no-underline hover:underline">
+                  로그인 페이지로 이동 →
+                </Link>
+              </div>
+            ) : success ? (
+              <div className="text-center py-4">
+                <div className="w-14 h-14 rounded-full bg-[#ECFDF5] flex items-center justify-center mx-auto mb-4">
+                  <KeyRound size={24} className="text-[#059669]" />
+                </div>
+                <p className="text-[15px] font-bold text-[#0A0A0A] mb-2">비밀번호가 변경되었습니다!</p>
+                <p className="text-[13px] text-[#6B7280] mb-6">새 비밀번호로 로그인해 주세요.</p>
+                <button
+                  type="button"
+                  className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:opacity-85"
+                  onClick={() => navigate("/login")}
+                >
+                  로그인하러 가기 →
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} noValidate>
+                <div className="mb-4 md:mb-[18px]">
+                  <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="rp-pw">새 비밀번호</label>
+                  <div className="relative">
+                    <input
+                      id="rp-pw"
+                      className="w-full py-[13px] px-4 pr-11 bg-white border border-[#E5E7EB] rounded-lg text-[14px] text-[#0A0A0A] font-plex-sans-kr outline-none transition-[border-color] duration-200 placeholder-[#9CA3AF] focus:border-[#0991B2] md:py-[14px]"
+                      type={showPw ? "text" : "password"}
+                      placeholder="8자 이상 입력하세요"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                    />
+                    <button
+                      type="button"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 bg-none border-none cursor-pointer text-[#9CA3AF] p-1 flex items-center justify-center hover:text-[#6B7280]"
+                      onClick={() => setShowPw(!showPw)}
+                      aria-label={showPw ? "비밀번호 숨기기" : "비밀번호 보기"}
+                    >
+                      {showPw ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="mb-4 md:mb-[18px]">
+                  <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="rp-pw-confirm">비밀번호 확인</label>
+                  <div className="relative">
+                    <input
+                      id="rp-pw-confirm"
+                      className="w-full py-[13px] px-4 pr-11 bg-white border border-[#E5E7EB] rounded-lg text-[14px] text-[#0A0A0A] font-plex-sans-kr outline-none transition-[border-color] duration-200 placeholder-[#9CA3AF] focus:border-[#0991B2] md:py-[14px]"
+                      type={showConfirmPw ? "text" : "password"}
+                      placeholder="비밀번호를 다시 입력하세요"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                    />
+                    <button
+                      type="button"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 bg-none border-none cursor-pointer text-[#9CA3AF] p-1 flex items-center justify-center hover:text-[#6B7280]"
+                      onClick={() => setShowConfirmPw(!showConfirmPw)}
+                      aria-label={showConfirmPw ? "비밀번호 숨기기" : "비밀번호 보기"}
+                    >
+                      {showConfirmPw ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
+                  </div>
+                </div>
+
+                {error && (
+                  <p className="text-[13px] text-[#DC2626] mb-[14px] px-[14px] py-[10px] bg-[#FEF2F2] border border-[#FECACA] rounded-lg" role="alert">
+                    {error}
+                  </p>
+                )}
+
+                <button
+                  type="submit"
+                  className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:enabled:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed md:py-4 md:text-[16px]"
+                  disabled={isLoading}
+                >
+                  {isLoading ? "변경 중..." : "비밀번호 변경하기 →"}
+                </button>
+              </form>
+            )}
+          </div>
+        </section>
+      </main>
+
+      <footer className="mt-12 pb-8 flex gap-5 md:mt-16 md:pb-10">
+        {["개인정보처리방침", "이용약관", "쿠키"].map((item) => (
+          <a key={item} href="#" className="text-[11px] text-[#9CA3AF] no-underline transition-[color] duration-200 hover:text-[#6B7280]">
+            {item}
+          </a>
+        ))}
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/reset-password/ui/ResetPasswordPage.tsx
+++ b/src/pages/reset-password/ui/ResetPasswordPage.tsx
@@ -3,6 +3,50 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { Eye, EyeOff, KeyRound } from "lucide-react";
 import { confirmPasswordResetApi } from "@/features/auth/api/authApi";
 
+const INPUT_CLS = "w-full py-[13px] px-4 pr-11 bg-white border border-[#E5E7EB] rounded-lg text-[14px] text-[#0A0A0A] font-plex-sans-kr outline-none transition-[border-color] duration-200 placeholder-[#9CA3AF] focus:border-[#0991B2] md:py-[14px]";
+const TOGGLE_BTN_CLS = "absolute right-3 top-1/2 -translate-y-1/2 bg-none border-none cursor-pointer text-[#9CA3AF] p-1 flex items-center justify-center hover:text-[#6B7280]";
+
+function PasswordInput({ id, value, show, placeholder, onChange, onToggle }: {
+  id: string; value: string; show: boolean; placeholder: string;
+  onChange: (v: string) => void; onToggle: () => void;
+}) {
+  return (
+    <div className="relative">
+      <input id={id} className={INPUT_CLS} type={show ? "text" : "password"} placeholder={placeholder} value={value} onChange={(e) => onChange(e.target.value)} />
+      <button type="button" className={TOGGLE_BTN_CLS} onClick={onToggle} aria-label={show ? "비밀번호 숨기기" : "비밀번호 보기"}>
+        {show ? <EyeOff size={18} /> : <Eye size={18} />}
+      </button>
+    </div>
+  );
+}
+
+function InvalidTokenView() {
+  return (
+    <div className="text-center py-4">
+      <div className="w-14 h-14 rounded-full bg-[#FEF2F2] flex items-center justify-center mx-auto mb-4">
+        <KeyRound size={24} className="text-[#DC2626]" />
+      </div>
+      <p className="text-[14px] font-semibold text-[#DC2626] mb-4">유효하지 않은 링크입니다.</p>
+      <Link to="/login" className="text-[13px] text-[#0991B2] font-bold no-underline hover:underline">로그인 페이지로 이동 →</Link>
+    </div>
+  );
+}
+
+function SuccessView({ onLogin }: { onLogin: () => void }) {
+  return (
+    <div className="text-center py-4">
+      <div className="w-14 h-14 rounded-full bg-[#ECFDF5] flex items-center justify-center mx-auto mb-4">
+        <KeyRound size={24} className="text-[#059669]" />
+      </div>
+      <p className="text-[15px] font-bold text-[#0A0A0A] mb-2">비밀번호가 변경되었습니다!</p>
+      <p className="text-[13px] text-[#6B7280] mb-6">새 비밀번호로 로그인해 주세요.</p>
+      <button type="button" className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:opacity-85" onClick={onLogin}>
+        로그인하러 가기 →
+      </button>
+    </div>
+  );
+}
+
 export function ResetPasswordPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -16,28 +60,16 @@ export function ResetPasswordPage() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
-  const validate = (): string | null => {
-    if (!token) return "유효하지 않은 링크입니다.";
-    if (newPassword.length < 8) return "비밀번호는 8자 이상이어야 합니다.";
-    if (newPassword !== confirmPassword) return "비밀번호가 일치하지 않습니다.";
-    return null;
-  };
-
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
-    const err = validate();
-    if (err) { setError(err); return; }
-
+    if (newPassword.length < 8) { setError("비밀번호는 8자 이상이어야 합니다."); return; }
+    if (newPassword !== confirmPassword) { setError("비밀번호가 일치하지 않습니다."); return; }
     setIsLoading(true);
     const result = await confirmPasswordResetApi({ token, newPassword });
     setIsLoading(false);
-
-    if (result.success) {
-      setSuccess(true);
-    } else {
-      setError(result.message);
-    }
+    if (result.success) setSuccess(true);
+    else setError(result.message);
   };
 
   return (
@@ -46,111 +78,34 @@ export function ResetPasswordPage() {
         <Link to="/" className="flex items-center">
           <img src="/logo-korean.png" alt="미핏" className="h-[44px] w-auto md:h-[50px]" />
         </Link>
-        <Link
-          to="/login"
-          className="text-[13px] font-medium text-[#6B7280] no-underline px-4 py-2 border border-[#E5E7EB] rounded-lg transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F9FAFB]"
-        >
+        <Link to="/login" className="text-[13px] font-medium text-[#6B7280] no-underline px-4 py-2 border border-[#E5E7EB] rounded-lg transition-[color,background] duration-200 hover:text-[#0A0A0A] hover:bg-[#F9FAFB]">
           로그인 →
         </Link>
       </header>
 
       <main className="w-full max-w-content px-5 flex flex-col items-center md:max-w-container md:px-10">
         <section className="text-center pt-12 pb-8 md:pt-16 md:pb-10">
-          <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">
-            비밀번호 재설정
-          </div>
+          <div className="inline-block text-[12px] font-bold text-[#0991B2] bg-[#E6F7FA] rounded px-[14px] py-[5px] mb-[14px] md:text-[13px] md:px-[18px] md:py-[6px] md:mb-[18px]">비밀번호 재설정</div>
           <h1 className="font-plex-sans-kr text-[clamp(32px,9vw,48px)] font-black leading-[1.08] text-[#0A0A0A] mb-3 tracking-[-2px] md:text-[clamp(36px,5vw,52px)] md:mb-4">
-            새 비밀번호를
-            <br />
-            <span className="gradient-text">설정하세요</span>
+            새 비밀번호를<br /><span className="gradient-text">설정하세요</span>
           </h1>
           <p className="text-[14px] text-[#6B7280] leading-[1.7] md:text-[15px]">새로운 비밀번호를 입력하면 바로 로그인할 수 있어요.</p>
         </section>
 
         <section className="w-full flex justify-center">
           <div className="w-full max-w-[480px] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-7 shadow-[var(--sc)] sm:px-7 sm:py-9">
-            {!token ? (
-              <div className="text-center py-4">
-                <div className="w-14 h-14 rounded-full bg-[#FEF2F2] flex items-center justify-center mx-auto mb-4">
-                  <KeyRound size={24} className="text-[#DC2626]" />
-                </div>
-                <p className="text-[14px] font-semibold text-[#DC2626] mb-4">유효하지 않은 링크입니다.</p>
-                <Link to="/login" className="text-[13px] text-[#0991B2] font-bold no-underline hover:underline">
-                  로그인 페이지로 이동 →
-                </Link>
-              </div>
-            ) : success ? (
-              <div className="text-center py-4">
-                <div className="w-14 h-14 rounded-full bg-[#ECFDF5] flex items-center justify-center mx-auto mb-4">
-                  <KeyRound size={24} className="text-[#059669]" />
-                </div>
-                <p className="text-[15px] font-bold text-[#0A0A0A] mb-2">비밀번호가 변경되었습니다!</p>
-                <p className="text-[13px] text-[#6B7280] mb-6">새 비밀번호로 로그인해 주세요.</p>
-                <button
-                  type="button"
-                  className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:opacity-85"
-                  onClick={() => navigate("/login")}
-                >
-                  로그인하러 가기 →
-                </button>
-              </div>
-            ) : (
+            {!token ? <InvalidTokenView /> : success ? <SuccessView onLogin={() => navigate("/login")} /> : (
               <form onSubmit={handleSubmit} noValidate>
                 <div className="mb-4 md:mb-[18px]">
                   <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="rp-pw">새 비밀번호</label>
-                  <div className="relative">
-                    <input
-                      id="rp-pw"
-                      className="w-full py-[13px] px-4 pr-11 bg-white border border-[#E5E7EB] rounded-lg text-[14px] text-[#0A0A0A] font-plex-sans-kr outline-none transition-[border-color] duration-200 placeholder-[#9CA3AF] focus:border-[#0991B2] md:py-[14px]"
-                      type={showPw ? "text" : "password"}
-                      placeholder="8자 이상 입력하세요"
-                      value={newPassword}
-                      onChange={(e) => setNewPassword(e.target.value)}
-                    />
-                    <button
-                      type="button"
-                      className="absolute right-3 top-1/2 -translate-y-1/2 bg-none border-none cursor-pointer text-[#9CA3AF] p-1 flex items-center justify-center hover:text-[#6B7280]"
-                      onClick={() => setShowPw(!showPw)}
-                      aria-label={showPw ? "비밀번호 숨기기" : "비밀번호 보기"}
-                    >
-                      {showPw ? <EyeOff size={18} /> : <Eye size={18} />}
-                    </button>
-                  </div>
+                  <PasswordInput id="rp-pw" value={newPassword} show={showPw} placeholder="8자 이상 입력하세요" onChange={setNewPassword} onToggle={() => setShowPw(!showPw)} />
                 </div>
-
                 <div className="mb-4 md:mb-[18px]">
                   <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="rp-pw-confirm">비밀번호 확인</label>
-                  <div className="relative">
-                    <input
-                      id="rp-pw-confirm"
-                      className="w-full py-[13px] px-4 pr-11 bg-white border border-[#E5E7EB] rounded-lg text-[14px] text-[#0A0A0A] font-plex-sans-kr outline-none transition-[border-color] duration-200 placeholder-[#9CA3AF] focus:border-[#0991B2] md:py-[14px]"
-                      type={showConfirmPw ? "text" : "password"}
-                      placeholder="비밀번호를 다시 입력하세요"
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                    />
-                    <button
-                      type="button"
-                      className="absolute right-3 top-1/2 -translate-y-1/2 bg-none border-none cursor-pointer text-[#9CA3AF] p-1 flex items-center justify-center hover:text-[#6B7280]"
-                      onClick={() => setShowConfirmPw(!showConfirmPw)}
-                      aria-label={showConfirmPw ? "비밀번호 숨기기" : "비밀번호 보기"}
-                    >
-                      {showConfirmPw ? <EyeOff size={18} /> : <Eye size={18} />}
-                    </button>
-                  </div>
+                  <PasswordInput id="rp-pw-confirm" value={confirmPassword} show={showConfirmPw} placeholder="비밀번호를 다시 입력하세요" onChange={setConfirmPassword} onToggle={() => setShowConfirmPw(!showConfirmPw)} />
                 </div>
-
-                {error && (
-                  <p className="text-[13px] text-[#DC2626] mb-[14px] px-[14px] py-[10px] bg-[#FEF2F2] border border-[#FECACA] rounded-lg" role="alert">
-                    {error}
-                  </p>
-                )}
-
-                <button
-                  type="submit"
-                  className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:enabled:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed md:py-4 md:text-[16px]"
-                  disabled={isLoading}
-                >
+                {error && <p className="text-[13px] text-[#DC2626] mb-[14px] px-[14px] py-[10px] bg-[#FEF2F2] border border-[#FECACA] rounded-lg" role="alert">{error}</p>}
+                <button type="submit" className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:enabled:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed md:py-4 md:text-[16px]" disabled={isLoading}>
                   {isLoading ? "변경 중..." : "비밀번호 변경하기 →"}
                 </button>
               </form>
@@ -161,9 +116,7 @@ export function ResetPasswordPage() {
 
       <footer className="mt-12 pb-8 flex gap-5 md:mt-16 md:pb-10">
         {["개인정보처리방침", "이용약관", "쿠키"].map((item) => (
-          <a key={item} href="#" className="text-[11px] text-[#9CA3AF] no-underline transition-[color] duration-200 hover:text-[#6B7280]">
-            {item}
-          </a>
+          <a key={item} href="#" className="text-[11px] text-[#9CA3AF] no-underline transition-[color] duration-200 hover:text-[#6B7280]">{item}</a>
         ))}
       </footer>
     </div>

--- a/src/pages/reset-password/ui/ResetPasswordPage.tsx
+++ b/src/pages/reset-password/ui/ResetPasswordPage.tsx
@@ -6,7 +6,7 @@ import { confirmPasswordResetApi } from "@/features/auth/api/authApi";
 const INPUT_CLS = "w-full py-[13px] px-4 pr-11 bg-white border border-[#E5E7EB] rounded-lg text-[14px] text-[#0A0A0A] font-plex-sans-kr outline-none transition-[border-color] duration-200 placeholder-[#9CA3AF] focus:border-[#0991B2] md:py-[14px]";
 const TOGGLE_BTN_CLS = "absolute right-3 top-1/2 -translate-y-1/2 bg-none border-none cursor-pointer text-[#9CA3AF] p-1 flex items-center justify-center hover:text-[#6B7280]";
 
-function PasswordInput({ id, value, show, placeholder, onChange, onToggle }: {
+function SecureInput({ id, value, show, placeholder, onChange, onToggle }: {
   id: string; value: string; show: boolean; placeholder: string;
   onChange: (v: string) => void; onToggle: () => void;
 }) {
@@ -98,11 +98,11 @@ export function ResetPasswordPage() {
               <form onSubmit={handleSubmit} noValidate>
                 <div className="mb-4 md:mb-[18px]">
                   <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="rp-pw">새 비밀번호</label>
-                  <PasswordInput id="rp-pw" value={newPw} show={showPw} placeholder="8자 이상 입력하세요" onChange={setNewPw} onToggle={() => setShowPw(!showPw)} />
+                  <SecureInput id="rp-pw" value={newPw} show={showPw} placeholder="8자 이상 입력하세요" onChange={setNewPw} onToggle={() => setShowPw(!showPw)} />
                 </div>
                 <div className="mb-4 md:mb-[18px]">
                   <label className="block text-[13px] font-semibold text-[#374151] mb-1.5" htmlFor="rp-pw-confirm">비밀번호 확인</label>
-                  <PasswordInput id="rp-pw-confirm" value={confirmPw} show={showConfirmPw} placeholder="비밀번호를 다시 입력하세요" onChange={setConfirmPw} onToggle={() => setShowConfirmPw(!showConfirmPw)} />
+                  <SecureInput id="rp-pw-confirm" value={confirmPw} show={showConfirmPw} placeholder="비밀번호를 다시 입력하세요" onChange={setConfirmPw} onToggle={() => setShowConfirmPw(!showConfirmPw)} />
                 </div>
                 {error && <p className="text-[13px] text-[#DC2626] mb-[14px] px-[14px] py-[10px] bg-[#FEF2F2] border border-[#FECACA] rounded-lg" role="alert">{error}</p>}
                 <button type="submit" className="w-full py-[15px] bg-[#0A0A0A] text-white font-plex-sans-kr text-[15px] font-bold border-none rounded-lg cursor-pointer transition-opacity duration-200 hover:enabled:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed md:py-4 md:text-[16px]" disabled={isLoading}>


### PR DESCRIPTION
## 관련 이슈
Closes #146

## 변경 사항
- 비밀번호 찾기 페이지(`/forgot-password`)를 추가하여 이메일 입력 후 비밀번호 재설정 링크를 요청할 수 있도록 구현했습니다.
- 비밀번호 재설정 페이지(`/reset-password`)를 추가하여 토큰 기반으로 새 비밀번호를 설정할 수 있도록 구현했습니다.
- 로그인 페이지와 설정 페이지에 비밀번호 찾기 링크를 추가하여 사용자가 비밀번호 재설정 흐름으로 쉽게 이동할 수 있도록 개선했습니다.

## 변경 유형
- [ ] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. `/forgot-password` 페이지에서 이메일을 입력한 뒤 비밀번호 재설정 링크 발송 요청이 정상적으로 동작하는지 확인했습니다.
2. 이메일로 전달된 토큰을 사용해 `/reset-password` 페이지에 접근한 뒤 새 비밀번호 설정이 정상적으로 완료되는지 확인했습니다.
3. 잘못되었거나 만료된 토큰으로 접근했을 때 에러 메시지가 표시되는지 확인했습니다.
4. 로그인 페이지에서 비밀번호 찾기 링크 클릭 시 `/forgot-password` 페이지로 정상 이동하는지 확인했습니다.
5. 설정 페이지에서 비밀번호 찾기 링크 클릭 시 `/forgot-password` 페이지로 정상 이동하는지 확인했습니다.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 반응형 디자인을 확인했습니다
- [x] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보
- 비밀번호 재설정 링크 발송 및 토큰 검증은 백엔드 API 응답을 기준으로 처리됩니다.
- 토큰이 만료되었거나 유효하지 않은 경우 사용자에게 에러 메시지가 표시되도록 처리했습니다.
- 자동화 테스트는 추가하지 않았으며, 주요 사용자 흐름은 Chrome 환경에서 수동으로 확인했습니다.