### PR TITLE
[148] 자잘한 수정

### DIFF
--- a/src/features/jd/model/detailStore.ts
+++ b/src/features/jd/model/detailStore.ts
@@ -48,6 +48,7 @@ interface JdDetailState {
   error: string | null;
 
   fetchJd: (uuid: string) => Promise<void>;
+  silentRefreshJd: (uuid: string) => Promise<void>;
   updateStatus: (next: JdStatus) => Promise<boolean>;
   deleteJd: () => Promise<boolean>;
   clearError: () => void;
@@ -102,6 +103,15 @@ export const useJdDetailStore = create<JdDetailState>()((set, get) => ({
         isLoading: false,
         error: e instanceof Error ? e.message : "채용공고를 찾을 수 없습니다.",
       });
+    }
+  },
+
+  silentRefreshJd: async (uuid) => {
+    try {
+      const raw = await userJobDescriptionApi.retrieve(uuid);
+      set({ jd: toDetail(raw) });
+    } catch {
+      // silent — don't overwrite error state
     }
   },
 

--- a/src/features/jd/model/listStore.ts
+++ b/src/features/jd/model/listStore.ts
@@ -36,7 +36,6 @@ export interface JdListItem {
   companyColor: string;
   categoryId: number;
   title: string;
-  categoryId: number;
   status: JdListStatus;
   tags: JdTag[];
   registeredAt: string;
@@ -46,9 +45,9 @@ export interface JdListItem {
   raw: UserJobDescription;
 }
 
-export type FilterKey = "all" | "planned" | "applied" | "saved";
-
 export type JdListStats = UserJobDescriptionStats;
+
+export type FilterKey = "all" | "planned" | "applied" | "saved";
 
 interface JdListState {
   items: JdListItem[];
@@ -89,7 +88,6 @@ function transform(item: UserJobDescription): JdListItem {
     companyColor: getCompanyColor(company),
     categoryId: inferCategoryId(jd.platform || "", title),
     title,
-    categoryId: inferCategoryId(jd.platform || "", title),
     status,
     tags,
     registeredAt: getRelativeTime(item.createdAt),

--- a/src/features/jd/model/listStore.ts
+++ b/src/features/jd/model/listStore.ts
@@ -34,6 +34,7 @@ export interface JdListItem {
   company: string;
   companyInitial: string;
   companyColor: string;
+  categoryId: number;
   title: string;
   categoryId: number;
   status: JdListStatus;
@@ -86,6 +87,7 @@ function transform(item: UserJobDescription): JdListItem {
     company,
     companyInitial: getCompanyInitial(company),
     companyColor: getCompanyColor(company),
+    categoryId: inferCategoryId(jd.platform || "", title),
     title,
     categoryId: inferCategoryId(jd.platform || "", title),
     status,

--- a/src/features/settings/api/settingsApi.ts
+++ b/src/features/settings/api/settingsApi.ts
@@ -167,14 +167,34 @@ export async function uploadAvatarApi(file: File): Promise<{ success: boolean; a
   }
 }
 
+/* ── Update Name ── PATCH /api/v1/users/me/ ── */
+export async function updateNameApi(name: string): Promise<ApiResult> {
+  try {
+    const body = new URLSearchParams({ name });
+    await apiRequest("/api/v1/users/me/", {
+      method: "PATCH",
+      auth: true,
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+    return { success: true, message: "이름이 저장되었습니다." };
+  } catch {
+    return { success: false, message: "이름 저장에 실패했습니다." };
+  }
+}
+
 /* ── Update Profile ── POST /api/v1/profiles/me/ ── */
 export async function updateProfileApi(payload: {
+  name: string;
   jobCategoryId: number;
   jobIds: number[];
   careerStage?: string;
 }): Promise<ApiResult> {
   try {
-    await profileApi.saveMyProfile({ jobCategoryId: payload.jobCategoryId, jobIds: payload.jobIds, careerStage: payload.careerStage });
+    await Promise.all([
+      updateNameApi(payload.name),
+      profileApi.saveMyProfile({ jobCategoryId: payload.jobCategoryId, jobIds: payload.jobIds, careerStage: payload.careerStage }),
+    ]);
     return { success: true, message: "프로필이 저장되었습니다." };
   } catch {
     return { success: false, message: "저장에 실패했습니다." };

--- a/src/features/settings/api/settingsApi.ts
+++ b/src/features/settings/api/settingsApi.ts
@@ -22,6 +22,7 @@ export interface SettingsProfile {
 export interface SettingsNotifications {
   streakReminder: boolean;
   streakExpire: boolean;
+  streakReward: boolean;
   reportReady: boolean;
   serviceNotice: boolean;
   marketing: boolean;
@@ -58,6 +59,7 @@ export interface ApiResult {
 const FALLBACK_NOTIFICATIONS: SettingsNotifications = {
   streakReminder: true,
   streakExpire: true,
+  streakReward: true,
   reportReady: true,
   serviceNotice: true,
   marketing: true,

--- a/src/features/settings/api/settingsApi.ts
+++ b/src/features/settings/api/settingsApi.ts
@@ -193,10 +193,11 @@ export async function updateProfileApi(payload: {
   careerStage?: string;
 }): Promise<ApiResult> {
   try {
-    await Promise.all([
+    const [nameRes] = await Promise.all([
       updateNameApi(payload.name),
       profileApi.saveMyProfile({ jobCategoryId: payload.jobCategoryId, jobIds: payload.jobIds, careerStage: payload.careerStage }),
     ]);
+    if (!nameRes.success) return nameRes;
     return { success: true, message: "프로필이 저장되었습니다." };
   } catch {
     return { success: false, message: "저장에 실패했습니다." };

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -28,8 +28,11 @@ interface SettingsState {
   saving: boolean;
   /* 동시 진행 중인 알림 토글 PUT 개수 (race condition 방지: 모든 요청 완료 시까지 saving 유지) */
   pendingNotificationRequests: number;
+  passwordSaving: boolean;
   error: string | null;
   saveMessage: string | null;
+  passwordError: string | null;
+  passwordSaveMessage: string | null;
   activePanel: SettingsPanel;
   consentBadge: boolean;
 
@@ -69,6 +72,7 @@ interface SettingsState {
   deleteAccount: () => Promise<void>;
 
   clearMessage: () => void;
+  clearPasswordMessage: () => void;
 }
 
 const EMPTY_PROFILE_DRAFT: ProfileDraft = { name: "", jobCategoryId: null, jobIds: [], careerStage: "" };
@@ -78,8 +82,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   loading: false,
   saving: false,
   pendingNotificationRequests: 0,
+  passwordSaving: false,
   error: null,
   saveMessage: null,
+  passwordError: null,
+  passwordSaveMessage: null,
   activePanel: "account" as SettingsPanel,
   consentBadge: true,
 
@@ -250,23 +257,23 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   savePassword: async () => {
     const { passwordDraft } = get();
     if (passwordDraft.newPassword !== passwordDraft.confirmPassword) {
-      set({ error: "새 비밀번호가 일치하지 않습니다." });
+      set({ passwordError: "새 비밀번호가 일치하지 않습니다." });
       return;
     }
-    set({ saving: true, error: null, saveMessage: null });
+    set({ passwordSaving: true, passwordError: null, passwordSaveMessage: null });
     const res = await changePasswordApi({
       currentPassword: passwordDraft.currentPassword,
       newPassword: passwordDraft.newPassword,
     });
     if (res.success) {
-      set({ saving: false, saveMessage: res.message, passwordDraft: { currentPassword: "", newPassword: "", confirmPassword: "" } });
+      set({ passwordSaving: false, passwordSaveMessage: res.message, passwordDraft: { currentPassword: "", newPassword: "", confirmPassword: "" } });
     } else {
-      set({ saving: false, error: res.message });
+      set({ passwordSaving: false, passwordError: res.message });
     }
   },
 
   resetPasswordDraft: () => {
-    set({ passwordDraft: { currentPassword: "", newPassword: "", confirmPassword: "" }, saveMessage: null, error: null });
+    set({ passwordDraft: { currentPassword: "", newPassword: "", confirmPassword: "" }, passwordSaveMessage: null, passwordError: null });
   },
 
   toggleNotification: async (key) => {
@@ -345,4 +352,5 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   },
 
   clearMessage: () => set({ saveMessage: null, error: null }),
+  clearPasswordMessage: () => set({ passwordSaveMessage: null, passwordError: null }),
 }));

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -204,6 +204,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     }
     set({ saving: true, error: null, saveMessage: null });
     const res = await updateProfileApi({
+      name: profileDraft.name,
       jobCategoryId: profileDraft.jobCategoryId,
       jobIds: profileDraft.jobIds,
       careerStage: profileDraft.careerStage || undefined,
@@ -221,6 +222,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
             ...s.data,
             profile: {
               ...s.data.profile,
+              name: profileDraft.name,
+              avatarInitial: profileDraft.name ? profileDraft.name[0] : s.data.profile.avatarInitial,
               jobCategoryId: profileDraft.jobCategoryId,
               jobCategory: selectedCategory,
               jobIds: profileDraft.jobIds,

--- a/src/features/settings/model/store.ts
+++ b/src/features/settings/model/store.ts
@@ -210,6 +210,9 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       careerStage: profileDraft.careerStage || undefined,
     });
     if (res.success) {
+      // auth store user name 업데이트 (navbar 즉시 반영)
+      const authUser = useAuthStore.getState().user;
+      if (authUser) useAuthStore.getState().setUser({ ...authUser, name: profileDraft.name });
       // 로컬 data 업데이트
       set((s) => {
         if (!s.data) return { saving: false, saveMessage: res.message };

--- a/src/features/settings/ui/PasswordChangeForm.tsx
+++ b/src/features/settings/ui/PasswordChangeForm.tsx
@@ -104,7 +104,7 @@ export function PasswordChangeForm({
         </p>
       </div>
 
-      <div className="flex items-center justify-end gap-[10px] pt-5 border-t border-[#E5E7EB] mt-1 max-[640px]:flex-col-reverse max-[640px]:items-stretch">
+      <div className="flex items-center justify-end gap-[10px] mt-5 max-[640px]:flex-col-reverse max-[640px]:items-stretch">
         {saveMessage && <span className="text-[12px] font-bold text-[#059669] mr-auto animate-[spFadeUp_0.3s_ease]">✓ {saveMessage}</span>}
         {error && <span className="text-[12px] font-bold text-[#EF4444] mr-auto animate-[spFadeUp_0.3s_ease]">✕ {error}</span>}
         <button className="font-plex-sans-kr text-[14px] font-semibold text-[#6B7280] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-[10px] cursor-pointer transition-all duration-150 hover:bg-[#F3F4F6] hover:text-[#0A0A0A]" onClick={onReset}>취소</button>
@@ -116,6 +116,7 @@ export function PasswordChangeForm({
           {saving ? <span className="w-[14px] h-[14px] border-2 border-white/40 border-t-white rounded-full animate-[spSpin_0.6s_linear_infinite]" /> : <span>변경하기</span>}
         </button>
       </div>
+      <div className="border-t border-[#E5E7EB] my-5" />
     </>
   );
 }

--- a/src/pages/achievements/ui/AchievementsPage.tsx
+++ b/src/pages/achievements/ui/AchievementsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Loader2, RefreshCw } from "lucide-react";
+import { AlertTriangle, Loader2, RefreshCw, Trophy } from "lucide-react";
 import { useAchievementsStore } from "@/features/achievements";
 import { AchievementCard } from "@/features/achievements";
 import { refreshAchievementsApi } from "@/features/achievements/api/achievementsApi";
@@ -39,7 +39,7 @@ export function AchievementsPage() {
         <div className="flex items-start justify-between mb-8 gap-4">
           <div>
             <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[1.4px] uppercase text-[#0991B2] bg-[#E6F7FA] py-1 px-3 rounded-full mb-2.5">
-              🏆 도전과제
+              <Trophy size={12} /> 도전과제
             </div>
             <h1 className="text-[clamp(24px,3vw,36px)] font-black tracking-[-0.8px] text-[#0A0A0A] leading-[1.1]">
               내 도전과제
@@ -72,7 +72,7 @@ export function AchievementsPage() {
           </div>
         ) : !data && error ? (
           <div className="flex flex-col items-center justify-center py-20 text-center">
-            <span className="text-5xl mb-5">⚠️</span>
+            <AlertTriangle size={48} className="text-[#F59E0B] mb-5" />
             <p className="text-[15px] font-extrabold text-[#0A0A0A] mb-2">불러오기 실패</p>
             <p className="text-sm text-[#9CA3AF]">{error}</p>
           </div>
@@ -85,7 +85,7 @@ export function AchievementsPage() {
             )}
             {data && data.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-20 text-center">
-                <span className="text-5xl mb-5">🏆</span>
+                <Trophy size={48} className="text-[#0991B2] mb-5" />
                 <p className="text-[15px] font-extrabold text-[#0A0A0A] mb-2">아직 달성한 도전과제가 없어요</p>
                 <p className="text-sm text-[#9CA3AF]">면접 연습을 통해 도전과제를 달성해 보세요</p>
               </div>

--- a/src/pages/home/ui/HomeContent.tsx
+++ b/src/pages/home/ui/HomeContent.tsx
@@ -63,6 +63,7 @@ export function HomeContent() {
                 todayYear={todayY}
                 todayMonth={todayM}
                 todayDay={todayD}
+                hideIcon
               />
             </div>
           )}

--- a/src/pages/home/ui/components/JobStatus.tsx
+++ b/src/pages/home/ui/components/JobStatus.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import { Link } from "react-router-dom";
-import { ClipboardList } from "lucide-react";
 import { useJdListStore } from "@/features/jd";
 import { CompanyIcon } from "@/shared/ui/CompanyIcon";
 
@@ -30,10 +29,7 @@ export function JobStatus({ revealed }: JobStatusProps) {
       style={{ padding: 20, transitionDelay: "550ms" }}
     >
       <div className="flex items-center gap-2 mb-3">
-        <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center">
-          <ClipboardList size={14} className="text-[#0991B2]" />
-        </span>
-        <h3 className="text-[14px] font-bold text-[#0A0A0A]">채용공고</h3>
+        <h3 className="text-[16px] font-bold text-[#0A0A0A]">채용공고</h3>
         <Link to="/jd" className="text-[12px] text-[#0991B2] ml-auto">관리 →</Link>
       </div>
 
@@ -47,7 +43,7 @@ export function JobStatus({ revealed }: JobStatusProps) {
           return (
             <Link key={jd.uuid} to={`/jd/${jd.uuid}`} className="hp-job-item no-underline">
               <div className="w-7 h-7 shrink-0">
-                <CompanyIcon platform={jd.raw.jobDescription.platform} title={jd.title} size={16} />
+                <CompanyIcon categoryId={jd.categoryId} size={16} />
               </div>
               <div className="hp-job-body">
                 <div className="hp-job-name">{jd.company}</div>

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -41,48 +41,50 @@ export function RecentSessions({ revealed }: RecentSessionsProps) {
   }, []);
 
   return (
-    <>
-      <div className={`hp-sec-head hp-rv${revealed ? " hp-rv-in" : ""}`} style={{ transitionDelay: "275ms" }}>
-        <div className="hp-sec-title">최근 면접 기록</div>
-        <Link to="/interview/results" className="hp-sec-link">전체 보기 →</Link>
+    <div
+      className={`hp-card-white hp-rv${revealed ? " hp-rv-in" : ""}`}
+      style={{ padding: 20, transitionDelay: "275ms", marginBottom: 16 }}
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <h3 className="text-[16px] font-bold text-[#0A0A0A]">최근 면접 기록</h3>
+        <Link to="/interview/results" className="text-[12px] text-[#0991B2] ml-auto">전체 보기 →</Link>
       </div>
-      <div className="hp-session-list">
-        {loading ? (
-          <div className="flex flex-col gap-2">
-            {[0, 1, 2].map((i) => (
-              <div key={i} className="h-[52px] rounded-lg bg-[#F3F4F6] animate-pulse" />
-            ))}
-          </div>
-        ) : sessions.length === 0 ? (
-          <p className="text-[13px] text-[#9CA3AF] py-2">아직 완료된 면접이 없어요</p>
-        ) : (
-          sessions.map((session, i) => (
-            <Link
-              key={session.uuid}
-              to={`/interview/session/${session.uuid}/report`}
-              className={`hp-session-item hp-rv${revealed ? " hp-rv-in" : ""}`}
-              style={{ transitionDelay: `${330 + i * 55}ms` }}
-            >
-              <div className="w-9 h-9 rounded-lg bg-white border border-[#E5E7EB] flex items-center justify-center shrink-0">
-                {session.reportStatus === "completed"
-                  ? <BarChart2 size={16} className="text-[#0991B2]" />
-                  : <ClipboardList size={16} className="text-[#9CA3AF]" />}
+
+      {loading ? (
+        <div className="flex flex-col gap-2">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-[52px] rounded-lg bg-[#F3F4F6] animate-pulse" />
+          ))}
+        </div>
+      ) : sessions.length === 0 ? (
+        <p className="text-[13px] text-[#9CA3AF] py-2">아직 완료된 면접이 없어요</p>
+      ) : (
+        sessions.map((session, i) => (
+          <Link
+            key={session.uuid}
+            to={`/interview/session/${session.uuid}/report`}
+            className={`hp-session-item hp-rv${revealed ? " hp-rv-in" : ""}`}
+            style={{ transitionDelay: `${330 + i * 55}ms` }}
+          >
+            <div className="w-9 h-9 rounded-lg bg-white border border-[#E5E7EB] flex items-center justify-center shrink-0">
+              {session.reportStatus === "completed"
+                ? <BarChart2 size={16} className="text-[#0991B2]" />
+                : <ClipboardList size={16} className="text-[#9CA3AF]" />}
+            </div>
+            <div className="hp-si-body">
+              <div className="hp-si-company">
+                {session.jobDescriptionLabel}
+                <span className="hp-badge" style={{ fontSize: 10 }}>
+                  {SESSION_TYPE_LABEL[session.interviewSessionType] ?? session.interviewSessionType}
+                </span>
               </div>
-              <div className="hp-si-body">
-                <div className="hp-si-company">
-                  {session.jobDescriptionLabel}
-                  <span className="hp-badge" style={{ fontSize: 10 }}>
-                    {SESSION_TYPE_LABEL[session.interviewSessionType] ?? session.interviewSessionType}
-                  </span>
-                </div>
-                <div className="hp-si-meta">
-                  {session.resumeTitle} · {DIFFICULTY_LABEL[session.interviewDifficultyLevel] ?? session.interviewDifficultyLevel} · {formatDate(session.createdAt)}
-                </div>
+              <div className="hp-si-meta">
+                {session.resumeTitle} · {DIFFICULTY_LABEL[session.interviewDifficultyLevel] ?? session.interviewDifficultyLevel} · {formatDate(session.createdAt)}
               </div>
-            </Link>
-          ))
-        )}
-      </div>
-    </>
+            </div>
+          </Link>
+        ))
+      )}
+    </div>
   );
 }

--- a/src/pages/interview-session/ui/InterviewSessionPage.tsx
+++ b/src/pages/interview-session/ui/InterviewSessionPage.tsx
@@ -74,6 +74,51 @@ const interviewCoachMarksSteps: CoachMarkStep[] = [
   },
 ];
 
+const INTERVIEW_COACH_MARKS_KEY = "interview-session";
+
+const interviewCoachMarksSteps: CoachMarkStep[] = [
+  {
+    id: "welcome",
+    title: "면접 세션 안내",
+    description: "면접 세션이 시작되었습니다. 주요 기능을 안내해 드리겠습니다.",
+    targetSelector: ".session-header",
+    position: "bottom",
+    align: "center",
+  },
+  {
+    id: "question-panel",
+    title: "질문 패널",
+    description: "여기서 면접관의 질문이 표시됩니다. 질문이 끝나면 답변을 시작하세요.",
+    targetSelector: ".question-panel",
+    position: "top",
+    align: "center",
+  },
+  {
+    id: "action-panel",
+    title: "액션 패널",
+    description: "면접 시작, 답변 제출 등 주요 액션을 여기서 수행합니다.",
+    targetSelector: ".session-action-panel",
+    position: "left",
+    align: "center",
+  },
+  {
+    id: "transcript-panel",
+    title: "대본 패널",
+    description: "당신의 답변이 실시간으로 표시됩니다. 말하기 습관을 확인할 수 있습니다.",
+    targetSelector: ".transcript-panel",
+    position: "left",
+    align: "center",
+  },
+  {
+    id: "behavior-metrics",
+    title: "행동 지표",
+    description: "말하기 속도, 채움말 사용 등 다양한 지표를 실시간으로 확인할 수 있습니다.",
+    targetSelector: ".behavior-metrics",
+    position: "left",
+    align: "center",
+  },
+];
+
 export function InterviewSessionPage() {
   const { interviewSessionUuid } = useParams<{ interviewSessionUuid: string }>();
   const navigate = useNavigate();

--- a/src/pages/interview-session/ui/InterviewSessionPage.tsx
+++ b/src/pages/interview-session/ui/InterviewSessionPage.tsx
@@ -74,51 +74,6 @@ const interviewCoachMarksSteps: CoachMarkStep[] = [
   },
 ];
 
-const INTERVIEW_COACH_MARKS_KEY = "interview-session";
-
-const interviewCoachMarksSteps: CoachMarkStep[] = [
-  {
-    id: "welcome",
-    title: "면접 세션 안내",
-    description: "면접 세션이 시작되었습니다. 주요 기능을 안내해 드리겠습니다.",
-    targetSelector: ".session-header",
-    position: "bottom",
-    align: "center",
-  },
-  {
-    id: "question-panel",
-    title: "질문 패널",
-    description: "여기서 면접관의 질문이 표시됩니다. 질문이 끝나면 답변을 시작하세요.",
-    targetSelector: ".question-panel",
-    position: "top",
-    align: "center",
-  },
-  {
-    id: "action-panel",
-    title: "액션 패널",
-    description: "면접 시작, 답변 제출 등 주요 액션을 여기서 수행합니다.",
-    targetSelector: ".session-action-panel",
-    position: "left",
-    align: "center",
-  },
-  {
-    id: "transcript-panel",
-    title: "대본 패널",
-    description: "당신의 답변이 실시간으로 표시됩니다. 말하기 습관을 확인할 수 있습니다.",
-    targetSelector: ".transcript-panel",
-    position: "left",
-    align: "center",
-  },
-  {
-    id: "behavior-metrics",
-    title: "행동 지표",
-    description: "말하기 속도, 채움말 사용 등 다양한 지표를 실시간으로 확인할 수 있습니다.",
-    targetSelector: ".behavior-metrics",
-    position: "left",
-    align: "center",
-  },
-];
-
 export function InterviewSessionPage() {
   const { interviewSessionUuid } = useParams<{ interviewSessionUuid: string }>();
   const navigate = useNavigate();

--- a/src/pages/interview-setup/ui/InterviewModeSection.tsx
+++ b/src/pages/interview-setup/ui/InterviewModeSection.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Lock, Zap } from "lucide-react";
+import { BookOpen, GitBranch, LayoutList, Lock, Zap } from "lucide-react";
 import { SetupSection } from "@/shared/ui/SetupSection";
 import { OptionCard } from "@/shared/ui/OptionCard";
 import { InfoTooltip } from "@/shared/ui/InfoTooltip";
@@ -24,6 +24,7 @@ export function InterviewModeSection({
           <OptionCard
             selected={interviewMode === "tail"}
             onClick={() => onModeChange("tail")}
+            icon={<div className="w-8 h-8 rounded-lg bg-[#E0F2FE] flex items-center justify-center"><GitBranch size={16} className="text-[#0284C7]" /></div>}
             title="꼬리질문 방식"
             description="답변 기반 심층 꼬리질문 생성"
             badge={
@@ -44,6 +45,7 @@ export function InterviewModeSection({
               }
               onModeChange("full");
             }}
+            icon={<div className="w-8 h-8 rounded-lg bg-[#E6F7FA] flex items-center justify-center"><LayoutList size={16} className="text-[#0991B2]" /></div>}
             title="전체 프로세스"
             description="면접 전 과정 시뮬레이션"
             badge={
@@ -66,7 +68,12 @@ export function InterviewModeSection({
             icon={<div className="w-8 h-8 rounded-lg bg-[#ECFDF5] flex items-center justify-center"><BookOpen size={16} className="text-[#059669]" /></div>}
             title="연습 모드"
             description="준비 후 직접 시작"
-            badge={<InfoTooltip text="질문 음성이 끝난 후 '말하기 시작' 버튼을 직접 눌러 답변합니다. 자신의 페이스에 맞춰 충분히 생각한 후 답변할 수 있어요." />}
+            badge={
+              <span className="flex items-center gap-1.5">
+                <span className="text-[10px] font-bold text-[#059669] bg-[#ECFDF5] py-px px-2 rounded-full">Free</span>
+                <InfoTooltip text="질문 음성이 끝난 후 '말하기 시작' 버튼을 직접 눌러 답변합니다. 자신의 페이스에 맞춰 충분히 생각한 후 답변할 수 있어요." />
+              </span>
+            }
           />
           <OptionCard
             selected={practiceMode === "real"}
@@ -81,7 +88,12 @@ export function InterviewModeSection({
             icon={<div className="w-8 h-8 rounded-lg bg-[#FFFBEB] flex items-center justify-center"><Zap size={16} className="text-[#D97706]" /></div>}
             title="실전 모드"
             description="랜덤 대기 후 자동 시작"
-            badge={<InfoTooltip text="질문 음성이 끝나면 5~30초 랜덤 대기 후 자동으로 STT가 시작됩니다. 실제 면접의 긴장감을 최대한 재현합니다." />}
+            badge={
+              <span className="flex items-center gap-1.5">
+                <span className="text-[10px] font-bold text-white bg-[#0991B2] py-px px-2 rounded-full">Pro</span>
+                <InfoTooltip text="질문 음성이 끝나면 5~30초 랜덤 대기 후 자동으로 STT가 시작됩니다. 실제 면접의 긴장감을 최대한 재현합니다." />
+              </span>
+            }
           />
         </div>
       </SetupSection>

--- a/src/pages/interview-setup/ui/InterviewSetupPage.tsx
+++ b/src/pages/interview-setup/ui/InterviewSetupPage.tsx
@@ -87,8 +87,9 @@ export function InterviewSetupPage() {
               stepLabel="STEP 1"
               title="면접을 연습할 이력서와 채용공고를 선택해주세요."
               description=""
+              columnClassName="flex flex-col min-h-[400px] max-h-[520px]"
               left={
-                <div className="flex flex-col h-full overflow-hidden">
+                <div className="flex flex-col h-full">
                   <ResumeSection
                     resumes={resumes}
                     selectedResumeUuid={selectedResumeUuid}
@@ -99,7 +100,7 @@ export function InterviewSetupPage() {
                 </div>
               }
               right={
-                <div className="flex flex-col h-full overflow-hidden">
+                <div className="flex flex-col h-full">
                   <JdSection
                     jdList={jdList}
                     jdListLoading={jdListLoading}

--- a/src/pages/interview-setup/ui/InterviewSetupPage.tsx
+++ b/src/pages/interview-setup/ui/InterviewSetupPage.tsx
@@ -88,7 +88,7 @@ export function InterviewSetupPage() {
               title="면접을 연습할 이력서와 채용공고를 선택해주세요."
               description=""
               left={
-                <div className="flex flex-col min-h-[400px] max-h-[520px]">
+                <div className="flex flex-col h-full overflow-hidden">
                   <ResumeSection
                     resumes={resumes}
                     selectedResumeUuid={selectedResumeUuid}
@@ -99,7 +99,7 @@ export function InterviewSetupPage() {
                 </div>
               }
               right={
-                <div className="flex flex-col min-h-[400px] max-h-[520px]">
+                <div className="flex flex-col h-full overflow-hidden">
                   <JdSection
                     jdList={jdList}
                     jdListLoading={jdListLoading}

--- a/src/pages/jd-detail/ui/JdDetailPage.tsx
+++ b/src/pages/jd-detail/ui/JdDetailPage.tsx
@@ -38,7 +38,7 @@ export function JdDetailPage() {
   const { uuid } = useParams<{ uuid: string }>();
   const navigate = useNavigate();
   const [liveStatus, setLiveStatus] = useState<JobDescriptionCollectionStatus | null>(null);
-  const { jd, isLoading, isUpdating, error, fetchJd, updateStatus, deleteJd, clearError } =
+  const { jd, isLoading, isUpdating, error, fetchJd, silentRefreshJd, updateStatus, deleteJd, clearError } =
     useJdDetailStore();
 
   useEffect(() => {
@@ -47,6 +47,13 @@ export function JdDetailPage() {
   }, [uuid]);
 
   const sseEnabled = !!uuid && !!jd && !jd.analyzed;
+
+  // SSE 누락 대비 폴링 fallback: 분석 중일 때 5초마다 조용히 재조회
+  useEffect(() => {
+    if (!sseEnabled || !uuid) return;
+    const interval = setInterval(() => { silentRefreshJd(uuid); }, 5000);
+    return () => clearInterval(interval);
+  }, [sseEnabled, uuid, silentRefreshJd]);
 
   useUserJobDescriptionScrapingSse({
     uuid: uuid ?? "",

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -48,6 +48,7 @@ export function SettingsPage() {
     setAiDataDraft, saveConsents,
     deleteAccount,
     clearMessage,
+    clearPasswordMessage,
   } = useSettingsStore();
 
   const {
@@ -77,6 +78,13 @@ export function SettingsPage() {
       return () => clearTimeout(t);
     }
   }, [saveMessage, clearMessage]);
+
+  useEffect(() => {
+    if (passwordSaveMessage) {
+      const t = setTimeout(() => clearPasswordMessage(), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [passwordSaveMessage, clearPasswordMessage]);
 
   const pwdStrength = getPwdStrength(passwordDraft.newPassword);
   const pwdMatch = passwordDraft.confirmPassword

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Archive, ClipboardList, Eye, FileText, Flame, Gem, Megaphone, ShieldCheck, Star, UserCircle, Zap } from "lucide-react";
+import { ClipboardList, FileText, Flame, Gem, History, Megaphone, ShieldCheck, Star, UserCircle, Zap } from "lucide-react";
 import { ConfirmModal } from "@/shared/ui";
 import { useSettingsStore } from "@/features/settings";
 import { useSubscriptionStore } from "@/features/subscription";
@@ -312,10 +312,10 @@ export function SettingsPage() {
                     </div>
                     <div className="grid grid-cols-2 gap-[10px] max-[640px]:grid-cols-1">
                       {([
-                        { icon: <Eye size={20} className="text-[#8B5CF6]" />, name: "시선 추적 분석", desc: "Free/Pro 모두 사용 가능" },
                         { icon: <Zap size={20} className="text-[#F59E0B]" />, name: "실전 모드", desc: "PRO 전용 · 랜덤 대기 후 자동 시작" },
-                        { icon: <FileText size={20} className="text-[#0991B2]" />, name: "녹화 영상 확인", desc: "PRO 전용 · 리포트에서 재생" },
-                        { icon: <Archive size={20} className="text-[#059669]" />, name: "무제한 아카이브", desc: "Free는 최근 7일만 조회" },
+                        { icon: <ClipboardList size={20} className="text-[#059669]" />, name: "전체 프로세스", desc: "PRO 전용 · 처음부터 끝까지 전체 면접" },
+                        { icon: <History size={20} className="text-[#0991B2]" />, name: "전체 면접 기록", desc: "PRO 전용 · 모든 면접 세션 무제한 조회" },
+                        { icon: <FileText size={20} className="text-[#8B5CF6]" />, name: "녹화영상 확인", desc: "PRO 전용 · 리포트에서 녹화 영상 재생" },
                       ] as const).map((item) => (
                         <div key={item.name} className="bg-white border border-[#E5E7EB] rounded-[10px] px-4 py-[14px] transition-all duration-150 hover:border-[rgba(9,145,178,0.3)] hover:shadow-[0_2px_8px_rgba(0,0,0,0.1),0_8px_24px_rgba(0,0,0,0.08)]">
                           <div className="mb-[8px]">{item.icon}</div>

--- a/src/pages/settings/ui/SettingsPage.tsx
+++ b/src/pages/settings/ui/SettingsPage.tsx
@@ -37,7 +37,7 @@ const inputClass = "font-plex-sans-kr text-[14px] text-[#0A0A0A] bg-white border
 export function SettingsPage() {
   const navigate = useNavigate();
   const {
-    data, loading, saving, error, saveMessage, activePanel,
+    data, loading, saving, passwordSaving, error, saveMessage, passwordError, passwordSaveMessage, activePanel,
     profileDraft, passwordDraft, aiDataDraft,
     jobCategories, jobCategoriesLoading, availableJobs, availableJobsLoading,
     fetchSettings, setActivePanel,
@@ -178,7 +178,7 @@ export function SettingsPage() {
                     </div>
                   </div>
 
-                  <div className="flex items-center justify-end gap-[10px] pt-5 border-t border-[#E5E7EB] mt-1 mb-10 max-[640px]:flex-col-reverse max-[640px]:items-stretch">
+                  <div className="flex items-center justify-end gap-[10px] mt-5 max-[640px]:flex-col-reverse max-[640px]:items-stretch">
                     {saveMessage && activePanel === "account" && <span className="text-[12px] font-bold text-[#059669] mr-auto animate-[spFadeUp_0.3s_ease]">✓ {saveMessage}</span>}
                     {error && activePanel === "account" && <span className="text-[12px] font-bold text-[#EF4444] mr-auto animate-[spFadeUp_0.3s_ease]">✕ {error}</span>}
                     <button className="font-plex-sans-kr text-[14px] font-semibold text-[#6B7280] bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-5 py-[10px] cursor-pointer transition-all duration-150 hover:bg-[#F3F4F6] hover:text-[#0A0A0A]" onClick={resetProfileDraft}>취소</button>
@@ -187,17 +187,20 @@ export function SettingsPage() {
                     </button>
                   </div>
 
+                  <div className="border-t border-[#E5E7EB] my-5" />
+
                   {/* 비밀번호 변경 */}
                   <PasswordChangeForm
                     passwordDraft={passwordDraft}
                     pwdStrength={pwdStrength}
                     pwdMatch={pwdMatch}
                     inputClass={inputClass}
-                    saving={saving}
+                    saving={passwordSaving}
                     onSetPassword={setPasswordDraft}
                     callbacks={{ onSave: savePassword, onReset: resetPasswordDraft }}
-                    messages={{ error, saveMessage }}
+                    messages={{ error: passwordError, saveMessage: passwordSaveMessage }}
                   />
+
 
                   {/* 계정 탈퇴 */}
                   <AccountUnregisterSection
@@ -235,6 +238,7 @@ export function SettingsPage() {
                     {([
                       { key: "streakReminder", title: "스트릭 리마인더", desc: "오늘 면접 연습을 아직 하지 않았을 때 저녁 8시에 알림" },
                       { key: "streakExpire", title: "스트릭 만료 경고", desc: "자정 1시간 전, 오늘 스트릭이 만료될 예정일 때 알림" },
+                      { key: "streakReward", title: "스트릭 보상 수령", desc: "마일스톤 달성 시 보상이 지급되었을 때 알림" },
                       { key: "reportReady", title: "면접 리포트 완성", desc: "AI 면접 리뷰 리포트 생성이 완료되었을 때 알림" },
                     ] as const).map((item) => (
                       <NotificationToggle

--- a/src/pages/streak/ui/components/StreakCalendar.tsx
+++ b/src/pages/streak/ui/components/StreakCalendar.tsx
@@ -23,6 +23,7 @@ interface StreakCalendarProps {
   todayYear: number;
   todayMonth: number;
   todayDay: number;
+  hideIcon?: boolean;
 }
 
 interface DayCell {
@@ -89,6 +90,7 @@ export function StreakCalendar({
   todayYear,
   todayMonth,
   todayDay,
+  hideIcon = false,
 }: StreakCalendarProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [cellSize, setCellSize] = useState(13);
@@ -143,10 +145,12 @@ export function StreakCalendar({
       style={{ transitionDelay: "80ms" }}
     >
       <div className="flex items-center gap-2 mb-4">
-        <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center">
-          <Calendar size={14} className="text-[#0991B2]" />
-        </span>
-        <Link to="/streak" className="text-[14px] font-bold text-[#0A0A0A] no-underline hover:text-[#0991B2] transition-colors">스트릭</Link>
+        {!hideIcon && (
+          <span className="w-7 h-7 rounded-lg bg-[#E6F7FA] flex items-center justify-center">
+            <Calendar size={14} className="text-[#0991B2]" />
+          </span>
+        )}
+        <Link to="/streak" className={`${hideIcon ? "text-[16px]" : "text-[14px]"} font-bold text-[#0A0A0A] no-underline hover:text-[#0991B2] transition-colors`}>스트릭</Link>
         <span className="text-[11px] text-[#9CA3AF] font-medium ml-auto">
           {visibleWeeks < MAX_WEEKS ? `최근 ${visibleWeeks}주` : "최근 52주"} ·{" "}
           <strong className="text-[#0991B2]">{totalDone}일</strong> 참여

--- a/src/shared/ui/StepLayout.tsx
+++ b/src/shared/ui/StepLayout.tsx
@@ -21,8 +21,8 @@ export function StepLayout({ stepLabel, title, description, left, right }: StepL
 
       {/* Two-column body */}
       <div className="grid grid-cols-2 gap-8 max-md:grid-cols-1 items-stretch">
-        <div className="flex flex-col gap-4 h-full">{left}</div>
-        <div className="flex flex-col gap-4 h-full">{right}</div>
+        <div className="flex flex-col gap-4 min-h-[400px] max-h-[520px]">{left}</div>
+        <div className="flex flex-col gap-4 min-h-[400px] max-h-[520px]">{right}</div>
       </div>
     </div>
   );

--- a/src/shared/ui/StepLayout.tsx
+++ b/src/shared/ui/StepLayout.tsx
@@ -7,9 +7,10 @@ interface StepLayoutProps {
   description: string;
   left: ReactNode;
   right: ReactNode;
+  columnClassName?: string;
 }
 
-export function StepLayout({ stepLabel, title, description, left, right }: StepLayoutProps) {
+export function StepLayout({ stepLabel, title, description, left, right, columnClassName = "flex flex-col gap-4" }: StepLayoutProps) {
   return (
     <div>
       {/* Header — full width */}
@@ -21,8 +22,8 @@ export function StepLayout({ stepLabel, title, description, left, right }: StepL
 
       {/* Two-column body */}
       <div className="grid grid-cols-2 gap-8 max-md:grid-cols-1 items-stretch">
-        <div className="flex flex-col gap-4 min-h-[400px] max-h-[520px]">{left}</div>
-        <div className="flex flex-col gap-4 min-h-[400px] max-h-[520px]">{right}</div>
+        <div className={columnClassName}>{left}</div>
+        <div className={columnClassName}>{right}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 관련 이슈
Closes #148

## 변경 사항

- **홈 화면 UI 개선**: `RecentSessions`와 `JobStatus`를 카드 스타일로 재설계, 헤더 아이콘 제거 및 폰트 크기 통일
- **스트릭 캘린더 `hideIcon` prop 추가**: 홈 화면에서 아이콘 없이 표시되도록 옵션 추가
- **인터뷰 설정 레이아웃 개선**: STEP 1 좌우 컬럼 높이 동기화 및 스크롤 활성화, `StepLayout`에 `columnClassName` prop 추가
- **인터뷰 모드 선택 UI 개선**: 꼬리질문/전체 프로세스 모드에 아이콘 추가, 연습/실전 모드에 Free/Pro 배지 표시
- **설정 페이지 비밀번호 에러 상태 분리**: 프로필 저장과 비밀번호 변경의 에러/성공 메시지 상태를 독립적으로 관리 (`passwordError`, `passwordSaveMessage`)
- **프로필 저장 시 이름 반영**: `PATCH /api/v1/users/me/`로 이름 저장 추가, 저장 후 auth store 및 navbar 즉시 업데이트
- **설정 구독 패널 Pro 혜택 문구 업데이트**: 전체 프로세스, 전체 면접 기록, 녹화영상 확인으로 항목 변경
- **알림 설정에 스트릭 보상 수령 항목 추가**
- **JD 상세 페이지 SSE 폴링 폴백 추가**: 분석 중일 때 5초마다 `silentRefreshJd` 호출로 SSE 누락 대비
- **JD 목록 아이템에 `categoryId` 추가**: `inferCategoryId`로 카테고리 계산 후 `CompanyIcon`에 적용
- **도전과제 페이지 이모지 → lucide 아이콘 교체**
- **PasswordChangeForm 구분선 위치 수정**: 버튼 위 → 버튼 아래로 이동

## 변경 유형

- [x] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [ ] 기타 (Other)

## 테스트 방법

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경
- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:
1. 설정 페이지에서 프로필 저장 후 navbar 이름이 즉시 반영되는지 확인
2. 설정 페이지에서 비밀번호 변경 실패 시 프로필 저장 성공 메시지가 사라지지 않는지 확인
3. 인터뷰 설정 STEP 1에서 좌우 컬럼 높이가 동일하게 맞춰지는지 확인
4. 홈 화면에서 최근 면접 기록과 채용공고가 카드 스타일로 표시되는지 확인
5. JD 분석 중 페이지에서 SSE 없이도 5초 후 분석 완료 상태로 전환되는지 확인

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [ ] 테스트를 추가했으며 모든 테스트가 통과합니다
- [x] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보

리뷰어가 알아야 할 추가 정보를 작성해주세요.