### PR TITLE
이메일 알림 설정 API 연동 및 토글 방식 수정

### DIFF
--- a/src/features/settings/api/settingsApi.ts
+++ b/src/features/settings/api/settingsApi.ts
@@ -22,7 +22,6 @@ export interface SettingsProfile {
 export interface SettingsNotifications {
   streakReminder: boolean;
   streakExpire: boolean;
-  streakReward: boolean;
   reportReady: boolean;
   serviceNotice: boolean;
   marketing: boolean;
@@ -55,14 +54,13 @@ export interface ApiResult {
   message: string;
 }
 
-/* ── Fallback Mock (비프로필 영역 — 아직 API 미구현) ── */
-const MOCK_NOTIFICATIONS: SettingsNotifications = {
+/* ── Fallback (이메일 알림 API 호출 실패 시 모든 항목 동의 상태로 가정) ── */
+const FALLBACK_NOTIFICATIONS: SettingsNotifications = {
   streakReminder: true,
   streakExpire: true,
-  streakReward: true,
   reportReady: true,
-  serviceNotice: false,
-  marketing: false,
+  serviceNotice: true,
+  marketing: true,
 };
 
 const MOCK_SUBSCRIPTION: SettingsSubscription = {
@@ -77,21 +75,27 @@ const MOCK_SUBSCRIPTION: SettingsSubscription = {
 /* ── Fetch Settings ──
    - 사용자 기본정보: GET /api/v1/users/me/
    - 프로필 (직군/직업): GET /api/v1/profiles/me/
-   - 나머지는 미구현 → mock fallback
+   - 이메일 알림: GET /api/v1/email-notifications/
+   - 구독: 미구현 → mock fallback
 */
 export async function fetchSettingsApi(): Promise<{ success: boolean; data?: SettingsData; error?: string }> {
   try {
-    const [me, userProfile, myConsents, avatar] = await Promise.allSettled([
+    const [me, userProfile, myConsents, avatar, notifications] = await Promise.allSettled([
       getMeApi(),
       profileApi.getMyProfile(),
       getMyConsentsApi(),
       profileApi.getAvatar(),
+      fetchEmailNotificationsApi(),
     ]);
 
     const meData = me.status === "fulfilled" ? me.value : null;
     const profileData = userProfile.status === "fulfilled" ? userProfile.value : null;
     const consentsData = myConsents.status === "fulfilled" ? myConsents.value : [];
     const avatarData = avatar.status === "fulfilled" ? avatar.value : null;
+    const notificationsData =
+      notifications.status === "fulfilled" && notifications.value.success && notifications.value.data
+        ? notifications.value.data
+        : FALLBACK_NOTIFICATIONS;
 
     const profile: SettingsProfile = {
       name: meData?.name ?? "",
@@ -130,13 +134,26 @@ export async function fetchSettingsApi(): Promise<{ success: boolean; data?: Set
       success: true,
       data: {
         profile,
-        notifications: MOCK_NOTIFICATIONS,
+        notifications: notificationsData,
         subscription: MOCK_SUBSCRIPTION,
         consents,
       },
     };
   } catch {
     return { success: false, error: "설정을 불러오지 못했습니다." };
+  }
+}
+
+/* ── Fetch Email Notifications ── GET /api/v1/email-notifications/ ── */
+export async function fetchEmailNotificationsApi(): Promise<{ success: boolean; data?: SettingsNotifications; message?: string }> {
+  try {
+    const data = await apiRequest<SettingsNotifications>("/api/v1/email-notifications/", {
+      method: "GET",
+      auth: true,
+    });
+    return { success: true, data };
+  } catch {
+    return { success: false, message: "알림 설정을 불러오지 못했습니다." };
   }
 }
 
@@ -183,10 +200,10 @@ export async function changePasswordApi(payload: {
   }
 }
 
-/* ── Update Notifications ── */
-export async function updateNotificationsApi(payload: SettingsNotifications): Promise<ApiResult> {
+/* ── Update Notifications ── PUT /api/v1/email-notifications/ ── */
+export async function updateNotificationsApi(payload: Partial<SettingsNotifications>): Promise<ApiResult> {
   try {
-    await apiRequest("/api/v1/users/notifications/", {
+    await apiRequest("/api/v1/email-notifications/", {
       method: "PUT", auth: true, body: JSON.stringify(payload),
     });
     return { success: true, message: "알림 설정이 저장되었습니다." };

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -26,6 +26,8 @@ interface SettingsState {
   data: SettingsData | null;
   loading: boolean;
   saving: boolean;
+  /* 동시 진행 중인 알림 토글 PUT 개수 (race condition 방지: 모든 요청 완료 시까지 saving 유지) */
+  pendingNotificationRequests: number;
   error: string | null;
   saveMessage: string | null;
   activePanel: SettingsPanel;
@@ -75,6 +77,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   data: null,
   loading: false,
   saving: false,
+  pendingNotificationRequests: 0,
   error: null,
   saveMessage: null,
   activePanel: "account" as SettingsPanel,
@@ -273,9 +276,10 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     const previousValue = data.notifications[key];
     const newValue = !previousValue;
 
-    /* Optimistic update: 즉시 UI 반영 → 실패 시 rollback */
+    /* Optimistic update: 즉시 UI 반영 → 실패 시 rollback. 카운터로 동시 요청 추적. */
     set((s) => ({
       saving: true,
+      pendingNotificationRequests: s.pendingNotificationRequests + 1,
       error: null,
       saveMessage: null,
       data: s.data ? {
@@ -287,16 +291,27 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     const res = await updateNotificationsApi({ [key]: newValue });
 
     if (res.success) {
-      set({ saving: false, saveMessage: res.message });
+      set((s) => {
+        const remaining = s.pendingNotificationRequests - 1;
+        return {
+          pendingNotificationRequests: remaining,
+          saving: remaining > 0,
+          saveMessage: res.message,
+        };
+      });
     } else {
-      set((s) => ({
-        saving: false,
-        error: res.message,
-        data: s.data ? {
-          ...s.data,
-          notifications: { ...s.data.notifications, [key]: previousValue },
-        } : s.data,
-      }));
+      set((s) => {
+        const remaining = s.pendingNotificationRequests - 1;
+        return {
+          pendingNotificationRequests: remaining,
+          saving: remaining > 0,
+          error: res.message,
+          data: s.data ? {
+            ...s.data,
+            notifications: { ...s.data.notifications, [key]: previousValue },
+          } : s.data,
+        };
+      });
     }
   },
 

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -39,7 +39,6 @@ interface SettingsState {
 
   /* Draft state for editing */
   profileDraft: ProfileDraft;
-  notificationsDraft: Partial<SettingsNotifications>;
   passwordDraft: { currentPassword: string; newPassword: string; confirmPassword: string };
   aiDataDraft: boolean | null;
 
@@ -59,9 +58,7 @@ interface SettingsState {
   savePassword: () => Promise<void>;
   resetPasswordDraft: () => void;
 
-  toggleNotification: (key: keyof SettingsNotifications) => void;
-  saveNotifications: () => Promise<void>;
-  resetNotificationsDraft: () => void;
+  toggleNotification: (key: keyof SettingsNotifications) => Promise<void>;
 
   setAiDataDraft: (value: boolean) => void;
   saveConsents: () => Promise<void>;
@@ -89,7 +86,6 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   availableJobsLoading: false,
 
   profileDraft: EMPTY_PROFILE_DRAFT,
-  notificationsDraft: {},
   passwordDraft: { currentPassword: "", newPassword: "", confirmPassword: "" },
   aiDataDraft: null,
 
@@ -107,7 +103,6 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
           jobIds: profile.jobIds,
           careerStage: profile.careerStage,
         },
-        notificationsDraft: { ...res.data.notifications },
         aiDataDraft: res.data.consents.aiDataAgreed,
       });
       // 프로필에 직군이 있으면 해당 직군의 직업 목록을 미리 로드
@@ -271,31 +266,38 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     set({ passwordDraft: { currentPassword: "", newPassword: "", confirmPassword: "" }, saveMessage: null, error: null });
   },
 
-  toggleNotification: (key) => {
-    set((s) => ({
-      notificationsDraft: { ...s.notificationsDraft, [key]: !s.notificationsDraft[key] },
-    }));
-  },
+  toggleNotification: async (key) => {
+    const { data } = get();
+    if (!data) return;
 
-  saveNotifications: async () => {
-    const { notificationsDraft, data } = get();
-    const merged: SettingsNotifications = { ...data!.notifications, ...notificationsDraft };
-    set({ saving: true, error: null, saveMessage: null });
-    const res = await updateNotificationsApi(merged);
+    const previousValue = data.notifications[key];
+    const newValue = !previousValue;
+
+    /* Optimistic update: 즉시 UI 반영 → 실패 시 rollback */
+    set((s) => ({
+      saving: true,
+      error: null,
+      saveMessage: null,
+      data: s.data ? {
+        ...s.data,
+        notifications: { ...s.data.notifications, [key]: newValue },
+      } : s.data,
+    }));
+
+    const res = await updateNotificationsApi({ [key]: newValue });
+
     if (res.success) {
+      set({ saving: false, saveMessage: res.message });
+    } else {
       set((s) => ({
         saving: false,
-        saveMessage: res.message,
-        data: s.data ? { ...s.data, notifications: merged } : s.data,
+        error: res.message,
+        data: s.data ? {
+          ...s.data,
+          notifications: { ...s.data.notifications, [key]: previousValue },
+        } : s.data,
       }));
-    } else {
-      set({ saving: false, error: res.message });
     }
-  },
-
-  resetNotificationsDraft: () => {
-    const data = get().data;
-    if (data) set({ notificationsDraft: { ...data.notifications }, saveMessage: null });
   },
 
   setAiDataDraft: (value) => set({ aiDataDraft: value }),

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -38,13 +38,13 @@ export function SettingsPage() {
   const navigate = useNavigate();
   const {
     data, loading, saving, error, saveMessage, activePanel,
-    profileDraft, notificationsDraft, passwordDraft, aiDataDraft,
+    profileDraft, passwordDraft, aiDataDraft,
     jobCategories, jobCategoriesLoading, availableJobs, availableJobsLoading,
     fetchSettings, setActivePanel,
     loadJobCategories,
     setProfileDraftField, toggleJobId, uploadAvatar, saveProfile, resetProfileDraft,
     setPasswordDraft, savePassword, resetPasswordDraft,
-    toggleNotification, saveNotifications, resetNotificationsDraft,
+    toggleNotification,
     setAiDataDraft, saveConsents,
     deleteAccount,
     clearMessage,
@@ -207,9 +207,25 @@ export function SettingsPage() {
 
                 {/* ─── NOTIFICATIONS PANEL ─── */}
                 <div className={`${activePanel === "notifications" ? "block animate-[spFadeUp_0.3s_ease_both]" : "hidden"}`}>
-                  <div className="mb-7">
-                    <h1 className="font-plex-sans-kr text-[26px] font-black tracking-[-0.5px] text-[#0A0A0A] mb-[5px]">알림 설정</h1>
-                    <p className="text-[14px] text-[#6B7280] leading-[1.55]">원하는 알림만 골라서 받아보세요</p>
+                  <div className="mb-7 flex items-end justify-between gap-3 max-[640px]:flex-col max-[640px]:items-start">
+                    <div>
+                      <h1 className="font-plex-sans-kr text-[26px] font-black tracking-[-0.5px] text-[#0A0A0A] mb-[5px]">알림 설정</h1>
+                      <p className="text-[14px] text-[#6B7280] leading-[1.55]">원하는 알림만 골라서 받아보세요. 변경 사항은 자동으로 저장됩니다.</p>
+                    </div>
+                    <div className="min-h-[18px] text-[12px] font-bold flex items-center gap-2">
+                      {saving && activePanel === "notifications" && (
+                        <span className="text-[#6B7280] flex items-center gap-1.5">
+                          <span className="w-[12px] h-[12px] border-2 border-[#9CA3AF]/30 border-t-[#0991B2] rounded-full animate-[spSpin_0.6s_linear_infinite]" />
+                          저장 중…
+                        </span>
+                      )}
+                      {!saving && saveMessage && activePanel === "notifications" && (
+                        <span className="text-[#059669] animate-[spFadeUp_0.3s_ease]">✓ {saveMessage}</span>
+                      )}
+                      {!saving && error && activePanel === "notifications" && (
+                        <span className="text-[#EF4444] animate-[spFadeUp_0.3s_ease]">✕ {error}</span>
+                      )}
+                    </div>
                   </div>
 
                   <div className="bg-[#F9FAFB] border border-[#E5E7EB] rounded-xl px-7 py-7 shadow-[var(--sc)] mb-4 max-[640px]:px-[18px]">
@@ -225,7 +241,7 @@ export function SettingsPage() {
                         key={item.key}
                         title={item.title}
                         desc={item.desc}
-                        checked={notificationsDraft[item.key] ?? false}
+                        checked={data.notifications[item.key]}
                         onClick={() => toggleNotification(item.key)}
                       />
                     ))}
@@ -243,19 +259,10 @@ export function SettingsPage() {
                         key={item.key}
                         title={item.title}
                         desc={item.desc}
-                        checked={notificationsDraft[item.key] ?? false}
+                        checked={data.notifications[item.key]}
                         onClick={() => toggleNotification(item.key)}
                       />
                     ))}
-                  </div>
-
-                  <div className="flex items-center justify-end gap-[10px] pt-5 border-t border-[#E5E7EB] mt-1 max-[640px]:flex-col-reverse max-[640px]:items-stretch">
-                    {saveMessage && activePanel === "notifications" && <span className="text-[12px] font-bold text-[#059669] mr-auto animate-[spFadeUp_0.3s_ease]">✓ {saveMessage}</span>}
-                    {error && activePanel === "notifications" && <span className="text-[12px] font-bold text-[#EF4444] mr-auto animate-[spFadeUp_0.3s_ease]">✕ {error}</span>}
-                    <button className="font-plex-sans-kr text-[14px] font-semibold text-[#6B7280] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-[10px] cursor-pointer transition-all duration-150 hover:bg-[#F3F4F6] hover:text-[#0A0A0A]" onClick={resetNotificationsDraft}>취소</button>
-                    <button className="font-plex-sans-kr text-[14px] font-bold text-white bg-[#0A0A0A] border-none rounded-lg px-6 py-[10px] cursor-pointer transition-all duration-150 flex items-center gap-[7px] hover:opacity-85 hover:-translate-y-px disabled:opacity-60 disabled:cursor-not-allowed max-[640px]:justify-center" onClick={saveNotifications} disabled={saving}>
-                      {saving ? <span className="w-[14px] h-[14px] border-2 border-white/40 border-t-white rounded-full animate-[spSpin_0.6s_linear_infinite]" /> : <span>저장하기</span>}
-                    </button>
                   </div>
                 </div>
 

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -219,10 +219,10 @@ export function SettingsPage() {
                     {([
                       { key: "streakReminder", title: "스트릭 리마인더", desc: "오늘 면접 연습을 아직 하지 않았을 때 저녁 8시에 알림" },
                       { key: "streakExpire", title: "스트릭 만료 경고", desc: "자정 1시간 전, 오늘 스트릭이 만료될 예정일 때 알림" },
-                      { key: "streakReward", title: "스트릭 보상 수령", desc: "마일스톤 달성 시 보상이 지급되었을 때 알림" },
                       { key: "reportReady", title: "면접 리포트 완성", desc: "AI 면접 리뷰 리포트 생성이 완료되었을 때 알림" },
                     ] as const).map((item) => (
                       <NotificationToggle
+                        key={item.key}
                         title={item.title}
                         desc={item.desc}
                         checked={notificationsDraft[item.key] ?? false}
@@ -240,6 +240,7 @@ export function SettingsPage() {
                       { key: "marketing", title: "마케팅 정보 수신", desc: "할인, 프로모션, 이벤트 등 혜택 정보 이메일 발송" },
                     ] as const).map((item) => (
                       <NotificationToggle
+                        key={item.key}
                         title={item.title}
                         desc={item.desc}
                         checked={notificationsDraft[item.key] ?? false}


### PR DESCRIPTION
## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- 이메일 알림 설정 API와 연동하여 사용자 알림 설정을 가져오도록 변경
- 알림 설정의 토글 방식을 개별적으로 처리하도록 개선
- UI에서 알림 설정 저장 시 피드백 표시 기능 추가

## 변경 유형
해당하는 항목에 체크해주세요.

- [x] 버그 수정 (Bug fix)
- [x] 새로운 기능 (New feature)
- [ ] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법
변경 사항을 테스트한 방법을 설명해주세요.

- [x] 단위 테스트 (Unit tests)
- [x] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [ ] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 이메일 알림 설정이 로드되는지 확인
2. 각각의 알림 토글이 정상적으로 작동하는지 확인
3. 알림 설정 변경 시 UI의 피드백이 정상적으로 표시되는지 확인

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [ ] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷
UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보
리뷰어가 알아야 할 추가 정보를 작성해주세요.