### PR TITLE
[143] interview UI 수정 및 자잘한 수정

### DIFF
--- a/src/features/interview-session/constants/labels.ts
+++ b/src/features/interview-session/constants/labels.ts
@@ -4,9 +4,9 @@ export const SESSION_TYPE_LABEL: Record<string, string> = {
 };
 
 export const DIFFICULTY_LABEL: Record<string, string> = {
-  friendly: "친근",
-  normal: "일반",
-  pressure: "압박",
+  friendly: "친근한 면접관",
+  normal: "일반 면접관",
+  pressure: "압박 면접관",
 };
 
 export const REPORT_STATUS_BADGE: Record<string, { label: string; cls: string }> = {

--- a/src/features/interview-session/constants/labels.ts
+++ b/src/features/interview-session/constants/labels.ts
@@ -9,6 +9,12 @@ export const DIFFICULTY_LABEL: Record<string, string> = {
   pressure: "압박 면접관",
 };
 
+export const DIFFICULTY_STYLE: Record<string, { label: string; cls: string }> = {
+  friendly: { label: "친근한 면접관", cls: "border-[#A7F3D0] bg-[#ECFDF5] text-[#059669]" },
+  normal:   { label: "일반 면접관",   cls: "border-[#BAE6FD] bg-[#E6F7FA] text-[#0991B2]" },
+  pressure: { label: "압박 면접관",   cls: "border-[#FECACA] bg-[#FEF2F2] text-[#DC2626]" },
+};
+
 export const REPORT_STATUS_BADGE: Record<string, { label: string; cls: string }> = {
   pending:    { label: "리포트 대기",   cls: "text-[#D97706] bg-[#FFF7ED] border-[#FED7AA]" },
   generating: { label: "리포트 생성 중", cls: "text-[#0991B2] bg-[#E6F7FA] border-[#BAE6FD]" },

--- a/src/features/interview-session/index.ts
+++ b/src/features/interview-session/index.ts
@@ -24,7 +24,7 @@ export type {
   BehaviorAnalysis,
 } from "./api/types";
 
-export { SESSION_TYPE_LABEL, DIFFICULTY_LABEL, REPORT_STATUS_BADGE } from "./constants/labels";
+export { SESSION_TYPE_LABEL, DIFFICULTY_LABEL, DIFFICULTY_STYLE, REPORT_STATUS_BADGE } from "./constants/labels";
 
 export { AvatarSection } from "./ui/AvatarSection";
 export { QuestionPanel } from "./ui/QuestionPanel";

--- a/src/features/interview-session/ui/AvatarSection.tsx
+++ b/src/features/interview-session/ui/AvatarSection.tsx
@@ -23,19 +23,23 @@ function createProvider(difficulty: InterviewDifficultyLevel): IAvatarProvider {
 export function AvatarSection({ difficulty, onReady, className = "" }: AvatarSectionProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const providerRef = useRef<IAvatarProvider | null>(null);
+  const onReadyRef = useRef(onReady);
+  useEffect(() => {
+    onReadyRef.current = onReady;
+  });
 
   useEffect(() => {
     if (!containerRef.current || difficulty === undefined) return;
     const provider = createProvider(difficulty);
     providerRef.current = provider;
     provider.initialize(containerRef.current).then(() => {
-      onReady?.(provider);
+      onReadyRef.current?.(provider);
     });
     return () => {
       provider.destroy();
       providerRef.current = null;
     };
-  }, [difficulty]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [difficulty]);  
 
   return (
     <div

--- a/src/features/interview-session/ui/AvatarSection.tsx
+++ b/src/features/interview-session/ui/AvatarSection.tsx
@@ -1,19 +1,32 @@
 import { useEffect, useRef } from "react";
 import { PrettyAvatarProvider } from "@/shared/lib/avatar/PrettyAvatarProvider";
+import { FriendlyAvatarProvider } from "@/shared/lib/avatar/FriendlyAvatarProvider";
+import { PressureAvatarProvider } from "@/shared/lib/avatar/PressureAvatarProvider";
 import type { IAvatarProvider } from "@/shared/lib/avatar/IAvatarProvider";
+import type { InterviewDifficultyLevel } from "@/features/interview-session/api/types";
 
 interface AvatarSectionProps {
+  difficulty?: InterviewDifficultyLevel;
   onReady?: (avatar: IAvatarProvider) => void;
   className?: string;
 }
 
-export function AvatarSection({ onReady, className = "" }: AvatarSectionProps) {
+function createProvider(difficulty: InterviewDifficultyLevel): IAvatarProvider {
+  switch (difficulty) {
+    case "friendly": return new FriendlyAvatarProvider();
+    case "pressure": return new PressureAvatarProvider();
+    case "normal":
+    default:         return new PrettyAvatarProvider();
+  }
+}
+
+export function AvatarSection({ difficulty, onReady, className = "" }: AvatarSectionProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const providerRef = useRef<IAvatarProvider | null>(null);
 
   useEffect(() => {
-    if (!containerRef.current) return;
-    const provider = new PrettyAvatarProvider();
+    if (!containerRef.current || difficulty === undefined) return;
+    const provider = createProvider(difficulty);
     providerRef.current = provider;
     provider.initialize(containerRef.current).then(() => {
       onReady?.(provider);
@@ -22,7 +35,7 @@ export function AvatarSection({ onReady, className = "" }: AvatarSectionProps) {
       provider.destroy();
       providerRef.current = null;
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [difficulty]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div

--- a/src/features/interview-session/ui/BehaviorMetrics.tsx
+++ b/src/features/interview-session/ui/BehaviorMetrics.tsx
@@ -19,8 +19,8 @@ export function BehaviorMetrics({
   isAnalyzing,
 }: BehaviorMetricsProps) {
   return (
-    <div className={`bg-slate-800/60 border border-white/10 rounded-2xl p-4 flex flex-col gap-3 ${className || ""}`}>
-      <div className="text-[10px] font-bold tracking-widest uppercase text-slate-500">실시간 분석</div>
+    <div className={`bg-[#071a26]/80 border border-[#0991B2]/20 rounded-2xl p-4 flex flex-col gap-3 ${className || ""}`}>
+      <div className="text-[10px] font-bold tracking-widest uppercase text-[#0991B2]/60">실시간 분석</div>
 
       <div className="grid grid-cols-2 gap-2">
         <MetricItem label="발화 속도" value={speechMetrics.wpm} unit="SPM" warnAt={0} />
@@ -33,11 +33,11 @@ export function BehaviorMetrics({
       <div>
         <div className="text-[10px] text-slate-500 mb-1 flex justify-between">
           <span>마이크 레벨</span>
-          {isAnalyzing && <span className="text-green-400 font-mono">{fps} FPS</span>}
+          {isAnalyzing && <span className="text-[#06B6D4] font-mono">{fps} FPS</span>}
         </div>
-        <div className="h-1.5 bg-slate-700 rounded-full overflow-hidden">
+        <div className="h-1.5 bg-[#0a1e2a] rounded-full overflow-hidden">
           <div
-            className="h-full bg-gradient-to-r from-indigo-500 to-blue-400 transition-all duration-75"
+            className="h-full bg-gradient-to-r from-[#0991B2] to-[#06B6D4] transition-all duration-75"
             style={{ width: `${Math.min(100, audioLevel)}%` }}
           />
         </div>
@@ -60,7 +60,7 @@ function MetricItem({
   const isWarn = value > warnAt && warnAt > 0;
   const isGood = warnAt === 0;
   return (
-    <div className="bg-slate-900/40 rounded-xl px-3 py-2">
+    <div className="bg-[#050e18] border border-[#0991B2]/10 rounded-xl px-3 py-2">
       <div className="text-[10px] text-slate-500">{label}</div>
       <div
         className={`text-lg font-mono font-bold ${

--- a/src/features/interview-session/ui/QuestionPanel.tsx
+++ b/src/features/interview-session/ui/QuestionPanel.tsx
@@ -33,14 +33,14 @@ export function QuestionPanel({
   const isGenerating = interviewPhase === "generating_followup" || interviewPhase === "starting";
 
   return (
-    <div className={`bg-slate-800/60 border border-white/10 rounded-2xl p-6 min-h-[260px] flex flex-col ${className || ""}`}>
+    <div className={`bg-[#071a26]/80 border border-[#0991B2]/20 rounded-2xl p-6 min-h-[260px] flex flex-col ${className || ""}`}>
       {/* ── 상단: 라벨 + 카운터 + TTS 컨트롤 ── */}
       <div className="flex items-center gap-2 mb-3">
-        <span className="text-[10px] font-bold tracking-widest uppercase text-indigo-400">
+        <span className="text-[10px] font-bold tracking-widest uppercase text-[#06B6D4]">
           {currentInterviewTurn?.turnType === "followup" ? "꼬리질문" : "면접 질문"}
         </span>
         {totalTurns > 0 && (
-          <span className="text-[11px] text-slate-500 font-mono">
+          <span className="text-[11px] text-[#0991B2]/70 font-mono">
             {currentTurnIndex + 1} / {totalTurns}
           </span>
         )}
@@ -49,8 +49,8 @@ export function QuestionPanel({
         <div className="ml-auto flex items-center gap-2">
           {/* 재생 중 표시 */}
           {ttsPlaying && (
-            <span className="flex items-center gap-1 text-[10px] text-indigo-300 font-semibold">
-              <span className="w-1.5 h-1.5 rounded-full bg-indigo-400 animate-pulse" />
+            <span className="flex items-center gap-1 text-[10px] text-[#06B6D4] font-semibold">
+              <span className="w-1.5 h-1.5 rounded-full bg-[#06B6D4] animate-pulse" />
               재생 중
             </span>
           )}
@@ -60,7 +60,7 @@ export function QuestionPanel({
             <button
               onClick={onSkipTts}
               title="음성 스킵"
-              className="flex items-center gap-1 text-[10px] text-slate-400 hover:text-white border border-white/10 rounded-md px-1.5 py-0.5 transition-colors"
+              className="flex items-center gap-1 text-[10px] text-slate-400 hover:text-[#06B6D4] border border-[#0991B2]/20 rounded-md px-1.5 py-0.5 transition-colors"
             >
               <SkipForward size={11} /> 스킵
             </button>
@@ -75,7 +75,7 @@ export function QuestionPanel({
             >
               {ttsMuted
                 ? <VolumeX size={13} className="text-slate-500" />
-                : <Volume2 size={13} className="text-slate-300" />
+                : <Volume2 size={13} className="text-[#06B6D4]/80" />
               }
               <span className="text-[10px] text-slate-500 select-none">{ttsMuted ? "음소거" : "음성"}</span>
             </button>
@@ -89,18 +89,18 @@ export function QuestionPanel({
               max={100}
               value={ttsVolume}
               onChange={(e) => onVolumeChange(Number(e.target.value))}
-              className="w-16 h-1 accent-indigo-400 cursor-pointer"
+              className="w-16 h-1 accent-[#0991B2] cursor-pointer"
               title={`볼륨 ${ttsVolume}%`}
             />
           )}
         </div>
       </div>
 
-      {/* ── 질문 본문 (flex-1 → 영역 채움) ── */}
+      {/* ── 질문 본문 ── */}
       <div className="flex-1 flex items-start">
         {isGenerating ? (
           <div className="flex items-center gap-3 text-slate-400">
-            <span className="w-4 h-4 rounded-full border-2 border-indigo-400 border-t-transparent animate-spin shrink-0" />
+            <span className="w-4 h-4 rounded-full border-2 border-[#0991B2] border-t-transparent animate-spin shrink-0" />
             <span className="text-sm">질문을 생성하고 있습니다...</span>
           </div>
         ) : currentInterviewTurn ? (

--- a/src/features/interview-session/ui/TranscriptPanel.tsx
+++ b/src/features/interview-session/ui/TranscriptPanel.tsx
@@ -54,8 +54,8 @@ export function TranscriptPanel({
   }, [highlightedHtml, interimText]);
 
   return (
-    <div className={`bg-slate-900/50 border border-white/10 rounded-2xl p-5 flex flex-col gap-2 min-h-[120px] flex-1 h-full min-h-0 ${className || ""}`}>
-      <div className="text-[10px] font-bold tracking-widest uppercase text-slate-500 mb-1">
+    <div className={`bg-[#050e18]/80 border border-[#0991B2]/15 rounded-2xl p-5 flex flex-col gap-2 min-h-[120px] flex-1 h-full min-h-0 ${className || ""}`}>
+      <div className="text-[10px] font-bold tracking-widest uppercase text-[#0991B2]/60 mb-1">
         실시간 답변
       </div>
       <div
@@ -63,7 +63,7 @@ export function TranscriptPanel({
         className="flex-1 min-h-0 font-mono text-base leading-relaxed overflow-y-auto"
       >
         <span className="text-white">{parseHighlightedHtml(highlightedHtml)}</span>
-        <span className="text-indigo-300 italic animate-pulse ml-1">{interimText}</span>
+        <span className="text-[#06B6D4] italic animate-pulse ml-1">{interimText}</span>
         {!highlightedHtml && !interimText && !isListening && (
           <span className="text-slate-600 italic text-sm">답변이 여기에 표시됩니다...</span>
         )}

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { BarChart2, ClipboardList } from "lucide-react";
+import { BarChart2 } from "lucide-react";
 import { interviewApi, SESSION_TYPE_LABEL, DIFFICULTY_LABEL } from "@/features/interview-session";
 import type { InterviewSessionListItem } from "@/features/interview-session";
 
@@ -25,7 +25,11 @@ export function RecentSessions({ revealed }: RecentSessionsProps) {
 
   useEffect(() => {
     interviewApi.getMyInterviews(1).then((data) => {
-      setSessions(data.results.filter((s) => s.interviewSessionStatus === "completed").slice(0, 3));
+      setSessions(
+        data.results
+          .filter((s) => s.interviewSessionStatus === "completed" && s.reportStatus === "completed")
+          .slice(0, 3)
+      );
     }).catch(() => {}).finally(() => setLoading(false));
   }, []);
 
@@ -55,10 +59,8 @@ export function RecentSessions({ revealed }: RecentSessionsProps) {
             className={`hp-job-item no-underline hp-rv${revealed ? " hp-rv-in" : ""}`}
             style={{ transitionDelay: `${330 + i * 55}ms`, color: "inherit" }}
           >
-            <div className="w-7 h-7 shrink-0 flex items-center justify-center">
-              {session.reportStatus === "completed"
-                ? <BarChart2 size={16} className="text-[#0991B2]" />
-                : <ClipboardList size={16} className="text-[#9CA3AF]" />}
+            <div className="w-7 h-7 shrink-0 rounded-lg bg-[#E6F7FA] flex items-center justify-center">
+              <BarChart2 size={16} className="text-[#0991B2]" />
             </div>
             <div className="hp-job-body">
               <div className="hp-job-name flex items-center gap-1.5">

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -1,19 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { BarChart2, ClipboardList } from "lucide-react";
-import { interviewApi } from "@/features/interview-session";
+import { interviewApi, SESSION_TYPE_LABEL, DIFFICULTY_LABEL } from "@/features/interview-session";
 import type { InterviewSessionListItem } from "@/features/interview-session";
-
-const SESSION_TYPE_LABEL: Record<string, string> = {
-  followup: "꼬리질문",
-  full_process: "전체 프로세스",
-};
-
-const DIFFICULTY_LABEL: Record<string, string> = {
-  friendly: "편안한",
-  normal: "일반",
-  pressure: "압박",
-};
 
 function formatDate(dateStr: string): string {
   const date = new Date(dateStr);

--- a/src/pages/home/ui/components/RecentSessions.tsx
+++ b/src/pages/home/ui/components/RecentSessions.tsx
@@ -63,22 +63,22 @@ export function RecentSessions({ revealed }: RecentSessionsProps) {
           <Link
             key={session.uuid}
             to={`/interview/session/${session.uuid}/report`}
-            className={`hp-session-item hp-rv${revealed ? " hp-rv-in" : ""}`}
-            style={{ transitionDelay: `${330 + i * 55}ms` }}
+            className={`hp-job-item no-underline hp-rv${revealed ? " hp-rv-in" : ""}`}
+            style={{ transitionDelay: `${330 + i * 55}ms`, color: "inherit" }}
           >
-            <div className="w-9 h-9 rounded-lg bg-white border border-[#E5E7EB] flex items-center justify-center shrink-0">
+            <div className="w-7 h-7 shrink-0 flex items-center justify-center">
               {session.reportStatus === "completed"
                 ? <BarChart2 size={16} className="text-[#0991B2]" />
                 : <ClipboardList size={16} className="text-[#9CA3AF]" />}
             </div>
-            <div className="hp-si-body">
-              <div className="hp-si-company">
+            <div className="hp-job-body">
+              <div className="hp-job-name flex items-center gap-1.5">
                 {session.jobDescriptionLabel}
                 <span className="hp-badge" style={{ fontSize: 10 }}>
                   {SESSION_TYPE_LABEL[session.interviewSessionType] ?? session.interviewSessionType}
                 </span>
               </div>
-              <div className="hp-si-meta">
+              <div className="hp-job-sub">
                 {session.resumeTitle} · {DIFFICULTY_LABEL[session.interviewDifficultyLevel] ?? session.interviewDifficultyLevel} · {formatDate(session.createdAt)}
               </div>
             </div>

--- a/src/pages/home/ui/components/SettingsSidebar.tsx
+++ b/src/pages/home/ui/components/SettingsSidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate, useLocation } from "react-router-dom";
-import { User, Gem, ClipboardList, Bell, Inbox } from "lucide-react";
+import { User, Gem, ClipboardList, Bell, Inbox, Home } from "lucide-react";
 import { useSettingsStore } from "@/features/settings";
 import { useAuthStore } from "@/features/auth";
 import type { SettingsPanel } from "@/features/settings";
@@ -42,6 +42,11 @@ export function SettingsSidebar({ menuOpen }: SettingsSidebarProps) {
           </div>
         </div>
       </div>
+
+      {/* 홈으로 이동 */}
+      <Link to="/" className="hp-sb-item mb-1">
+        <span className="hp-sb-icon"><Home size={18} /></span>홈
+      </Link>
 
       {/* 설정 메뉴 */}
       <div className="hp-sb-sep">설정</div>

--- a/src/pages/interview-precheck/ui/StepBrowserEnv.tsx
+++ b/src/pages/interview-precheck/ui/StepBrowserEnv.tsx
@@ -1,4 +1,5 @@
 import type { CheckStatus } from "@/features/interview-precheck";
+import { Globe, Zap } from "lucide-react";
 
 interface StepBrowserEnvProps {
   networkStatus: CheckStatus;
@@ -57,13 +58,17 @@ export function StepBrowserEnv({
         <div className="flex flex-col gap-4">
           <div className="grid grid-cols-2 gap-3">
             <div className="bg-slate-800/60 border border-white/10 rounded-xl p-4 text-center">
-              <div className="text-[20px] mb-1">🌐</div>
+              <div className="flex justify-center mb-2">
+                <Globe size={20} className="text-slate-400" />
+              </div>
               <div className="text-[13px] font-extrabold text-slate-200 mb-1">네트워크</div>
               <div className="text-[12px] font-semibold">{statusText(networkStatus, "정상 연결")}</div>
               <div className="text-[10px] text-slate-500 mt-1">{networkStatus === "ok" ? `응답 ${networkLatency}` : "측정 중"}</div>
             </div>
             <div className="bg-slate-800/60 border border-white/10 rounded-xl p-4 text-center">
-              <div className="text-[20px] mb-1">⚡</div>
+              <div className="flex justify-center mb-2">
+                <Zap size={20} className="text-slate-400" />
+              </div>
               <div className="text-[13px] font-extrabold text-slate-200 mb-1">GPU 가속</div>
               <div className="text-[12px] font-semibold">{statusText(gpuStatus, "활성화")}</div>
               <div className="text-[10px] text-slate-500 mt-1 line-clamp-1">{gpuStatus === "ok" && gpuInfo ? gpuInfo : gpuStatus === "fail" ? "소프트웨어" : "확인 중"}</div>
@@ -84,7 +89,7 @@ export function StepBrowserEnv({
 
           <div className="flex gap-3 mt-auto">
             <button className="flex-1 py-3 rounded-xl font-bold text-[13px] text-slate-400 bg-transparent border border-white/10 hover:bg-white/5 transition-colors cursor-pointer" onClick={onBack}>← 이전</button>
-            <button disabled={!step2Ok} onClick={onNext} className="flex-1 py-3 rounded-xl font-bold text-[13px] text-white bg-indigo-600 hover:bg-indigo-500 transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer">
+            <button disabled={!step2Ok} onClick={onNext} className="flex-1 py-3 rounded-xl font-bold text-[13px] text-white bg-[#06B6D4] hover:bg-[#22D3EE] transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer">
               {step2Checked ? (step2Ok ? "다음 →" : "네트워크 필요") : "점검 중..."}
             </button>
           </div>

--- a/src/pages/interview-precheck/ui/StepCameraMic.tsx
+++ b/src/pages/interview-precheck/ui/StepCameraMic.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import { Camera, Mic, Ban, User, CheckCircle2, XCircle } from "lucide-react";
 import type { CameraInfo, MicInfo, CheckStatus } from "@/features/interview-precheck";
 
 interface StepCameraMicProps {
@@ -46,9 +47,14 @@ export function StepCameraMic({
               {cameraStream ? (
                 <video ref={videoRef} autoPlay playsInline muted className="w-full h-full object-cover -scale-x-100" />
               ) : (
-                <div className="text-center text-slate-600">
-                  <div className="text-[32px] mb-1.5">{cameraStatus === "fail" ? "🚫" : "👤"}</div>
-                  <div className="text-[12px] font-medium">{cameraStatus === "fail" ? "카메라 권한 차단됨" : "카메라 연결 중"}</div>
+                <div className="text-center text-slate-600 flex flex-col items-center gap-2">
+                  {cameraStatus === "fail"
+                    ? <Ban size={32} className="text-red-500/70" />
+                    : <User size={32} className="text-slate-600" />
+                  }
+                  <div className="text-[12px] font-medium">
+                    {cameraStatus === "fail" ? "카메라 권한 차단됨" : "카메라 연결 중"}
+                  </div>
                 </div>
               )}
               {cameraStream && (
@@ -75,7 +81,10 @@ export function StepCameraMic({
         <div className="flex flex-col gap-4">
           {step1Checked && (
             <div className={`rounded-xl p-3 flex items-center gap-2.5 ${anyDenied ? "bg-red-500/10 border border-red-500/20" : "bg-emerald-500/10 border border-emerald-500/20"}`}>
-              <span className="text-sm shrink-0">{anyDenied ? "🚫" : "✅"}</span>
+              {anyDenied
+                ? <XCircle size={16} className="text-red-400 shrink-0" />
+                : <CheckCircle2 size={16} className="text-emerald-400 shrink-0" />
+              }
               <div className="text-[13px] text-slate-200 leading-[1.5]">
                 {anyDenied
                   ? <strong className="font-bold text-red-400">{camDenied && micDenied ? "카메라 및 마이크 권한 차단" : camDenied ? "카메라 권한 차단" : "마이크 권한 차단"}</strong>
@@ -86,7 +95,9 @@ export function StepCameraMic({
 
           <div className="grid grid-cols-2 gap-3">
             <div className="bg-slate-800/60 border border-white/10 rounded-xl p-4 text-center">
-              <div className="text-[20px] mb-1">📷</div>
+              <div className="flex justify-center mb-2">
+                <Camera size={20} className="text-slate-400" />
+              </div>
               <div className="text-[13px] font-extrabold text-slate-200 mb-1">카메라</div>
               <div className="text-[12px] font-semibold">{statusText(cameraStatus, "정상 감지")}</div>
               <div className="text-[10px] text-slate-500 mt-1">
@@ -94,7 +105,9 @@ export function StepCameraMic({
               </div>
             </div>
             <div className="bg-slate-800/60 border border-white/10 rounded-xl p-4 text-center">
-              <div className="text-[20px] mb-1">🎙️</div>
+              <div className="flex justify-center mb-2">
+                <Mic size={20} className="text-slate-400" />
+              </div>
               <div className="text-[13px] font-extrabold text-slate-200 mb-1">마이크</div>
               <div className="text-[12px] font-semibold">{statusText(micStatus, "정상 감지")}</div>
               <div className="text-[10px] text-slate-500 mt-1">
@@ -117,7 +130,7 @@ export function StepCameraMic({
 
           <div className="flex gap-3 mt-auto">
             <button className="flex-1 py-3 rounded-xl font-bold text-[13px] text-slate-400 bg-transparent border border-white/10 hover:bg-white/5 transition-colors cursor-pointer" onClick={onBack}>닫기</button>
-            <button disabled={!step1Ok} onClick={onNext} className="flex-1 py-3 rounded-xl font-bold text-[13px] text-white bg-indigo-600 hover:bg-indigo-500 transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer">
+            <button disabled={!step1Ok} onClick={onNext} className="flex-1 py-3 rounded-xl font-bold text-[13px] text-white bg-[#06B6D4] hover:bg-[#22D3EE] transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer">
               {step1Checked ? (step1Ok ? "다음 →" : "권한 필요") : "점검 중..."}
             </button>
           </div>

--- a/src/pages/interview-precheck/ui/StepVoiceCheck.tsx
+++ b/src/pages/interview-precheck/ui/StepVoiceCheck.tsx
@@ -57,7 +57,7 @@ export function StepVoiceCheck({ allPassed, isCreating, createError, onStart, on
 
           <div className="flex gap-3 mt-auto">
             <button className="flex-1 py-3 rounded-xl font-bold text-[13px] text-slate-400 bg-transparent border border-white/10 hover:bg-white/5 transition-colors cursor-pointer" onClick={onBack}>← 이전</button>
-            <button disabled={!allPassed || isCreating} onClick={onStart} className="flex-1 py-3 rounded-xl font-bold text-[13px] text-white bg-indigo-600 hover:bg-indigo-500 transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer">
+            <button disabled={!allPassed || isCreating} onClick={onStart} className="flex-1 py-3 rounded-xl font-bold text-[13px] text-white bg-[#06B6D4] hover:bg-[#22D3EE] transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer">
               {isCreating ? "생성 중..." : "면접 시작 →"}
             </button>
           </div>

--- a/src/pages/interview-precheck/ui/SttTestCard.tsx
+++ b/src/pages/interview-precheck/ui/SttTestCard.tsx
@@ -1,5 +1,6 @@
 /** STT 음성 인식 테스트 카드 (다크 테마). */
 import { useEffect, useRef, useState } from "react";
+import { Mic } from "lucide-react";
 import { WebSpeechSTTProvider } from "@/shared/lib/stt/WebSpeechSTTProvider";
 import { checkSttMatch, type SttMatchResult } from "@/shared/lib/voice/matchVoice";
 
@@ -53,7 +54,7 @@ export function SttTestCard() {
   return (
     <div className="bg-slate-800/60 border border-white/10 rounded-xl p-5">
       <div className="flex items-center gap-2 mb-2">
-        <span className="text-lg">🎙️</span>
+        <Mic size={18} className="text-slate-400 shrink-0" />
         <h3 className="text-[14px] font-extrabold text-slate-200">음성 인식 테스트</h3>
       </div>
       <p className="text-[12px] text-slate-400 leading-[1.5] mb-3">

--- a/src/pages/interview-precheck/ui/TtsTestCard.tsx
+++ b/src/pages/interview-precheck/ui/TtsTestCard.tsx
@@ -1,5 +1,6 @@
 /** 면접관 TTS 음성 테스트 카드 (다크 테마). */
 import { useEffect, useRef, useState } from "react";
+import { Volume2 } from "lucide-react";
 import {
   getAccessToken,
 } from "@/shared/api/client";
@@ -37,7 +38,7 @@ export function TtsTestCard() {
   return (
     <div className="bg-slate-800/60 border border-white/10 rounded-xl p-5">
       <div className="flex items-center gap-2 mb-3">
-        <span className="text-lg">🔊</span>
+        <Volume2 size={18} className="text-slate-400 shrink-0" />
         <h3 className="text-[14px] font-extrabold text-slate-200">면접관 음성 테스트</h3>
       </div>
       <p className="text-[12px] text-slate-400 leading-[1.5] mb-3">버튼을 눌러 음성이 잘 들리는지 확인하세요.</p>

--- a/src/pages/interview-report/ui/InterviewOverview.tsx
+++ b/src/pages/interview-report/ui/InterviewOverview.tsx
@@ -1,9 +1,9 @@
 import type { InterviewAnalysisReport } from "@/features/interview-session";
 
-const DIFFICULTY_KO: Record<string, string> = {
-  friendly: "친근한 면접관",
-  normal: "일반 면접관",
-  pressure: "압박 면접관",
+const DIFFICULTY_STYLE: Record<string, { label: string; cls: string }> = {
+  friendly: { label: "친근한 면접관", cls: "border-[#A7F3D0] bg-[#ECFDF5] text-[#059669]" },
+  normal:   { label: "일반 면접관",   cls: "border-[#BAE6FD] bg-[#E6F7FA] text-[#0991B2]" },
+  pressure: { label: "압박 면접관",   cls: "border-[#FECACA] bg-[#FEF2F2] text-[#DC2626]" },
 };
 
 function formatDate(iso: string | null): string {
@@ -34,7 +34,13 @@ export function InterviewOverview({ report }: Props) {
     { label: "지원 회사", value: report.companyName || "-" },
     { label: "채용 포지션", value: report.positionTitle || "-" },
     { label: "소요시간", value: formatDuration(report.durationSeconds) },
-    { label: "면접 난이도", value: DIFFICULTY_KO[report.difficultyLevel] ?? report.difficultyLevel },
+    { label: "면접 난이도", value: (
+      <span className={`text-[11px] font-semibold py-0.5 px-2 rounded-full border ${
+        (DIFFICULTY_STYLE[report.difficultyLevel] ?? DIFFICULTY_STYLE.normal).cls
+      }`}>
+        {(DIFFICULTY_STYLE[report.difficultyLevel] ?? { label: report.difficultyLevel }).label}
+      </span>
+    )},
     {
       label: "총 질문 수",
       value: (

--- a/src/pages/interview-report/ui/InterviewOverview.tsx
+++ b/src/pages/interview-report/ui/InterviewOverview.tsx
@@ -1,10 +1,5 @@
 import type { InterviewAnalysisReport } from "@/features/interview-session";
-
-const DIFFICULTY_STYLE: Record<string, { label: string; cls: string }> = {
-  friendly: { label: "친근한 면접관", cls: "border-[#A7F3D0] bg-[#ECFDF5] text-[#059669]" },
-  normal:   { label: "일반 면접관",   cls: "border-[#BAE6FD] bg-[#E6F7FA] text-[#0991B2]" },
-  pressure: { label: "압박 면접관",   cls: "border-[#FECACA] bg-[#FEF2F2] text-[#DC2626]" },
-};
+import { DIFFICULTY_STYLE } from "@/features/interview-session";
 
 function formatDate(iso: string | null): string {
   if (!iso) return "-";

--- a/src/pages/interview-results/ui/SessionCard.tsx
+++ b/src/pages/interview-results/ui/SessionCard.tsx
@@ -37,7 +37,13 @@ export function SessionCard({ session: s, isGenerating, onContinue, onViewReport
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5 flex-wrap mb-1">
             <span className="text-[13px] font-bold text-[#0A0A0A]">{SESSION_TYPE_LABEL[s.interviewSessionType] ?? s.interviewSessionType}</span>
-            <span className="text-[10px] font-semibold py-px px-2 rounded-full border border-[#E5E7EB] bg-white text-[#6B7280]">
+            <span className={`text-[10px] font-semibold py-px px-2 rounded-full border ${
+              s.interviewDifficultyLevel === "friendly"
+                ? "border-[#A7F3D0] bg-[#ECFDF5] text-[#059669]"
+                : s.interviewDifficultyLevel === "pressure"
+                  ? "border-[#FECACA] bg-[#FEF2F2] text-[#DC2626]"
+                  : "border-[#BAE6FD] bg-[#E6F7FA] text-[#0991B2]"
+            }`}>
               {DIFFICULTY_LABEL[s.interviewDifficultyLevel] ?? s.interviewDifficultyLevel}
             </span>
             {isInProgress && (

--- a/src/pages/interview-results/ui/SessionCard.tsx
+++ b/src/pages/interview-results/ui/SessionCard.tsx
@@ -1,5 +1,5 @@
 import { Loader2, FileText, Plus, ChevronRight, Play, Mic, BarChart2, ClipboardList } from "lucide-react";
-import { SESSION_TYPE_LABEL, DIFFICULTY_LABEL, REPORT_STATUS_BADGE } from "@/features/interview-session";
+import { SESSION_TYPE_LABEL, DIFFICULTY_STYLE, REPORT_STATUS_BADGE } from "@/features/interview-session";
 import type { InterviewSessionListItem } from "@/features/interview-session";
 import { formatDateTime } from "@/shared/lib/format/date";
 
@@ -38,13 +38,9 @@ export function SessionCard({ session: s, isGenerating, onContinue, onViewReport
           <div className="flex items-center gap-1.5 flex-wrap mb-1">
             <span className="text-[13px] font-bold text-[#0A0A0A]">{SESSION_TYPE_LABEL[s.interviewSessionType] ?? s.interviewSessionType}</span>
             <span className={`text-[10px] font-semibold py-px px-2 rounded-full border ${
-              s.interviewDifficultyLevel === "friendly"
-                ? "border-[#A7F3D0] bg-[#ECFDF5] text-[#059669]"
-                : s.interviewDifficultyLevel === "pressure"
-                  ? "border-[#FECACA] bg-[#FEF2F2] text-[#DC2626]"
-                  : "border-[#BAE6FD] bg-[#E6F7FA] text-[#0991B2]"
+              (DIFFICULTY_STYLE[s.interviewDifficultyLevel] ?? DIFFICULTY_STYLE.normal).cls
             }`}>
-              {DIFFICULTY_LABEL[s.interviewDifficultyLevel] ?? s.interviewDifficultyLevel}
+              {(DIFFICULTY_STYLE[s.interviewDifficultyLevel] ?? DIFFICULTY_STYLE.normal).label}
             </span>
             {isInProgress && (
               <span className="text-[10px] font-bold py-px px-2 rounded-full border border-[#FED7AA] bg-[#FFF7ED] text-[#D97706]">

--- a/src/pages/interview-session/ui/InterviewSessionPage.tsx
+++ b/src/pages/interview-session/ui/InterviewSessionPage.tsx
@@ -292,7 +292,14 @@ export function InterviewSessionPage() {
             </div>
           )}
           <div className="flex-1 relative min-h-0">
-            <AvatarSection onReady={(a) => { avatarRef.current = a; }} className="absolute inset-0 w-full h-full" />
+            {interviewSession?.interviewDifficultyLevel && (
+              <AvatarSection
+                key={interviewSession.interviewDifficultyLevel}
+                difficulty={interviewSession.interviewDifficultyLevel}
+                onReady={(a) => { avatarRef.current = a; }}
+                className="absolute inset-0 w-full h-full"
+              />
+            )}
           </div>
           <div className="shrink-0 px-6 pb-5 pt-4 border-t border-white/5 bg-[#080f1a]/80">
              <QuestionPanel

--- a/src/pages/interview-session/ui/PermissionOverlay.tsx
+++ b/src/pages/interview-session/ui/PermissionOverlay.tsx
@@ -45,7 +45,7 @@ export function PermissionOverlay({ onReload, onGoResults }: PermissionOverlayPr
             </p>
           </div>
           <div className="flex flex-col gap-3">
-            <button onClick={onReload} className="w-full h-12 rounded-[10px] bg-[#0991B2] text-white font-bold text-[14px] hover:opacity-90 transition-opacity">
+            <button onClick={onReload} className="w-full h-12 rounded-[10px] bg-[#06B6D4] text-white font-bold text-[14px] hover:bg-[#22D3EE] transition-colors">
               권한 허용 후 새로고침
             </button>
             <button onClick={onGoResults} className="w-full h-12 rounded-[10px] bg-[#374151] text-white font-semibold text-[14px] hover:bg-[#4B5563] transition-colors">

--- a/src/pages/interview-session/ui/ScreenSizeOverlay.tsx
+++ b/src/pages/interview-session/ui/ScreenSizeOverlay.tsx
@@ -1,3 +1,5 @@
+import { EyeOff } from "lucide-react";
+
 interface ScreenSizeOverlayProps {
   screenWidth: number;
   screenHeight: number;
@@ -10,9 +12,7 @@ export function ScreenSizeOverlay({ screenWidth, screenHeight, onGoHome }: Scree
       <div className="flex-1 flex items-center justify-center p-8">
         <div className="flex flex-col items-center gap-8 w-full max-w-[340px]">
           <div className="w-[80px] h-[80px] rounded-full bg-[#F9731620] flex items-center justify-center">
-            <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="#F97316" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M1 13s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" /><circle cx="12" cy="13" r="3" /><line x1="1" y1="1" x2="23" y2="23" />
-            </svg>
+            <EyeOff size={36} stroke="#F97316" strokeWidth={2} />
           </div>
           <div className="flex flex-col gap-3 text-center">
             <h2 className="text-[22px] font-bold text-white">화면이 너무 작습니다</h2>
@@ -28,7 +28,7 @@ export function ScreenSizeOverlay({ screenWidth, screenHeight, onGoHome }: Scree
               <span className="text-[12px] font-semibold text-[#22C55E]">1024 x 768</span>
             </div>
           </div>
-          <button onClick={onGoHome} className="w-full h-12 rounded-[10px] bg-[#0991B2] text-white font-semibold text-[14px] hover:opacity-90 transition-opacity">
+          <button onClick={onGoHome} className="w-full h-12 rounded-[10px] bg-[#06B6D4] text-white font-semibold text-[14px] hover:bg-[#22D3EE] transition-colors">
             홈으로 돌아가기
           </button>
         </div>

--- a/src/pages/interview-session/ui/SessionActionPanel.tsx
+++ b/src/pages/interview-session/ui/SessionActionPanel.tsx
@@ -65,12 +65,12 @@ export function SessionActionPanel({
 
   useEffect(() => {
     if (!shouldWarn) {
-      setWarnVisible(false); // eslint-disable-line react-hooks/set-state-in-effect -- reset on mode change
+      setWarnVisible(false); // eslint-disable-line react-hooks/set-state-in-effect
       if (warnTimerRef.current) { clearTimeout(warnTimerRef.current); warnTimerRef.current = null; }
       return;
     }
     if (audioLevel >= AUDIO_WARN_THRESHOLD) {
-      setWarnVisible(true);  
+      setWarnVisible(true);
       if (warnTimerRef.current) clearTimeout(warnTimerRef.current);
       warnTimerRef.current = setTimeout(() => {
         setWarnVisible(false);
@@ -85,12 +85,12 @@ export function SessionActionPanel({
   const showLoading = mode === "loading" || mode === "starting" || (mode === "not_started" && isModelLoading);
 
   return (
-    <div className={`shrink-0 p-4 border-b border-white/10 flex flex-col gap-2 ${className || ""}`}>
+    <div className={`shrink-0 p-4 border-b border-[#0991B2]/15 flex flex-col gap-2 ${className || ""}`}>
       {(mode === "loading" || mode === "not_started" || mode === "starting") && (
         <button
           onClick={onStart}
           disabled={mode !== "not_started" || isModelLoading}
-          className="w-full py-3 rounded-xl font-bold text-base bg-indigo-600 hover:bg-indigo-500 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+          className="w-full py-3 rounded-xl font-bold text-base bg-[#06B6D4] hover:bg-[#22D3EE] text-white transition-colors disabled:opacity-50 flex items-center justify-center gap-2 shadow-[0_2px_12px_rgba(6,182,212,0.35)]"
         >
           {showLoading
             ? <><Loader2 size={16} className="animate-spin" /> 준비 중...</>
@@ -99,8 +99,8 @@ export function SessionActionPanel({
       )}
 
       {mode === "real_tts_playing" && (
-        <div className="w-full py-3 rounded-xl bg-indigo-500/10 border border-indigo-500/30 text-center">
-          <p className="text-indigo-300 text-xs font-semibold flex items-center justify-center gap-1.5">
+        <div className="w-full py-3 rounded-xl bg-[#0991B2]/10 border border-[#0991B2]/30 text-center">
+          <p className="text-[#06B6D4] text-xs font-semibold flex items-center justify-center gap-1.5">
             <Loader2 size={12} className="animate-spin" /> 질문 음성 재생 중...
           </p>
         </div>
@@ -114,13 +114,13 @@ export function SessionActionPanel({
       )}
 
       {mode === "practice_tts_playing" && (
-        <button disabled className="w-full py-3 rounded-xl font-bold text-base bg-green-600 transition-colors opacity-50 flex items-center justify-center gap-2">
+        <button disabled className="w-full py-3 rounded-xl font-bold text-base bg-[#06B6D4] transition-colors opacity-50 flex items-center justify-center gap-2 text-white">
           <Loader2 size={14} className="animate-spin" /> 질문 음성 재생 중...
         </button>
       )}
 
       {mode === "preparing_record" && (
-        <button disabled className="w-full py-3 rounded-xl font-bold text-base bg-green-600 transition-colors opacity-50 flex items-center justify-center gap-2">
+        <button disabled className="w-full py-3 rounded-xl font-bold text-base bg-[#06B6D4] transition-colors opacity-50 flex items-center justify-center gap-2 text-white">
           <Loader2 size={14} className="animate-spin" /> 녹화 준비 중...
         </button>
       )}
@@ -128,7 +128,7 @@ export function SessionActionPanel({
       {mode === "practice_ready" && (
         <button
           onClick={onPracticeStart}
-          className="w-full py-3 rounded-xl font-bold text-base bg-green-600 hover:bg-green-500 transition-colors flex items-center justify-center gap-2"
+          className="w-full py-3 rounded-xl font-bold text-base bg-emerald-600 hover:bg-emerald-500 text-white transition-colors flex items-center justify-center gap-2 shadow-[0_2px_12px_rgba(5,150,105,0.3)]"
         >
           말하기 시작
         </button>
@@ -140,14 +140,14 @@ export function SessionActionPanel({
         <button
           onClick={onSubmitAnswer}
           disabled={!hasAnswer}
-          className="w-full py-3 rounded-xl font-bold text-base bg-indigo-600 hover:bg-indigo-500 transition-colors disabled:opacity-40 flex items-center justify-center gap-2"
+          className="w-full py-3 rounded-xl font-bold text-base bg-[#06B6D4] hover:bg-[#22D3EE] text-white transition-colors disabled:opacity-40 flex items-center justify-center gap-2 shadow-[0_2px_12px_rgba(6,182,212,0.35)]"
         >
           답변 제출
         </button>
       )}
 
       {mode === "submitting" && (
-        <button disabled className="w-full py-3 rounded-xl font-bold text-base bg-indigo-600 opacity-50 flex items-center justify-center gap-2">
+        <button disabled className="w-full py-3 rounded-xl font-bold text-base bg-[#06B6D4] opacity-50 text-white flex items-center justify-center gap-2">
           <Loader2 size={16} className="animate-spin" />
           {interviewPhase === "generating_followup" ? "꼬리질문 생성 중..." : interviewPhase === "submitting" ? "제출 중..." : "답변 저장 중..."}
         </button>

--- a/src/pages/interview-session/ui/SessionHeader.tsx
+++ b/src/pages/interview-session/ui/SessionHeader.tsx
@@ -18,25 +18,29 @@ export function SessionHeader({
   hasStarted, isFinished, difficultyLabel, practiceModeLabel, onFinish,
 }: SessionHeaderProps) {
   return (
-    <header className={`h-14 border-b border-white/10 flex items-center justify-between px-6 shrink-0 bg-[#0d1826]/80 backdrop-blur ${className || ""}`}>
+    <header className={`h-14 border-b border-[#0991B2]/20 flex items-center justify-between px-6 shrink-0 bg-[#060f16]/90 backdrop-blur ${className || ""}`}>
       <div className="flex items-center gap-3">
-        <span className="w-2 h-2 rounded-full bg-red-400 animate-pulse" />
-        <span className="text-sm font-bold text-slate-300">
+        <span className="w-2 h-2 rounded-full bg-[#06B6D4] animate-pulse" />
+        <span className="text-sm font-bold text-slate-200">
           {interviewSession?.interviewSessionType === "followup" ? "꼬리질문형" : "전체 프로세스"} 면접
         </span>
-        <span className="text-[11px] text-slate-500 border border-slate-700 rounded-full px-2 py-px">{difficultyLabel}</span>
-        <span className="text-[11px] text-indigo-400 border border-indigo-800 rounded-full px-2 py-px">{practiceModeLabel}</span>
+        <span className="text-[11px] text-[#06B6D4]/80 border border-[#0991B2]/30 rounded-full px-2 py-px bg-[#0991B2]/10">
+          {difficultyLabel}
+        </span>
+        <span className="text-[11px] text-[#06B6D4] border border-[#06B6D4]/30 rounded-full px-2 py-px bg-[#06B6D4]/10">
+          {practiceModeLabel}
+        </span>
       </div>
       <div className="flex items-center gap-3">
         {interviewSession && hasStarted && (
-          <span className="text-[11px] font-mono text-slate-500">
+          <span className="text-[11px] font-mono text-[#0991B2]">
             {currentInterviewTurnIndex + 1} / {interviewSession.estimatedTotalQuestions || "?"}
           </span>
         )}
         <button
           onClick={onFinish}
           disabled={isFinished || !hasStarted}
-          className="flex items-center gap-1.5 text-xs font-bold text-red-400 border border-red-400/30 bg-red-400/10 rounded-lg px-3 py-1.5 hover:bg-red-400/20 transition-colors disabled:opacity-40"
+          className="flex items-center gap-1.5 text-xs font-bold text-red-400 border border-red-500/30 bg-red-500/10 rounded-lg px-3 py-1.5 hover:bg-red-500/20 transition-colors disabled:opacity-40"
         >
           <Square size={12} /> 면접 종료
         </button>

--- a/src/pages/interview-setup/ui/JdSavedTab.tsx
+++ b/src/pages/interview-setup/ui/JdSavedTab.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { SelectableCard } from "@/shared/ui/SelectableCard";
 import { CompanyIcon } from "@/shared/ui/CompanyIcon";
 
@@ -24,8 +25,11 @@ export function JdSavedTab({ jdList, jdListLoading, selectedJdId, onSelectJd }: 
 
   if (jdList.length === 0) {
     return (
-      <div className="p-4 text-center text-[13px] text-[#6B7280] border border-dashed border-[#E5E7EB] rounded-lg">
-        등록된 채용공고가 없어요. 먼저 채용공고를 업로드해 주세요.
+      <div className="py-4 px-6 text-center text-[13px] text-[#6B7280] border border-dashed border-[#E5E7EB] rounded-lg">
+        <div>아직 등록된 채용공고가 없어요.</div>
+        <Link to="/jd" className="mt-1.5 inline-block text-[#0991B2] font-semibold underline underline-offset-2 hover:opacity-75">
+          채용공고 추가하기 →
+        </Link>
       </div>
     );
   }

--- a/src/pages/interview-setup/ui/ResumeSection.tsx
+++ b/src/pages/interview-setup/ui/ResumeSection.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { SetupSection } from "@/shared/ui/SetupSection";
 import { SelectableCard } from "@/shared/ui/SelectableCard";
 import { FileText, PencilLine } from "lucide-react";
@@ -36,8 +37,11 @@ export function ResumeSection({
       {resumesLoading ? (
         <div className="p-4 text-center text-[13px] text-[#9CA3AF]">이력서 목록을 불러오는 중...</div>
       ) : resumes.length === 0 ? (
-        <div className="p-4 text-center text-[13px] text-[#6B7280] border border-dashed border-[#E5E7EB] rounded-lg">
-          등록된 이력서가 없어요. 먼저 이력서를 업로드해 주세요.
+        <div className="py-4 px-6 text-center text-[13px] text-[#6B7280] border border-dashed border-[#E5E7EB] rounded-lg">
+          <div>아직 등록된 이력서가 없어요.</div>
+          <Link to="/resume/new" className="mt-1.5 inline-block text-[#0991B2] font-semibold underline underline-offset-2 hover:opacity-75">
+            이력서 추가하기 →
+          </Link>
         </div>
       ) : (
         <div className="flex flex-col gap-[7px] flex-1 overflow-y-auto min-h-0">

--- a/src/shared/lib/avatar/FriendlyAvatarProvider.ts
+++ b/src/shared/lib/avatar/FriendlyAvatarProvider.ts
@@ -56,84 +56,9 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
     wrapper.style.background = "#080f1a";
     wrapper.innerHTML = `
       <div id="friendly-body-wrapper" class="friendly-container relative w-56 h-56 shrink-0">
-        <div class="absolute -top-8 -left-4 -z-10"
-          style="width:256px; height:144px; background:linear-gradient(180deg,#7B5236 0%,#5a3a20 100%); border-radius:100px 100px 30px 30px;"></div>
-        <div class="absolute -z-10"
-          style="width:18px; height:26px; background:linear-gradient(160deg,#e8b89a,#c07a50); border-radius:50%; top:38%; left:-6px; box-shadow:inset 3px 0 6px rgba(160,80,30,0.3);">
-          <div style="position:absolute; top:25%; left:20%; width:8px; height:14px; background:rgba(160,80,30,0.2); border-radius:50%;"></div>
-        </div>
-        <div class="absolute -z-10"
-          style="width:18px; height:26px; background:linear-gradient(160deg,#e8b89a,#c07a50); border-radius:50%; top:38%; right:-6px; box-shadow:inset -3px 0 6px rgba(160,80,30,0.3);">
-          <div style="position:absolute; top:25%; right:20%; width:8px; height:14px; background:rgba(160,80,30,0.2); border-radius:50%;"></div>
-        </div>
-        <div id="friendly-face" class="friendly-face w-full h-full rounded-[42%] flex flex-col items-center relative overflow-hidden transition-all duration-300">
-          <div class="absolute top-[42%] left-[8%] w-12 h-7 rounded-full blur-lg opacity-50" style="background:#e07050;"></div>
-          <div class="absolute top-[42%] right-[8%] w-12 h-7 rounded-full blur-lg opacity-50" style="background:#e07050;"></div>
-          <div class="absolute top-[24%] w-full flex justify-between px-10">
-            <svg width="32" height="12" viewBox="0 0 32 12"><path d="M 2 10 Q 8 1 30 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/></svg>
-            <svg width="32" height="12" viewBox="0 0 32 12"><path d="M 30 10 Q 24 1 2 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/></svg>
-          </div>
-          <div class="absolute top-[33%] w-full flex justify-between px-10">
-            <div class="friendly-eye w-9 h-10 bg-white rounded-full relative overflow-hidden shadow-md">
-              <div class="absolute bottom-1 right-1 w-6 h-7 rounded-full" style="background:#3d2010;">
-                <div class="absolute top-1 right-1 w-2 h-2 bg-white rounded-full opacity-90"></div>
-                <div class="absolute bottom-1 left-0.5 w-1 h-1 bg-white rounded-full opacity-50"></div>
-              </div>
-            </div>
-            <div class="friendly-eye w-9 h-10 bg-white rounded-full relative overflow-hidden shadow-md">
-              <div class="absolute bottom-1 left-1 w-6 h-7 rounded-full" style="background:#3d2010;">
-                <div class="absolute top-1 left-1 w-2 h-2 bg-white rounded-full opacity-90"></div>
-                <div class="absolute bottom-1 right-0.5 w-1 h-1 bg-white rounded-full opacity-50"></div>
-              </div>
-            </div>
-          </div>
-          <div class="absolute top-[54%] left-1/2 -translate-x-1/2"
-            style="width:0; height:0; border-left:5px solid transparent; border-right:5px solid transparent; border-top:7px solid rgba(160,80,40,0.25);"></div>
-          <div class="absolute top-[65%] w-full flex justify-center">
-            <div id="friendly-mouth" class="relative overflow-hidden transition-all duration-75"
-              style="width:38px; height:10px; border-radius:0 0 20px 20px; background:#7a2020;">
-              <div class="absolute top-0 w-full h-[25%]" style="background:rgba(255,255,255,0.85);"></div>
-              <div class="absolute bottom-0 w-full h-[40%] rounded-full" style="background:#c06060; transform:translateY(40%);"></div>
-            </div>
-          </div>
-          <svg class="absolute top-0 left-0 w-full h-20" viewBox="0 0 100 40" preserveAspectRatio="none">
-            <path d="M 0 0 L 100 0 L 100 15 Q 75 35 50 20 Q 25 35 0 15 Z" fill="#7B5236"/>
-          </svg>
-        </div>
-        <div class="absolute pointer-events-none" style="top:-32px; left:-16px; width:256px; height:144px; z-index:1;">
-          <svg width="256" height="144" viewBox="0 0 256 144" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-              <linearGradient id="f-fg-hair-grad" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stop-color="#7B5236"/>
-                <stop offset="100%" stop-color="#5a3a20"/>
-              </linearGradient>
-              <clipPath id="f-hair-shape-clip">
-                <path d="M 100 0 L 156 0 Q 256 0 256 100 L 256 114 Q 256 144 226 144 L 30 144 Q 0 144 0 114 L 0 100 Q 0 0 100 0 Z"/>
-              </clipPath>
-            </defs>
-            <g clip-path="url(#f-hair-shape-clip)">
-              <path d="M 0 0 L 256 0 L 256 108 Q 240 98 224 106 Q 208 114 192 104 Q 176 94 160 103 Q 144 112 128 72 Q 112 112 96 103 Q 80 94 64 104 Q 48 114 32 106 Q 16 98 0 108 Z" fill="url(#f-fg-hair-grad)"/>
-            </g>
-          </svg>
-        </div>
-        <div class="absolute pointer-events-none" style="bottom:-100px; left:50%; transform:translateX(-50%); width:280px; height:110px; z-index:-1;">
-          <svg width="280" height="110" viewBox="0 0 280 110" xmlns="http://www.w3.org/2000/svg">
-            <path d="M 0 50 Q 0 30 24 26 L 95 18 L 140 32 L 185 18 L 256 26 Q 280 30 280 50 L 280 110 L 0 110 Z" fill="#4a5e3a"/>
-            <path d="M 0 50 Q 0 30 24 26 L 95 18 L 85 34 L 28 44 Q 10 48 0 58 Z" fill="#3d4f30"/>
-            <path d="M 280 50 Q 280 30 256 26 L 185 18 L 195 34 L 252 44 Q 270 48 280 58 Z" fill="#3d4f30"/>
-            <path d="M 105 75 Q 140 70 175 75 L 175 110 L 105 110 Z" fill="#3d4f30" opacity="0.5"/>
-            <line x1="140" y1="46" x2="140" y2="110" stroke="#3d4f30" stroke-width="2"/>
-            <rect x="134" y="46" width="12" height="7" rx="2" fill="#6b7280"/>
-            <rect x="116" y="0" width="48" height="40" rx="8" fill="#d4956a"/>
-            <path d="M 140 34 L 100 20 L 92 34 L 130 46 Z" fill="#4a5e3a"/>
-            <path d="M 140 34 L 180 20 L 188 34 L 150 46 Z" fill="#4a5e3a"/>
-            <path d="M 130 46 L 140 56 L 150 46 L 140 34 Z" fill="#c07a50"/>
-            <line x1="128" y1="46" x2="120" y2="72" stroke="#3d4f30" stroke-width="2.5" stroke-linecap="round"/>
-            <line x1="152" y1="46" x2="160" y2="72" stroke="#3d4f30" stroke-width="2.5" stroke-linecap="round"/>
-            <circle cx="120" cy="73" r="3" fill="#2d3a22"/>
-            <circle cx="160" cy="73" r="3" fill="#2d3a22"/>
-          </svg>
-        </div>
+        ${this.buildHairHTML()}
+        ${this.buildFaceHTML()}
+        ${this.buildBodyHTML()}
       </div>
       <div id="friendly-status" class="mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5"
         style="background:rgba(59,130,246,0.1); border-color:rgba(59,130,246,0.2); color:#93c5fd;">
@@ -142,6 +67,99 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
       </div>
     `;
     return wrapper;
+  }
+
+  private buildHairHTML(): string {
+    return `
+      <div class="absolute -top-8 -left-4 -z-10"
+        style="width:256px; height:144px; background:linear-gradient(180deg,#7B5236 0%,#5a3a20 100%); border-radius:100px 100px 30px 30px;"></div>
+      <div class="absolute -z-10"
+        style="width:18px; height:26px; background:linear-gradient(160deg,#e8b89a,#c07a50); border-radius:50%; top:38%; left:-6px; box-shadow:inset 3px 0 6px rgba(160,80,30,0.3);">
+        <div style="position:absolute; top:25%; left:20%; width:8px; height:14px; background:rgba(160,80,30,0.2); border-radius:50%;"></div>
+      </div>
+      <div class="absolute -z-10"
+        style="width:18px; height:26px; background:linear-gradient(160deg,#e8b89a,#c07a50); border-radius:50%; top:38%; right:-6px; box-shadow:inset -3px 0 6px rgba(160,80,30,0.3);">
+        <div style="position:absolute; top:25%; right:20%; width:8px; height:14px; background:rgba(160,80,30,0.2); border-radius:50%;"></div>
+      </div>
+      <div class="absolute pointer-events-none" style="top:-32px; left:-16px; width:256px; height:144px; z-index:1;">
+        <svg width="256" height="144" viewBox="0 0 256 144" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="f-fg-hair-grad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#7B5236"/>
+              <stop offset="100%" stop-color="#5a3a20"/>
+            </linearGradient>
+            <clipPath id="f-hair-shape-clip">
+              <path d="M 100 0 L 156 0 Q 256 0 256 100 L 256 114 Q 256 144 226 144 L 30 144 Q 0 144 0 114 L 0 100 Q 0 0 100 0 Z"/>
+            </clipPath>
+          </defs>
+          <g clip-path="url(#f-hair-shape-clip)">
+            <path d="M 0 0 L 256 0 L 256 108 Q 240 98 224 106 Q 208 114 192 104 Q 176 94 160 103 Q 144 112 128 72 Q 112 112 96 103 Q 80 94 64 104 Q 48 114 32 106 Q 16 98 0 108 Z" fill="url(#f-fg-hair-grad)"/>
+          </g>
+        </svg>
+      </div>
+    `;
+  }
+
+  private buildFaceHTML(): string {
+    return `
+      <div id="friendly-face" class="friendly-face w-full h-full rounded-[42%] flex flex-col items-center relative overflow-hidden transition-all duration-300">
+        <div class="absolute top-[42%] left-[8%] w-12 h-7 rounded-full blur-lg opacity-50" style="background:#e07050;"></div>
+        <div class="absolute top-[42%] right-[8%] w-12 h-7 rounded-full blur-lg opacity-50" style="background:#e07050;"></div>
+        <div class="absolute top-[24%] w-full flex justify-between px-10">
+          <svg width="32" height="12" viewBox="0 0 32 12"><path d="M 2 10 Q 8 1 30 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/></svg>
+          <svg width="32" height="12" viewBox="0 0 32 12"><path d="M 30 10 Q 24 1 2 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/></svg>
+        </div>
+        <div class="absolute top-[33%] w-full flex justify-between px-10">
+          <div class="friendly-eye w-9 h-10 bg-white rounded-full relative overflow-hidden shadow-md">
+            <div class="absolute bottom-1 right-1 w-6 h-7 rounded-full" style="background:#3d2010;">
+              <div class="absolute top-1 right-1 w-2 h-2 bg-white rounded-full opacity-90"></div>
+              <div class="absolute bottom-1 left-0.5 w-1 h-1 bg-white rounded-full opacity-50"></div>
+            </div>
+          </div>
+          <div class="friendly-eye w-9 h-10 bg-white rounded-full relative overflow-hidden shadow-md">
+            <div class="absolute bottom-1 left-1 w-6 h-7 rounded-full" style="background:#3d2010;">
+              <div class="absolute top-1 left-1 w-2 h-2 bg-white rounded-full opacity-90"></div>
+              <div class="absolute bottom-1 right-0.5 w-1 h-1 bg-white rounded-full opacity-50"></div>
+            </div>
+          </div>
+        </div>
+        <div class="absolute top-[54%] left-1/2 -translate-x-1/2"
+          style="width:0; height:0; border-left:5px solid transparent; border-right:5px solid transparent; border-top:7px solid rgba(160,80,40,0.25);"></div>
+        <div class="absolute top-[65%] w-full flex justify-center">
+          <div id="friendly-mouth" class="relative overflow-hidden transition-all duration-75"
+            style="width:38px; height:10px; border-radius:0 0 20px 20px; background:#7a2020;">
+            <div class="absolute top-0 w-full h-[25%]" style="background:rgba(255,255,255,0.85);"></div>
+            <div class="absolute bottom-0 w-full h-[40%] rounded-full" style="background:#c06060; transform:translateY(40%);"></div>
+          </div>
+        </div>
+        <svg class="absolute top-0 left-0 w-full h-20" viewBox="0 0 100 40" preserveAspectRatio="none">
+          <path d="M 0 0 L 100 0 L 100 15 Q 75 35 50 20 Q 25 35 0 15 Z" fill="#7B5236"/>
+        </svg>
+      </div>
+    `;
+  }
+
+  private buildBodyHTML(): string {
+    return `
+      <div class="absolute pointer-events-none" style="bottom:-100px; left:50%; transform:translateX(-50%); width:280px; height:110px; z-index:-1;">
+        <svg width="280" height="110" viewBox="0 0 280 110" xmlns="http://www.w3.org/2000/svg">
+          <path d="M 0 50 Q 0 30 24 26 L 95 18 L 140 32 L 185 18 L 256 26 Q 280 30 280 50 L 280 110 L 0 110 Z" fill="#4a5e3a"/>
+          <path d="M 0 50 Q 0 30 24 26 L 95 18 L 85 34 L 28 44 Q 10 48 0 58 Z" fill="#3d4f30"/>
+          <path d="M 280 50 Q 280 30 256 26 L 185 18 L 195 34 L 252 44 Q 270 48 280 58 Z" fill="#3d4f30"/>
+          <path d="M 105 75 Q 140 70 175 75 L 175 110 L 105 110 Z" fill="#3d4f30" opacity="0.5"/>
+          <line x1="140" y1="46" x2="140" y2="110" stroke="#3d4f30" stroke-width="2"/>
+          <rect x="134" y="46" width="12" height="7" rx="2" fill="#6b7280"/>
+          <rect x="116" y="0" width="48" height="40" rx="8" fill="#d4956a"/>
+          <path d="M 140 34 L 100 20 L 92 34 L 130 46 Z" fill="#4a5e3a"/>
+          <path d="M 140 34 L 180 20 L 188 34 L 150 46 Z" fill="#4a5e3a"/>
+          <path d="M 130 46 L 140 56 L 150 46 L 140 34 Z" fill="#c07a50"/>
+          <line x1="128" y1="46" x2="120" y2="72" stroke="#3d4f30" stroke-width="2.5" stroke-linecap="round"/>
+          <line x1="152" y1="46" x2="160" y2="72" stroke="#3d4f30" stroke-width="2.5" stroke-linecap="round"/>
+          <circle cx="120" cy="73" r="3" fill="#2d3a22"/>
+          <circle cx="160" cy="73" r="3" fill="#2d3a22"/>
+        </svg>
+      </div>
+    `;
   }
 
   private startBlinking() {

--- a/src/shared/lib/avatar/FriendlyAvatarProvider.ts
+++ b/src/shared/lib/avatar/FriendlyAvatarProvider.ts
@@ -58,7 +58,7 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
     const bodyWrapper = document.createElement("div");
     bodyWrapper.id = "friendly-body-wrapper";
     bodyWrapper.className = "friendly-container relative w-56 h-56 shrink-0";
-    bodyWrapper.innerHTML = this.buildHairHTML() + this.buildFaceHTML() + this.buildBodyHTML();
+    bodyWrapper.appendChild(this.parseStaticHTML(this.buildHairHTML() + this.buildFaceHTML() + this.buildBodyHTML()));
 
     const status = document.createElement("div");
     status.id = "friendly-status";
@@ -170,6 +170,16 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
         </svg>
       </div>
     `;
+  }
+
+  private parseStaticHTML(html: string): DocumentFragment {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+    const fragment = document.createDocumentFragment();
+    Array.from(doc.body.childNodes).forEach((node) =>
+      fragment.appendChild(document.adoptNode(node))
+    );
+    return fragment;
   }
 
   private startBlinking() {

--- a/src/shared/lib/avatar/FriendlyAvatarProvider.ts
+++ b/src/shared/lib/avatar/FriendlyAvatarProvider.ts
@@ -14,70 +14,65 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
 
   async initialize(container: HTMLElement): Promise<void> {
     this.container = container;
-    const styleId = "friendly-avatar-style";
-    if (!document.getElementById(styleId)) {
-      const styleEl = document.createElement("style");
-      styleEl.id = styleId;
-      styleEl.innerHTML = `
-        @keyframes friendlyFloat {
-          0%, 100% { transform: translateY(0px) rotate(-0.5deg); }
-          30% { transform: translateY(-12px) rotate(1deg); }
-          60% { transform: translateY(-6px) rotate(-0.5deg); }
-        }
-        @keyframes friendlyNod {
-          0%, 100% { transform: rotate(0deg); }
-          25% { transform: rotate(3deg); }
-          75% { transform: rotate(-2deg); }
-        }
-        .friendly-face {
-          background: linear-gradient(160deg, #e8b89a 0%, #d4956a 60%, #c07a50 100%);
-          box-shadow: inset -8px -12px 20px rgba(160,80,30,0.25), inset 4px 4px 12px rgba(255,220,190,0.3), 0 20px 50px rgba(0,0,0,0.35);
-        }
-        .friendly-eye { transition: transform 0.12s cubic-bezier(0.4,0,0.2,1); transform-origin: center; }
-        .friendly-container { animation: friendlyFloat 5s ease-in-out infinite; }
-        .friendly-speaking { animation: friendlyFloat 5s ease-in-out infinite, friendlyNod 1.2s ease-in-out infinite; }
-        .friendly-glow { box-shadow: inset -8px -12px 20px rgba(160,80,30,0.25), inset 4px 4px 12px rgba(255,220,190,0.3), 0 0 50px rgba(251,191,36,0.35) !important; }
-      `;
-      document.head.appendChild(styleEl);
-    }
+    this.injectStyles();
+    const wrapper = this.buildHTML();
+    container.appendChild(wrapper);
+    this.avatarWrapper = wrapper.querySelector("#friendly-body-wrapper");
+    this.mouthElement = wrapper.querySelector("#friendly-mouth");
+    this.startBlinking();
+  }
 
+  private injectStyles(): void {
+    const styleId = "friendly-avatar-style";
+    if (document.getElementById(styleId)) return;
+    const styleEl = document.createElement("style");
+    styleEl.id = styleId;
+    styleEl.innerHTML = `
+      @keyframes friendlyFloat {
+        0%, 100% { transform: translateY(0px) rotate(-0.5deg); }
+        30% { transform: translateY(-12px) rotate(1deg); }
+        60% { transform: translateY(-6px) rotate(-0.5deg); }
+      }
+      @keyframes friendlyNod {
+        0%, 100% { transform: rotate(0deg); }
+        25% { transform: rotate(3deg); }
+        75% { transform: rotate(-2deg); }
+      }
+      .friendly-face {
+        background: linear-gradient(160deg, #e8b89a 0%, #d4956a 60%, #c07a50 100%);
+        box-shadow: inset -8px -12px 20px rgba(160,80,30,0.25), inset 4px 4px 12px rgba(255,220,190,0.3), 0 20px 50px rgba(0,0,0,0.35);
+      }
+      .friendly-eye { transition: transform 0.12s cubic-bezier(0.4,0,0.2,1); transform-origin: center; }
+      .friendly-container { animation: friendlyFloat 5s ease-in-out infinite; }
+      .friendly-speaking { animation: friendlyFloat 5s ease-in-out infinite, friendlyNod 1.2s ease-in-out infinite; }
+      .friendly-glow { box-shadow: inset -8px -12px 20px rgba(160,80,30,0.25), inset 4px 4px 12px rgba(255,220,190,0.3), 0 0 50px rgba(251,191,36,0.35) !important; }
+    `;
+    document.head.appendChild(styleEl);
+  }
+
+  private buildHTML(): HTMLElement {
     const wrapper = document.createElement("div");
     wrapper.className = "w-full h-full flex flex-col items-center justify-center relative overflow-hidden";
     wrapper.style.background = "#080f1a";
     wrapper.innerHTML = `
       <div id="friendly-body-wrapper" class="friendly-container relative w-56 h-56 shrink-0">
-
-        <!-- 뒷머리 배경 -->
         <div class="absolute -top-8 -left-4 -z-10"
           style="width:256px; height:144px; background:linear-gradient(180deg,#7B5236 0%,#5a3a20 100%); border-radius:100px 100px 30px 30px;"></div>
-
-        <!-- 귀 왼쪽 -->
         <div class="absolute -z-10"
           style="width:18px; height:26px; background:linear-gradient(160deg,#e8b89a,#c07a50); border-radius:50%; top:38%; left:-6px; box-shadow:inset 3px 0 6px rgba(160,80,30,0.3);">
           <div style="position:absolute; top:25%; left:20%; width:8px; height:14px; background:rgba(160,80,30,0.2); border-radius:50%;"></div>
         </div>
-        <!-- 귀 오른쪽 -->
         <div class="absolute -z-10"
           style="width:18px; height:26px; background:linear-gradient(160deg,#e8b89a,#c07a50); border-radius:50%; top:38%; right:-6px; box-shadow:inset -3px 0 6px rgba(160,80,30,0.3);">
           <div style="position:absolute; top:25%; right:20%; width:8px; height:14px; background:rgba(160,80,30,0.2); border-radius:50%;"></div>
         </div>
-
         <div id="friendly-face" class="friendly-face w-full h-full rounded-[42%] flex flex-col items-center relative overflow-hidden transition-all duration-300">
-          <!-- 볼터치 -->
           <div class="absolute top-[42%] left-[8%] w-12 h-7 rounded-full blur-lg opacity-50" style="background:#e07050;"></div>
           <div class="absolute top-[42%] right-[8%] w-12 h-7 rounded-full blur-lg opacity-50" style="background:#e07050;"></div>
-
-          <!-- 눈썹: 자연스러운 아치형 SVG, 머리카락 색과 동일 -->
           <div class="absolute top-[24%] w-full flex justify-between px-10">
-            <svg width="32" height="12" viewBox="0 0 32 12">
-              <path d="M 2 10 Q 8 1 30 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/>
-            </svg>
-            <svg width="32" height="12" viewBox="0 0 32 12">
-              <path d="M 30 10 Q 24 1 2 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/>
-            </svg>
+            <svg width="32" height="12" viewBox="0 0 32 12"><path d="M 2 10 Q 8 1 30 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/></svg>
+            <svg width="32" height="12" viewBox="0 0 32 12"><path d="M 30 10 Q 24 1 2 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/></svg>
           </div>
-
-          <!-- 눈 -->
           <div class="absolute top-[33%] w-full flex justify-between px-10">
             <div class="friendly-eye w-9 h-10 bg-white rounded-full relative overflow-hidden shadow-md">
               <div class="absolute bottom-1 right-1 w-6 h-7 rounded-full" style="background:#3d2010;">
@@ -92,12 +87,8 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
               </div>
             </div>
           </div>
-
-          <!-- 코 -->
           <div class="absolute top-[54%] left-1/2 -translate-x-1/2"
             style="width:0; height:0; border-left:5px solid transparent; border-right:5px solid transparent; border-top:7px solid rgba(160,80,40,0.25);"></div>
-
-          <!-- 입 -->
           <div class="absolute top-[65%] w-full flex justify-center">
             <div id="friendly-mouth" class="relative overflow-hidden transition-all duration-75"
               style="width:38px; height:10px; border-radius:0 0 20px 20px; background:#7a2020;">
@@ -105,14 +96,10 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
               <div class="absolute bottom-0 w-full h-[40%] rounded-full" style="background:#c06060; transform:translateY(40%);"></div>
             </div>
           </div>
-
-          <!-- 얼굴 위 머리카락 마스크 -->
           <svg class="absolute top-0 left-0 w-full h-20" viewBox="0 0 100 40" preserveAspectRatio="none">
             <path d="M 0 0 L 100 0 L 100 15 Q 75 35 50 20 Q 25 35 0 15 Z" fill="#7B5236"/>
           </svg>
         </div>
-
-        <!-- 앞머리 SVG: 웨이브 -->
         <div class="absolute pointer-events-none" style="top:-32px; left:-16px; width:256px; height:144px; z-index:1;">
           <svg width="256" height="144" viewBox="0 0 256 144" xmlns="http://www.w3.org/2000/svg">
             <defs>
@@ -125,68 +112,36 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
               </clipPath>
             </defs>
             <g clip-path="url(#f-hair-shape-clip)">
-              <path d="
-                M 0 0 L 256 0 L 256 108
-                Q 240 98 224 106
-                Q 208 114 192 104
-                Q 176 94 160 103
-                Q 144 112 128 72
-                Q 112 112 96 103
-                Q 80 94 64 104
-                Q 48 114 32 106
-                Q 16 98 0 108
-                Z
-              " fill="url(#f-fg-hair-grad)"/>
+              <path d="M 0 0 L 256 0 L 256 108 Q 240 98 224 106 Q 208 114 192 104 Q 176 94 160 103 Q 144 112 128 72 Q 112 112 96 103 Q 80 94 64 104 Q 48 114 32 106 Q 16 98 0 108 Z" fill="url(#f-fg-hair-grad)"/>
             </g>
           </svg>
         </div>
-
-        <!-- 목 + 후드티 SVG 통합 -->
         <div class="absolute pointer-events-none" style="bottom:-100px; left:50%; transform:translateX(-50%); width:280px; height:110px; z-index:-1;">
           <svg width="280" height="110" viewBox="0 0 280 110" xmlns="http://www.w3.org/2000/svg">
-            <!-- 후드티 몸통 (따뜻한 올리브 그린) -->
             <path d="M 0 50 Q 0 30 24 26 L 95 18 L 140 32 L 185 18 L 256 26 Q 280 30 280 50 L 280 110 L 0 110 Z" fill="#4a5e3a"/>
-            <!-- 후드티 어깨 음영 -->
             <path d="M 0 50 Q 0 30 24 26 L 95 18 L 85 34 L 28 44 Q 10 48 0 58 Z" fill="#3d4f30"/>
             <path d="M 280 50 Q 280 30 256 26 L 185 18 L 195 34 L 252 44 Q 270 48 280 58 Z" fill="#3d4f30"/>
-            <!-- 후드티 중앙 포켓 라인 -->
             <path d="M 105 75 Q 140 70 175 75 L 175 110 L 105 110 Z" fill="#3d4f30" opacity="0.5"/>
-            <!-- 후드티 지퍼 라인 -->
             <line x1="140" y1="46" x2="140" y2="110" stroke="#3d4f30" stroke-width="2"/>
-            <!-- 지퍼 슬라이더 -->
             <rect x="134" y="46" width="12" height="7" rx="2" fill="#6b7280"/>
-            <!-- 목 -->
             <rect x="116" y="0" width="48" height="40" rx="8" fill="#d4956a"/>
-            <!-- 후드 넥라인 왼쪽 -->
             <path d="M 140 34 L 100 20 L 92 34 L 130 46 Z" fill="#4a5e3a"/>
-            <!-- 후드 넥라인 오른쪽 -->
             <path d="M 140 34 L 180 20 L 188 34 L 150 46 Z" fill="#4a5e3a"/>
-            <!-- 넥라인 안쪽 (목 피부색) -->
             <path d="M 130 46 L 140 56 L 150 46 L 140 34 Z" fill="#c07a50"/>
-            <!-- 후드 끈 왼쪽 -->
             <line x1="128" y1="46" x2="120" y2="72" stroke="#3d4f30" stroke-width="2.5" stroke-linecap="round"/>
-            <!-- 후드 끈 오른쪽 -->
             <line x1="152" y1="46" x2="160" y2="72" stroke="#3d4f30" stroke-width="2.5" stroke-linecap="round"/>
-            <!-- 끈 끝 고리 왼쪽 -->
             <circle cx="120" cy="73" r="3" fill="#2d3a22"/>
-            <!-- 끈 끝 고리 오른쪽 -->
             <circle cx="160" cy="73" r="3" fill="#2d3a22"/>
           </svg>
         </div>
-
       </div>
-
       <div id="friendly-status" class="mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5"
         style="background:rgba(59,130,246,0.1); border-color:rgba(59,130,246,0.2); color:#93c5fd;">
         <span class="w-2 h-2 rounded-full" style="background:#475569;"></span>
         <span class="status-text">AI 면접관 대기 중</span>
       </div>
     `;
-
-    container.appendChild(wrapper);
-    this.avatarWrapper = wrapper.querySelector("#friendly-body-wrapper");
-    this.mouthElement = wrapper.querySelector("#friendly-mouth");
-    this.startBlinking();
+    return wrapper;
   }
 
   private startBlinking() {
@@ -197,7 +152,10 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
       setTimeout(() => {
         if (!this.isDestroyed) eyes.forEach((e) => (e.style.transform = "scaleY(1)"));
       }, 120);
-      this.blinkTimeoutId = window.setTimeout(blink, Math.random() * 3000 + 1500);
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      const delay = (buf[0] / 0xFFFFFFFF) * 3000 + 1500;
+      this.blinkTimeoutId = window.setTimeout(blink, delay);
     };
     blink();
   }

--- a/src/shared/lib/avatar/FriendlyAvatarProvider.ts
+++ b/src/shared/lib/avatar/FriendlyAvatarProvider.ts
@@ -54,18 +54,28 @@ export class FriendlyAvatarProvider implements IAvatarProvider {
     const wrapper = document.createElement("div");
     wrapper.className = "w-full h-full flex flex-col items-center justify-center relative overflow-hidden";
     wrapper.style.background = "#080f1a";
-    wrapper.innerHTML = `
-      <div id="friendly-body-wrapper" class="friendly-container relative w-56 h-56 shrink-0">
-        ${this.buildHairHTML()}
-        ${this.buildFaceHTML()}
-        ${this.buildBodyHTML()}
-      </div>
-      <div id="friendly-status" class="mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5"
-        style="background:rgba(59,130,246,0.1); border-color:rgba(59,130,246,0.2); color:#93c5fd;">
-        <span class="w-2 h-2 rounded-full" style="background:#475569;"></span>
-        <span class="status-text">AI 면접관 대기 중</span>
-      </div>
-    `;
+
+    const bodyWrapper = document.createElement("div");
+    bodyWrapper.id = "friendly-body-wrapper";
+    bodyWrapper.className = "friendly-container relative w-56 h-56 shrink-0";
+    bodyWrapper.innerHTML = this.buildHairHTML() + this.buildFaceHTML() + this.buildBodyHTML();
+
+    const status = document.createElement("div");
+    status.id = "friendly-status";
+    status.className = "mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5";
+    status.setAttribute("style", "background:rgba(59,130,246,0.1); border-color:rgba(59,130,246,0.2); color:#93c5fd;");
+
+    const dot = document.createElement("span");
+    dot.className = "w-2 h-2 rounded-full";
+    dot.setAttribute("style", "background:#475569;");
+
+    const statusText = document.createElement("span");
+    statusText.className = "status-text";
+    statusText.textContent = "AI 면접관 대기 중";
+
+    status.append(dot, statusText);
+    wrapper.append(bodyWrapper, status);
+
     return wrapper;
   }
 

--- a/src/shared/lib/avatar/FriendlyAvatarProvider.ts
+++ b/src/shared/lib/avatar/FriendlyAvatarProvider.ts
@@ -1,0 +1,291 @@
+import type { IAvatarProvider } from "./IAvatarProvider";
+
+export class FriendlyAvatarProvider implements IAvatarProvider {
+  private container: HTMLElement | null = null;
+  private audio: HTMLAudioElement | null = null;
+  private audioCtx: AudioContext | null = null;
+  private analyser: AnalyserNode | null = null;
+  private source: MediaElementAudioSourceNode | null = null;
+  private animationFrameId: number | null = null;
+  private mouthElement: HTMLElement | null = null;
+  private avatarWrapper: HTMLElement | null = null;
+  private isDestroyed = false;
+  private blinkTimeoutId: number | null = null;
+
+  async initialize(container: HTMLElement): Promise<void> {
+    this.container = container;
+    const styleId = "friendly-avatar-style";
+    if (!document.getElementById(styleId)) {
+      const styleEl = document.createElement("style");
+      styleEl.id = styleId;
+      styleEl.innerHTML = `
+        @keyframes friendlyFloat {
+          0%, 100% { transform: translateY(0px) rotate(-0.5deg); }
+          30% { transform: translateY(-12px) rotate(1deg); }
+          60% { transform: translateY(-6px) rotate(-0.5deg); }
+        }
+        @keyframes friendlyNod {
+          0%, 100% { transform: rotate(0deg); }
+          25% { transform: rotate(3deg); }
+          75% { transform: rotate(-2deg); }
+        }
+        .friendly-face {
+          background: linear-gradient(160deg, #e8b89a 0%, #d4956a 60%, #c07a50 100%);
+          box-shadow: inset -8px -12px 20px rgba(160,80,30,0.25), inset 4px 4px 12px rgba(255,220,190,0.3), 0 20px 50px rgba(0,0,0,0.35);
+        }
+        .friendly-eye { transition: transform 0.12s cubic-bezier(0.4,0,0.2,1); transform-origin: center; }
+        .friendly-container { animation: friendlyFloat 5s ease-in-out infinite; }
+        .friendly-speaking { animation: friendlyFloat 5s ease-in-out infinite, friendlyNod 1.2s ease-in-out infinite; }
+        .friendly-glow { box-shadow: inset -8px -12px 20px rgba(160,80,30,0.25), inset 4px 4px 12px rgba(255,220,190,0.3), 0 0 50px rgba(251,191,36,0.35) !important; }
+      `;
+      document.head.appendChild(styleEl);
+    }
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "w-full h-full flex flex-col items-center justify-center relative overflow-hidden";
+    wrapper.style.background = "#080f1a";
+    wrapper.innerHTML = `
+      <div id="friendly-body-wrapper" class="friendly-container relative w-56 h-56 shrink-0">
+
+        <!-- 뒷머리 배경 -->
+        <div class="absolute -top-8 -left-4 -z-10"
+          style="width:256px; height:144px; background:linear-gradient(180deg,#7B5236 0%,#5a3a20 100%); border-radius:100px 100px 30px 30px;"></div>
+
+        <!-- 귀 왼쪽 -->
+        <div class="absolute -z-10"
+          style="width:18px; height:26px; background:linear-gradient(160deg,#e8b89a,#c07a50); border-radius:50%; top:38%; left:-6px; box-shadow:inset 3px 0 6px rgba(160,80,30,0.3);">
+          <div style="position:absolute; top:25%; left:20%; width:8px; height:14px; background:rgba(160,80,30,0.2); border-radius:50%;"></div>
+        </div>
+        <!-- 귀 오른쪽 -->
+        <div class="absolute -z-10"
+          style="width:18px; height:26px; background:linear-gradient(160deg,#e8b89a,#c07a50); border-radius:50%; top:38%; right:-6px; box-shadow:inset -3px 0 6px rgba(160,80,30,0.3);">
+          <div style="position:absolute; top:25%; right:20%; width:8px; height:14px; background:rgba(160,80,30,0.2); border-radius:50%;"></div>
+        </div>
+
+        <div id="friendly-face" class="friendly-face w-full h-full rounded-[42%] flex flex-col items-center relative overflow-hidden transition-all duration-300">
+          <!-- 볼터치 -->
+          <div class="absolute top-[42%] left-[8%] w-12 h-7 rounded-full blur-lg opacity-50" style="background:#e07050;"></div>
+          <div class="absolute top-[42%] right-[8%] w-12 h-7 rounded-full blur-lg opacity-50" style="background:#e07050;"></div>
+
+          <!-- 눈썹: 자연스러운 아치형 SVG, 머리카락 색과 동일 -->
+          <div class="absolute top-[24%] w-full flex justify-between px-10">
+            <svg width="32" height="12" viewBox="0 0 32 12">
+              <path d="M 2 10 Q 8 1 30 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+            </svg>
+            <svg width="32" height="12" viewBox="0 0 32 12">
+              <path d="M 30 10 Q 24 1 2 4" stroke="#5a3a20" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+
+          <!-- 눈 -->
+          <div class="absolute top-[33%] w-full flex justify-between px-10">
+            <div class="friendly-eye w-9 h-10 bg-white rounded-full relative overflow-hidden shadow-md">
+              <div class="absolute bottom-1 right-1 w-6 h-7 rounded-full" style="background:#3d2010;">
+                <div class="absolute top-1 right-1 w-2 h-2 bg-white rounded-full opacity-90"></div>
+                <div class="absolute bottom-1 left-0.5 w-1 h-1 bg-white rounded-full opacity-50"></div>
+              </div>
+            </div>
+            <div class="friendly-eye w-9 h-10 bg-white rounded-full relative overflow-hidden shadow-md">
+              <div class="absolute bottom-1 left-1 w-6 h-7 rounded-full" style="background:#3d2010;">
+                <div class="absolute top-1 left-1 w-2 h-2 bg-white rounded-full opacity-90"></div>
+                <div class="absolute bottom-1 right-0.5 w-1 h-1 bg-white rounded-full opacity-50"></div>
+              </div>
+            </div>
+          </div>
+
+          <!-- 코 -->
+          <div class="absolute top-[54%] left-1/2 -translate-x-1/2"
+            style="width:0; height:0; border-left:5px solid transparent; border-right:5px solid transparent; border-top:7px solid rgba(160,80,40,0.25);"></div>
+
+          <!-- 입 -->
+          <div class="absolute top-[65%] w-full flex justify-center">
+            <div id="friendly-mouth" class="relative overflow-hidden transition-all duration-75"
+              style="width:38px; height:10px; border-radius:0 0 20px 20px; background:#7a2020;">
+              <div class="absolute top-0 w-full h-[25%]" style="background:rgba(255,255,255,0.85);"></div>
+              <div class="absolute bottom-0 w-full h-[40%] rounded-full" style="background:#c06060; transform:translateY(40%);"></div>
+            </div>
+          </div>
+
+          <!-- 얼굴 위 머리카락 마스크 -->
+          <svg class="absolute top-0 left-0 w-full h-20" viewBox="0 0 100 40" preserveAspectRatio="none">
+            <path d="M 0 0 L 100 0 L 100 15 Q 75 35 50 20 Q 25 35 0 15 Z" fill="#7B5236"/>
+          </svg>
+        </div>
+
+        <!-- 앞머리 SVG: 웨이브 -->
+        <div class="absolute pointer-events-none" style="top:-32px; left:-16px; width:256px; height:144px; z-index:1;">
+          <svg width="256" height="144" viewBox="0 0 256 144" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <linearGradient id="f-fg-hair-grad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stop-color="#7B5236"/>
+                <stop offset="100%" stop-color="#5a3a20"/>
+              </linearGradient>
+              <clipPath id="f-hair-shape-clip">
+                <path d="M 100 0 L 156 0 Q 256 0 256 100 L 256 114 Q 256 144 226 144 L 30 144 Q 0 144 0 114 L 0 100 Q 0 0 100 0 Z"/>
+              </clipPath>
+            </defs>
+            <g clip-path="url(#f-hair-shape-clip)">
+              <path d="
+                M 0 0 L 256 0 L 256 108
+                Q 240 98 224 106
+                Q 208 114 192 104
+                Q 176 94 160 103
+                Q 144 112 128 72
+                Q 112 112 96 103
+                Q 80 94 64 104
+                Q 48 114 32 106
+                Q 16 98 0 108
+                Z
+              " fill="url(#f-fg-hair-grad)"/>
+            </g>
+          </svg>
+        </div>
+
+        <!-- 목 + 후드티 SVG 통합 -->
+        <div class="absolute pointer-events-none" style="bottom:-100px; left:50%; transform:translateX(-50%); width:280px; height:110px; z-index:-1;">
+          <svg width="280" height="110" viewBox="0 0 280 110" xmlns="http://www.w3.org/2000/svg">
+            <!-- 후드티 몸통 (따뜻한 올리브 그린) -->
+            <path d="M 0 50 Q 0 30 24 26 L 95 18 L 140 32 L 185 18 L 256 26 Q 280 30 280 50 L 280 110 L 0 110 Z" fill="#4a5e3a"/>
+            <!-- 후드티 어깨 음영 -->
+            <path d="M 0 50 Q 0 30 24 26 L 95 18 L 85 34 L 28 44 Q 10 48 0 58 Z" fill="#3d4f30"/>
+            <path d="M 280 50 Q 280 30 256 26 L 185 18 L 195 34 L 252 44 Q 270 48 280 58 Z" fill="#3d4f30"/>
+            <!-- 후드티 중앙 포켓 라인 -->
+            <path d="M 105 75 Q 140 70 175 75 L 175 110 L 105 110 Z" fill="#3d4f30" opacity="0.5"/>
+            <!-- 후드티 지퍼 라인 -->
+            <line x1="140" y1="46" x2="140" y2="110" stroke="#3d4f30" stroke-width="2"/>
+            <!-- 지퍼 슬라이더 -->
+            <rect x="134" y="46" width="12" height="7" rx="2" fill="#6b7280"/>
+            <!-- 목 -->
+            <rect x="116" y="0" width="48" height="40" rx="8" fill="#d4956a"/>
+            <!-- 후드 넥라인 왼쪽 -->
+            <path d="M 140 34 L 100 20 L 92 34 L 130 46 Z" fill="#4a5e3a"/>
+            <!-- 후드 넥라인 오른쪽 -->
+            <path d="M 140 34 L 180 20 L 188 34 L 150 46 Z" fill="#4a5e3a"/>
+            <!-- 넥라인 안쪽 (목 피부색) -->
+            <path d="M 130 46 L 140 56 L 150 46 L 140 34 Z" fill="#c07a50"/>
+            <!-- 후드 끈 왼쪽 -->
+            <line x1="128" y1="46" x2="120" y2="72" stroke="#3d4f30" stroke-width="2.5" stroke-linecap="round"/>
+            <!-- 후드 끈 오른쪽 -->
+            <line x1="152" y1="46" x2="160" y2="72" stroke="#3d4f30" stroke-width="2.5" stroke-linecap="round"/>
+            <!-- 끈 끝 고리 왼쪽 -->
+            <circle cx="120" cy="73" r="3" fill="#2d3a22"/>
+            <!-- 끈 끝 고리 오른쪽 -->
+            <circle cx="160" cy="73" r="3" fill="#2d3a22"/>
+          </svg>
+        </div>
+
+      </div>
+
+      <div id="friendly-status" class="mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5"
+        style="background:rgba(59,130,246,0.1); border-color:rgba(59,130,246,0.2); color:#93c5fd;">
+        <span class="w-2 h-2 rounded-full" style="background:#475569;"></span>
+        <span class="status-text">AI 면접관 대기 중</span>
+      </div>
+    `;
+
+    container.appendChild(wrapper);
+    this.avatarWrapper = wrapper.querySelector("#friendly-body-wrapper");
+    this.mouthElement = wrapper.querySelector("#friendly-mouth");
+    this.startBlinking();
+  }
+
+  private startBlinking() {
+    const blink = () => {
+      if (this.isDestroyed || !this.container) return;
+      const eyes = this.container.querySelectorAll(".friendly-eye") as NodeListOf<HTMLElement>;
+      eyes.forEach((e) => (e.style.transform = "scaleY(0.08)"));
+      setTimeout(() => {
+        if (!this.isDestroyed) eyes.forEach((e) => (e.style.transform = "scaleY(1)"));
+      }, 120);
+      this.blinkTimeoutId = window.setTimeout(blink, Math.random() * 3000 + 1500);
+    };
+    blink();
+  }
+
+  async speak(audioUrlOrBase64: string, text: string): Promise<void> {
+    void text;
+    this.stopAudio();
+    this.setStatus("speaking");
+    if (this.avatarWrapper) {
+      this.avatarWrapper.className = "friendly-speaking relative w-56 h-56 shrink-0";
+    }
+    this.container?.querySelector("#friendly-face")?.classList.add("friendly-glow");
+    return new Promise((resolve) => {
+      this.audio = new Audio(audioUrlOrBase64);
+      this.audio.crossOrigin = "anonymous";
+      const AudioCtxClass = window.AudioContext || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext!;
+      if (!this.audioCtx) {
+        this.audioCtx = new AudioCtxClass();
+        this.analyser = this.audioCtx.createAnalyser();
+        this.analyser.fftSize = 256;
+      }
+      if (this.audioCtx.state === "suspended") this.audioCtx.resume();
+      if (this.source) this.source.disconnect();
+      this.source = this.audioCtx.createMediaElementSource(this.audio);
+      this.source.connect(this.analyser!);
+      this.analyser!.connect(this.audioCtx.destination);
+      const dataArray = new Uint8Array(this.analyser!.frequencyBinCount);
+      const renderFrame = () => {
+        if (!this.analyser || !this.mouthElement || !this.audio || this.audio.paused) return;
+        this.analyser.getByteFrequencyData(dataArray);
+        const avg = dataArray.reduce((a, b) => a + b, 0) / dataArray.length;
+        if (avg > 5) {
+          const h = Math.min(44, 10 + (avg / 255) * 46);
+          const w = Math.max(28, 38 - (avg / 255) * 8);
+          const r = Math.min(20, 12 + (avg / 255) * 16);
+          this.mouthElement.style.height = `${h}px`;
+          this.mouthElement.style.width = `${w}px`;
+          this.mouthElement.style.borderRadius = `${r}px`;
+        } else { this.resetMouth(); }
+        this.animationFrameId = requestAnimationFrame(renderFrame);
+      };
+      this.audio.onplay = renderFrame;
+      this.audio.onended = () => { this.stopAudio(); resolve(); };
+      this.audio.onerror = () => { this.stopAudio(); resolve(); };
+      this.audio.play().catch(() => { this.stopAudio(); resolve(); });
+    });
+  }
+
+  private resetMouth() {
+    if (!this.mouthElement) return;
+    this.mouthElement.style.height = "10px";
+    this.mouthElement.style.width = "38px";
+    this.mouthElement.style.borderRadius = "0 0 20px 20px";
+  }
+
+  private setStatus(state: "speaking" | "idle") {
+    const dot = this.container?.querySelector("#friendly-status span") as HTMLElement | null;
+    const text = this.container?.querySelector(".status-text");
+    if (state === "speaking") {
+      dot?.setAttribute("style", "width:8px; height:8px; border-radius:50%; background:#4ade80; animation: pulse 1s infinite;");
+      if (text) text.textContent = "질문 중...";
+    } else {
+      dot?.setAttribute("style", "width:8px; height:8px; border-radius:50%; background:#475569;");
+      if (text) text.textContent = "AI 면접관 대기 중";
+    }
+  }
+
+  private stopAudio() {
+    if (this.animationFrameId) { cancelAnimationFrame(this.animationFrameId); this.animationFrameId = null; }
+    if (this.audio) { this.audio.pause(); this.audio.currentTime = 0; this.audio = null; }
+    this.resetMouth();
+    if (this.avatarWrapper) {
+      this.avatarWrapper.className = "friendly-container relative w-56 h-56 shrink-0";
+    }
+    this.container?.querySelector("#friendly-face")?.classList.remove("friendly-glow");
+    this.setStatus("idle");
+  }
+
+  stop(): void { this.stopAudio(); }
+
+  destroy(): void {
+    this.isDestroyed = true;
+    this.stopAudio();
+    if (this.blinkTimeoutId) clearTimeout(this.blinkTimeoutId);
+    if (this.source) this.source.disconnect();
+    if (this.audioCtx && this.audioCtx.state !== "closed") this.audioCtx.close();
+    if (this.container) this.container.innerHTML = "";
+    this.mouthElement = null;
+    this.avatarWrapper = null;
+  }
+}

--- a/src/shared/lib/avatar/PressureAvatarProvider.ts
+++ b/src/shared/lib/avatar/PressureAvatarProvider.ts
@@ -69,7 +69,7 @@ export class PressureAvatarProvider implements IAvatarProvider {
     const bodyWrapper = document.createElement("div");
     bodyWrapper.id = "pressure-body-wrapper";
     bodyWrapper.className = "pressure-container relative w-56 h-56 shrink-0";
-    bodyWrapper.innerHTML = this.buildHairHTML() + this.buildFaceHTML() + this.buildBodyHTML();
+    bodyWrapper.appendChild(this.parseStaticHTML(this.buildHairHTML() + this.buildFaceHTML() + this.buildBodyHTML()));
 
     const status = document.createElement("div");
     status.id = "pressure-status";
@@ -190,6 +190,16 @@ export class PressureAvatarProvider implements IAvatarProvider {
     `;
   }
  
+  private parseStaticHTML(html: string): DocumentFragment {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+    const fragment = document.createDocumentFragment();
+    Array.from(doc.body.childNodes).forEach((node) =>
+      fragment.appendChild(document.adoptNode(node))
+    );
+    return fragment;
+  }
+
   private startBlinking() {
     const blink = () => {
       if (this.isDestroyed || !this.container) return;

--- a/src/shared/lib/avatar/PressureAvatarProvider.ts
+++ b/src/shared/lib/avatar/PressureAvatarProvider.ts
@@ -65,17 +65,28 @@ export class PressureAvatarProvider implements IAvatarProvider {
     const wrapper = document.createElement("div");
     wrapper.className = "w-full h-full flex flex-col items-center justify-center relative overflow-hidden";
     wrapper.style.background = "#080f1a";
-    wrapper.innerHTML = `
-    <div id="pressure-body-wrapper" class="pressure-container relative w-56 h-56 shrink-0">
-      ${this.buildHairHTML()}
-      ${this.buildFaceHTML()}
-      ${this.buildBodyHTML()}
-    </div>
-    <div id="pressure-status" class="mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5"
-      style="background:rgba(239,68,68,0.08); border-color:rgba(239,68,68,0.2); color:#fca5a5;">
-      <span class="w-2 h-2 rounded-full" style="background:#475569;"></span>
-      <span class="status-text">AI 면접관 대기 중</span>
-    </div>`;
+
+    const bodyWrapper = document.createElement("div");
+    bodyWrapper.id = "pressure-body-wrapper";
+    bodyWrapper.className = "pressure-container relative w-56 h-56 shrink-0";
+    bodyWrapper.innerHTML = this.buildHairHTML() + this.buildFaceHTML() + this.buildBodyHTML();
+
+    const status = document.createElement("div");
+    status.id = "pressure-status";
+    status.className = "mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5";
+    status.setAttribute("style", "background:rgba(239,68,68,0.08); border-color:rgba(239,68,68,0.2); color:#fca5a5;");
+
+    const dot = document.createElement("span");
+    dot.className = "w-2 h-2 rounded-full";
+    dot.setAttribute("style", "background:#475569;");
+
+    const statusText = document.createElement("span");
+    statusText.className = "status-text";
+    statusText.textContent = "AI 면접관 대기 중";
+
+    status.append(dot, statusText);
+    wrapper.append(bodyWrapper, status);
+
     return wrapper;
   }
 

--- a/src/shared/lib/avatar/PressureAvatarProvider.ts
+++ b/src/shared/lib/avatar/PressureAvatarProvider.ts
@@ -67,40 +67,58 @@ export class PressureAvatarProvider implements IAvatarProvider {
     wrapper.style.background = "#080f1a";
     wrapper.innerHTML = `
     <div id="pressure-body-wrapper" class="pressure-container relative w-56 h-56 shrink-0">
- 
-      <!-- 뒷머리 배경 -->
+      ${this.buildHairHTML()}
+      ${this.buildFaceHTML()}
+      ${this.buildBodyHTML()}
+    </div>
+    <div id="pressure-status" class="mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5"
+      style="background:rgba(239,68,68,0.08); border-color:rgba(239,68,68,0.2); color:#fca5a5;">
+      <span class="w-2 h-2 rounded-full" style="background:#475569;"></span>
+      <span class="status-text">AI 면접관 대기 중</span>
+    </div>`;
+    return wrapper;
+  }
+
+  private buildHairHTML(): string {
+    return `
       <div class="absolute -z-10"
         style="width:260px; height:200px; top:-32px; left:-16px; background:linear-gradient(180deg,#2a2a2a 0%,#1a1a1a 100%); border-radius:50%;"></div>
       <div class="absolute -top-6 left-1/2 -z-10"
         style="width:4px; height:40px; background:#0a0a0a; transform:translateX(-50%);"></div>
- 
-      <!-- 귀 왼쪽 -->
       <div class="absolute -z-10"
         style="width:18px; height:26px; background:linear-gradient(160deg,#c07a50,#9a6035); border-radius:50%; top:38%; left:-6px; box-shadow:inset 3px 0 6px rgba(100,40,10,0.4);">
         <div style="position:absolute; top:25%; left:20%; width:8px; height:14px; background:rgba(100,40,10,0.2); border-radius:50%;"></div>
       </div>
-      <!-- 귀 오른쪽 -->
       <div class="absolute -z-10"
         style="width:18px; height:26px; background:linear-gradient(160deg,#c07a50,#9a6035); border-radius:50%; top:38%; right:-6px; box-shadow:inset -3px 0 6px rgba(100,40,10,0.4);">
         <div style="position:absolute; top:25%; right:20%; width:8px; height:14px; background:rgba(100,40,10,0.2); border-radius:50%;"></div>
       </div>
- 
+      <div class="absolute pointer-events-none" style="top:-32px; left:-16px; width:260px; height:120px; z-index:1;">
+        <svg width="260" height="120" viewBox="0 0 260 120" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="pr-fg-hair-grad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#2a2a2a"/>
+              <stop offset="100%" stop-color="#1a1a1a"/>
+            </linearGradient>
+          </defs>
+          <path d="M 130 8 C 85 8, 28 22, 12 58 C 4 78, 4 98, 4 108 C 62 102, 98 90, 130 56 C 162 90, 198 102, 256 108 C 256 98, 256 78, 248 58 C 232 22, 175 8, 130 8 Z" fill="url(#pr-fg-hair-grad)"/>
+        </svg>
+      </div>
+    `;
+  }
+
+  private buildFaceHTML(): string {
+    return `
       <div id="pressure-face" class="pressure-face w-full h-full flex flex-col items-center relative overflow-hidden transition-all duration-300"
         style="border-radius:40% 40% 45% 45%;">
- 
-        <!-- 눈썹: 원래 직사각형 -->
         <div class="absolute top-[25%] w-full flex justify-between px-9">
           <div class="pressure-eyebrow-l w-11 h-3 rounded-sm" style="background:#111; transform:rotate(-12deg); transform-origin:right center;"></div>
           <div class="pressure-eyebrow-r w-11 h-3 rounded-sm" style="background:#111; transform:rotate(12deg); transform-origin:left center;"></div>
         </div>
- 
-        <!-- 미간 주름 -->
         <div class="absolute top-[28%] left-1/2 -translate-x-1/2 flex gap-1.5">
           <div class="w-0.5 h-4 rounded-full opacity-40" style="background:#7a4520; transform:rotate(-8deg);"></div>
           <div class="w-0.5 h-4 rounded-full opacity-40" style="background:#7a4520; transform:rotate(8deg);"></div>
         </div>
- 
-        <!-- 눈 -->
         <div class="absolute top-[34%] w-full flex justify-between px-10">
           <div class="pressure-eye bg-white relative overflow-hidden shadow-inner"
             style="width:32px; height:28px; border-radius:40% 40% 50% 50%;">
@@ -117,19 +135,13 @@ export class PressureAvatarProvider implements IAvatarProvider {
             <div class="absolute top-0 w-full h-[30%] opacity-30" style="background:#333;"></div>
           </div>
         </div>
- 
-        <!-- 안경 -->
         <div class="absolute top-[30%] w-full flex justify-between px-7 pointer-events-none opacity-80">
           <div class="w-16 h-12 border-2 border-slate-300/70 rounded-sm"></div>
           <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-6 h-0.5 bg-slate-300/70"></div>
           <div class="w-16 h-12 border-2 border-slate-300/70 rounded-sm"></div>
         </div>
- 
-        <!-- 코 -->
         <div class="absolute top-[53%] left-1/2 -translate-x-1/2"
           style="width:0; height:0; border-left:5px solid transparent; border-right:5px solid transparent; border-top:7px solid rgba(120,60,20,0.3);"></div>
- 
-        <!-- 입 -->
         <div class="absolute top-[65%] w-full flex justify-center">
           <div id="pressure-mouth" class="relative overflow-hidden transition-all duration-75"
             style="width:32px; height:6px; border-radius:3px; background:#5a1515;">
@@ -137,75 +149,34 @@ export class PressureAvatarProvider implements IAvatarProvider {
             <div class="absolute bottom-0 w-full h-[35%] rounded-full" style="background:#8b3030; transform:translateY(40%);"></div>
           </div>
         </div>
- 
-        <!-- 얼굴 위 머리카락 마스크 -->
         <svg class="absolute top-0 left-0 w-full h-16" viewBox="0 0 100 35" preserveAspectRatio="none">
           <path d="M 0 0 L 100 0 L 100 10 Q 55 20 50 14 Q 45 20 0 10 Z" fill="#080f1a"/>
         </svg>
       </div>
- 
-      <!-- 앞머리 SVG -->
-      <div class="absolute pointer-events-none" style="top:-32px; left:-16px; width:260px; height:120px; z-index:1;">
-        <svg width="260" height="120" viewBox="0 0 260 120" xmlns="http://www.w3.org/2000/svg">
-          <defs>
-            <linearGradient id="pr-fg-hair-grad" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stop-color="#2a2a2a"/>
-              <stop offset="100%" stop-color="#1a1a1a"/>
-            </linearGradient>
-          </defs>
-          <path d="
-            M 130 8
-            C 85 8, 28 22, 12 58
-            C 4 78, 4 98, 4 108
-            C 62 102, 98 90, 130 56
-            C 162 90, 198 102, 256 108
-            C 256 98, 256 78, 248 58
-            C 232 22, 175 8, 130 8
-            Z
-          " fill="url(#pr-fg-hair-grad)"/>
-        </svg>
-      </div>
- 
-      <!-- 목 + 정장 SVG 통합 -->
+    `;
+  }
+
+  private buildBodyHTML(): string {
+    return `
       <div class="absolute pointer-events-none" style="bottom:-100px; left:50%; transform:translateX(-50%); width:280px; height:110px; z-index:-1;">
         <svg width="280" height="110" viewBox="0 0 280 110" xmlns="http://www.w3.org/2000/svg">
-          <!-- 정장 재킷 몸통 (짙은 남색) -->
           <path d="M 0 45 Q 0 28 22 24 L 90 16 L 140 30 L 190 16 L 258 24 Q 280 28 280 45 L 280 110 L 0 110 Z" fill="#1e293b"/>
-          <!-- 재킷 왼쪽 라펠 -->
           <path d="M 140 30 L 90 16 L 78 36 L 125 52 Z" fill="#263548"/>
-          <!-- 재킷 오른쪽 라펠 -->
           <path d="M 140 30 L 190 16 L 202 36 L 155 52 Z" fill="#263548"/>
-          <!-- 조끼 (더 밝은 남색) -->
           <path d="M 125 52 L 140 38 L 155 52 L 162 110 L 118 110 Z" fill="#334155"/>
-          <!-- 와이셔츠 (흰색, 라펠 사이) -->
           <path d="M 125 52 L 140 68 L 155 52 L 140 38 Z" fill="#f1f5f9"/>
-          <!-- 넥타이 -->
           <path d="M 136 42 L 144 42 L 146 60 L 140 72 L 134 60 Z" fill="#7f1d1d"/>
           <path d="M 137 42 L 143 42 L 140 50 Z" fill="#991b1b"/>
-          <!-- 목 -->
           <rect x="118" y="0" width="44" height="38" rx="6" fill="#b87a4a"/>
-          <!-- 셔츠 칼라 왼쪽 -->
           <path d="M 140 36 L 108 22 L 102 34 L 132 46 Z" fill="#f1f5f9"/>
-          <!-- 셔츠 칼라 오른쪽 -->
           <path d="M 140 36 L 172 22 L 178 34 L 148 46 Z" fill="#f1f5f9"/>
-          <!-- 재킷 단추 -->
           <circle cx="140" cy="72" r="3.5" fill="#0f172a"/>
           <circle cx="140" cy="88" r="3.5" fill="#0f172a"/>
-          <!-- 재킷 왼쪽 어깨 하이라이트 -->
           <path d="M 0 45 Q 0 28 22 24 L 90 16 L 78 36 L 30 42 Q 10 44 0 55 Z" fill="#253044"/>
-          <!-- 재킷 오른쪽 어깨 하이라이트 -->
           <path d="M 280 45 Q 280 28 258 24 L 190 16 L 202 36 L 250 42 Q 270 44 280 55 Z" fill="#253044"/>
         </svg>
       </div>
-    </div>
- 
-    <div id="pressure-status" class="mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5"
-      style="background:rgba(239,68,68,0.08); border-color:rgba(239,68,68,0.2); color:#fca5a5;">
-      <span class="w-2 h-2 rounded-full" style="background:#475569;"></span>
-      <span class="status-text">AI 면접관 대기 중</span>
-    </div>`;
- 
-    return wrapper;
+    `;
   }
  
   private startBlinking() {

--- a/src/shared/lib/avatar/PressureAvatarProvider.ts
+++ b/src/shared/lib/avatar/PressureAvatarProvider.ts
@@ -14,6 +14,15 @@ export class PressureAvatarProvider implements IAvatarProvider {
  
   async initialize(container: HTMLElement): Promise<void> {
     this.container = container;
+    this.injectStyles();
+    const wrapper = this.buildHTML();
+    container.appendChild(wrapper);
+    this.avatarWrapper = wrapper.querySelector("#pressure-body-wrapper");
+    this.mouthElement = wrapper.querySelector("#pressure-mouth");
+    this.startBlinking();
+  }
+
+  private injectStyles(): void {
     const styleId = "pressure-avatar-style";
     if (!document.getElementById(styleId)) {
       const styleEl = document.createElement("style");
@@ -50,6 +59,9 @@ export class PressureAvatarProvider implements IAvatarProvider {
       document.head.appendChild(styleEl);
     }
  
+  }
+
+  private buildHTML(): HTMLElement {
     const wrapper = document.createElement("div");
     wrapper.className = "w-full h-full flex flex-col items-center justify-center relative overflow-hidden";
     wrapper.style.background = "#080f1a";
@@ -193,10 +205,7 @@ export class PressureAvatarProvider implements IAvatarProvider {
       <span class="status-text">AI 면접관 대기 중</span>
     </div>`;
  
-    container.appendChild(wrapper);
-    this.avatarWrapper = wrapper.querySelector("#pressure-body-wrapper");
-    this.mouthElement = wrapper.querySelector("#pressure-mouth");
-    this.startBlinking();
+    return wrapper;
   }
  
   private startBlinking() {
@@ -207,7 +216,10 @@ export class PressureAvatarProvider implements IAvatarProvider {
       setTimeout(() => {
         if (!this.isDestroyed) eyes.forEach((e) => (e.style.transform = "scaleY(1)"));
       }, 100);
-      this.blinkTimeoutId = window.setTimeout(blink, Math.random() * 6000 + 3000);
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      const delay = (buf[0] / 0xFFFFFFFF) * 6000 + 3000;
+      this.blinkTimeoutId = window.setTimeout(blink, delay);
     };
     blink();
   }

--- a/src/shared/lib/avatar/PressureAvatarProvider.ts
+++ b/src/shared/lib/avatar/PressureAvatarProvider.ts
@@ -1,0 +1,301 @@
+import type { IAvatarProvider } from "./IAvatarProvider";
+ 
+export class PressureAvatarProvider implements IAvatarProvider {
+  private container: HTMLElement | null = null;
+  private audio: HTMLAudioElement | null = null;
+  private audioCtx: AudioContext | null = null;
+  private analyser: AnalyserNode | null = null;
+  private source: MediaElementAudioSourceNode | null = null;
+  private animationFrameId: number | null = null;
+  private mouthElement: HTMLElement | null = null;
+  private avatarWrapper: HTMLElement | null = null;
+  private isDestroyed = false;
+  private blinkTimeoutId: number | null = null;
+ 
+  async initialize(container: HTMLElement): Promise<void> {
+    this.container = container;
+    const styleId = "pressure-avatar-style";
+    if (!document.getElementById(styleId)) {
+      const styleEl = document.createElement("style");
+      styleEl.id = styleId;
+      styleEl.innerHTML = `
+        @keyframes pressureFloat {
+          0%, 100% { transform: translateY(0px) rotate(0deg); }
+          50% { transform: translateY(-4px) rotate(0.3deg); }
+        }
+        @keyframes pressureLean {
+          0%, 100% { transform: translateY(0px) rotate(0deg); }
+          40% { transform: translateY(-3px) rotate(-1deg) scale(1.01); }
+          60% { transform: translateY(-2px) rotate(0.5deg); }
+        }
+        @keyframes eyebrowTwitch {
+          0%, 90%, 100% { transform: rotate(-12deg) translateY(0px); }
+          95% { transform: rotate(-14deg) translateY(-1px); }
+        }
+        @keyframes eyebrowTwitchR {
+          0%, 90%, 100% { transform: rotate(12deg) translateY(0px); }
+          95% { transform: rotate(14deg) translateY(-1px); }
+        }
+        .pressure-face {
+          background: linear-gradient(160deg, #d4956a 0%, #b87a4a 60%, #9a6035 100%);
+          box-shadow: inset -14px -14px 28px rgba(100,40,10,0.4), inset 2px 2px 8px rgba(200,150,100,0.15), 0 20px 60px rgba(0,0,0,0.6);
+        }
+        .pressure-eye { transition: transform 0.1s cubic-bezier(0.4,0,0.2,1); transform-origin: center; }
+        .pressure-container { animation: pressureFloat 8s ease-in-out infinite; }
+        .pressure-speaking { animation: pressureLean 2s ease-in-out infinite; }
+        .pressure-glow { box-shadow: inset -14px -14px 28px rgba(100,40,10,0.4), inset 2px 2px 8px rgba(200,150,100,0.15), 0 0 60px rgba(239,68,68,0.4) !important; }
+        .pressure-eyebrow-l { animation: eyebrowTwitch 4s ease-in-out infinite; }
+        .pressure-eyebrow-r { animation: eyebrowTwitchR 4s ease-in-out infinite; }
+      `;
+      document.head.appendChild(styleEl);
+    }
+ 
+    const wrapper = document.createElement("div");
+    wrapper.className = "w-full h-full flex flex-col items-center justify-center relative overflow-hidden";
+    wrapper.style.background = "#080f1a";
+    wrapper.innerHTML = `
+    <div id="pressure-body-wrapper" class="pressure-container relative w-56 h-56 shrink-0">
+ 
+      <!-- 뒷머리 배경 -->
+      <div class="absolute -z-10"
+        style="width:260px; height:200px; top:-32px; left:-16px; background:linear-gradient(180deg,#2a2a2a 0%,#1a1a1a 100%); border-radius:50%;"></div>
+      <div class="absolute -top-6 left-1/2 -z-10"
+        style="width:4px; height:40px; background:#0a0a0a; transform:translateX(-50%);"></div>
+ 
+      <!-- 귀 왼쪽 -->
+      <div class="absolute -z-10"
+        style="width:18px; height:26px; background:linear-gradient(160deg,#c07a50,#9a6035); border-radius:50%; top:38%; left:-6px; box-shadow:inset 3px 0 6px rgba(100,40,10,0.4);">
+        <div style="position:absolute; top:25%; left:20%; width:8px; height:14px; background:rgba(100,40,10,0.2); border-radius:50%;"></div>
+      </div>
+      <!-- 귀 오른쪽 -->
+      <div class="absolute -z-10"
+        style="width:18px; height:26px; background:linear-gradient(160deg,#c07a50,#9a6035); border-radius:50%; top:38%; right:-6px; box-shadow:inset -3px 0 6px rgba(100,40,10,0.4);">
+        <div style="position:absolute; top:25%; right:20%; width:8px; height:14px; background:rgba(100,40,10,0.2); border-radius:50%;"></div>
+      </div>
+ 
+      <div id="pressure-face" class="pressure-face w-full h-full flex flex-col items-center relative overflow-hidden transition-all duration-300"
+        style="border-radius:40% 40% 45% 45%;">
+ 
+        <!-- 눈썹: 원래 직사각형 -->
+        <div class="absolute top-[25%] w-full flex justify-between px-9">
+          <div class="pressure-eyebrow-l w-11 h-3 rounded-sm" style="background:#111; transform:rotate(-12deg); transform-origin:right center;"></div>
+          <div class="pressure-eyebrow-r w-11 h-3 rounded-sm" style="background:#111; transform:rotate(12deg); transform-origin:left center;"></div>
+        </div>
+ 
+        <!-- 미간 주름 -->
+        <div class="absolute top-[28%] left-1/2 -translate-x-1/2 flex gap-1.5">
+          <div class="w-0.5 h-4 rounded-full opacity-40" style="background:#7a4520; transform:rotate(-8deg);"></div>
+          <div class="w-0.5 h-4 rounded-full opacity-40" style="background:#7a4520; transform:rotate(8deg);"></div>
+        </div>
+ 
+        <!-- 눈 -->
+        <div class="absolute top-[34%] w-full flex justify-between px-10">
+          <div class="pressure-eye bg-white relative overflow-hidden shadow-inner"
+            style="width:32px; height:28px; border-radius:40% 40% 50% 50%;">
+            <div class="absolute bottom-0.5 right-0.5 rounded-full" style="width:20px; height:22px; background:#1a0a00;">
+              <div class="absolute top-1 right-1 w-1.5 h-1.5 bg-white rounded-full opacity-80"></div>
+            </div>
+            <div class="absolute top-0 w-full h-[30%] opacity-30" style="background:#333;"></div>
+          </div>
+          <div class="pressure-eye bg-white relative overflow-hidden shadow-inner"
+            style="width:32px; height:28px; border-radius:40% 40% 50% 50%;">
+            <div class="absolute bottom-0.5 left-0.5 rounded-full" style="width:20px; height:22px; background:#1a0a00;">
+              <div class="absolute top-1 left-1 w-1.5 h-1.5 bg-white rounded-full opacity-80"></div>
+            </div>
+            <div class="absolute top-0 w-full h-[30%] opacity-30" style="background:#333;"></div>
+          </div>
+        </div>
+ 
+        <!-- 안경 -->
+        <div class="absolute top-[30%] w-full flex justify-between px-7 pointer-events-none opacity-80">
+          <div class="w-16 h-12 border-2 border-slate-300/70 rounded-sm"></div>
+          <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-6 h-0.5 bg-slate-300/70"></div>
+          <div class="w-16 h-12 border-2 border-slate-300/70 rounded-sm"></div>
+        </div>
+ 
+        <!-- 코 -->
+        <div class="absolute top-[53%] left-1/2 -translate-x-1/2"
+          style="width:0; height:0; border-left:5px solid transparent; border-right:5px solid transparent; border-top:7px solid rgba(120,60,20,0.3);"></div>
+ 
+        <!-- 입 -->
+        <div class="absolute top-[65%] w-full flex justify-center">
+          <div id="pressure-mouth" class="relative overflow-hidden transition-all duration-75"
+            style="width:32px; height:6px; border-radius:3px; background:#5a1515;">
+            <div class="absolute top-0 w-full h-[30%]" style="background:rgba(255,255,255,0.6);"></div>
+            <div class="absolute bottom-0 w-full h-[35%] rounded-full" style="background:#8b3030; transform:translateY(40%);"></div>
+          </div>
+        </div>
+ 
+        <!-- 얼굴 위 머리카락 마스크 -->
+        <svg class="absolute top-0 left-0 w-full h-16" viewBox="0 0 100 35" preserveAspectRatio="none">
+          <path d="M 0 0 L 100 0 L 100 10 Q 55 20 50 14 Q 45 20 0 10 Z" fill="#080f1a"/>
+        </svg>
+      </div>
+ 
+      <!-- 앞머리 SVG -->
+      <div class="absolute pointer-events-none" style="top:-32px; left:-16px; width:260px; height:120px; z-index:1;">
+        <svg width="260" height="120" viewBox="0 0 260 120" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="pr-fg-hair-grad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#2a2a2a"/>
+              <stop offset="100%" stop-color="#1a1a1a"/>
+            </linearGradient>
+          </defs>
+          <path d="
+            M 130 8
+            C 85 8, 28 22, 12 58
+            C 4 78, 4 98, 4 108
+            C 62 102, 98 90, 130 56
+            C 162 90, 198 102, 256 108
+            C 256 98, 256 78, 248 58
+            C 232 22, 175 8, 130 8
+            Z
+          " fill="url(#pr-fg-hair-grad)"/>
+        </svg>
+      </div>
+ 
+      <!-- 목 + 정장 SVG 통합 -->
+      <div class="absolute pointer-events-none" style="bottom:-100px; left:50%; transform:translateX(-50%); width:280px; height:110px; z-index:-1;">
+        <svg width="280" height="110" viewBox="0 0 280 110" xmlns="http://www.w3.org/2000/svg">
+          <!-- 정장 재킷 몸통 (짙은 남색) -->
+          <path d="M 0 45 Q 0 28 22 24 L 90 16 L 140 30 L 190 16 L 258 24 Q 280 28 280 45 L 280 110 L 0 110 Z" fill="#1e293b"/>
+          <!-- 재킷 왼쪽 라펠 -->
+          <path d="M 140 30 L 90 16 L 78 36 L 125 52 Z" fill="#263548"/>
+          <!-- 재킷 오른쪽 라펠 -->
+          <path d="M 140 30 L 190 16 L 202 36 L 155 52 Z" fill="#263548"/>
+          <!-- 조끼 (더 밝은 남색) -->
+          <path d="M 125 52 L 140 38 L 155 52 L 162 110 L 118 110 Z" fill="#334155"/>
+          <!-- 와이셔츠 (흰색, 라펠 사이) -->
+          <path d="M 125 52 L 140 68 L 155 52 L 140 38 Z" fill="#f1f5f9"/>
+          <!-- 넥타이 -->
+          <path d="M 136 42 L 144 42 L 146 60 L 140 72 L 134 60 Z" fill="#7f1d1d"/>
+          <path d="M 137 42 L 143 42 L 140 50 Z" fill="#991b1b"/>
+          <!-- 목 -->
+          <rect x="118" y="0" width="44" height="38" rx="6" fill="#b87a4a"/>
+          <!-- 셔츠 칼라 왼쪽 -->
+          <path d="M 140 36 L 108 22 L 102 34 L 132 46 Z" fill="#f1f5f9"/>
+          <!-- 셔츠 칼라 오른쪽 -->
+          <path d="M 140 36 L 172 22 L 178 34 L 148 46 Z" fill="#f1f5f9"/>
+          <!-- 재킷 단추 -->
+          <circle cx="140" cy="72" r="3.5" fill="#0f172a"/>
+          <circle cx="140" cy="88" r="3.5" fill="#0f172a"/>
+          <!-- 재킷 왼쪽 어깨 하이라이트 -->
+          <path d="M 0 45 Q 0 28 22 24 L 90 16 L 78 36 L 30 42 Q 10 44 0 55 Z" fill="#253044"/>
+          <!-- 재킷 오른쪽 어깨 하이라이트 -->
+          <path d="M 280 45 Q 280 28 258 24 L 190 16 L 202 36 L 250 42 Q 270 44 280 55 Z" fill="#253044"/>
+        </svg>
+      </div>
+    </div>
+ 
+    <div id="pressure-status" class="mt-28 px-5 py-2 rounded-full border text-sm font-medium flex items-center gap-2.5"
+      style="background:rgba(239,68,68,0.08); border-color:rgba(239,68,68,0.2); color:#fca5a5;">
+      <span class="w-2 h-2 rounded-full" style="background:#475569;"></span>
+      <span class="status-text">AI 면접관 대기 중</span>
+    </div>`;
+ 
+    container.appendChild(wrapper);
+    this.avatarWrapper = wrapper.querySelector("#pressure-body-wrapper");
+    this.mouthElement = wrapper.querySelector("#pressure-mouth");
+    this.startBlinking();
+  }
+ 
+  private startBlinking() {
+    const blink = () => {
+      if (this.isDestroyed || !this.container) return;
+      const eyes = this.container.querySelectorAll(".pressure-eye") as NodeListOf<HTMLElement>;
+      eyes.forEach((e) => (e.style.transform = "scaleY(0.05)"));
+      setTimeout(() => {
+        if (!this.isDestroyed) eyes.forEach((e) => (e.style.transform = "scaleY(1)"));
+      }, 100);
+      this.blinkTimeoutId = window.setTimeout(blink, Math.random() * 6000 + 3000);
+    };
+    blink();
+  }
+ 
+  async speak(audioUrlOrBase64: string, text: string): Promise<void> {
+    void text;
+    this.stopAudio();
+    this.setStatus("speaking");
+    if (this.avatarWrapper) {
+      this.avatarWrapper.className = "pressure-speaking relative w-56 h-56 shrink-0";
+    }
+    this.container?.querySelector("#pressure-face")?.classList.add("pressure-glow");
+    return new Promise((resolve) => {
+      this.audio = new Audio(audioUrlOrBase64);
+      this.audio.crossOrigin = "anonymous";
+      const AudioCtxClass = window.AudioContext || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext!;
+      if (!this.audioCtx) {
+        this.audioCtx = new AudioCtxClass();
+        this.analyser = this.audioCtx.createAnalyser();
+        this.analyser.fftSize = 256;
+      }
+      if (this.audioCtx.state === "suspended") this.audioCtx.resume();
+      if (this.source) this.source.disconnect();
+      this.source = this.audioCtx.createMediaElementSource(this.audio);
+      this.source.connect(this.analyser!);
+      this.analyser!.connect(this.audioCtx.destination);
+      const dataArray = new Uint8Array(this.analyser!.frequencyBinCount);
+      const renderFrame = () => {
+        if (!this.analyser || !this.mouthElement || !this.audio || this.audio.paused) return;
+        this.analyser.getByteFrequencyData(dataArray);
+        const avg = dataArray.reduce((a, b) => a + b, 0) / dataArray.length;
+        if (avg > 5) {
+          const h = Math.min(32, 6 + (avg / 255) * 34);
+          const w = Math.max(24, 32 - (avg / 255) * 6);
+          const r = Math.min(12, 3 + (avg / 255) * 12);
+          this.mouthElement.style.height = `${h}px`;
+          this.mouthElement.style.width = `${w}px`;
+          this.mouthElement.style.borderRadius = `${r}px`;
+        } else { this.resetMouth(); }
+        this.animationFrameId = requestAnimationFrame(renderFrame);
+      };
+      this.audio.onplay = renderFrame;
+      this.audio.onended = () => { this.stopAudio(); resolve(); };
+      this.audio.onerror = () => { this.stopAudio(); resolve(); };
+      this.audio.play().catch(() => { this.stopAudio(); resolve(); });
+    });
+  }
+ 
+  private resetMouth() {
+    if (!this.mouthElement) return;
+    this.mouthElement.style.height = "6px";
+    this.mouthElement.style.width = "32px";
+    this.mouthElement.style.borderRadius = "3px";
+  }
+ 
+  private setStatus(state: "speaking" | "idle") {
+    const dot = this.container?.querySelector("#pressure-status span") as HTMLElement | null;
+    const text = this.container?.querySelector(".status-text");
+    if (state === "speaking") {
+      dot?.setAttribute("style", "width:8px; height:8px; border-radius:50%; background:#ef4444; animation: pulse 0.8s infinite;");
+      if (text) text.textContent = "질문 중...";
+    } else {
+      dot?.setAttribute("style", "width:8px; height:8px; border-radius:50%; background:#475569;");
+      if (text) text.textContent = "AI 면접관 대기 중";
+    }
+  }
+ 
+  private stopAudio() {
+    if (this.animationFrameId) { cancelAnimationFrame(this.animationFrameId); this.animationFrameId = null; }
+    if (this.audio) { this.audio.pause(); this.audio.currentTime = 0; this.audio = null; }
+    this.resetMouth();
+    if (this.avatarWrapper) {
+      this.avatarWrapper.className = "pressure-container relative w-56 h-56 shrink-0";
+    }
+    this.container?.querySelector("#pressure-face")?.classList.remove("pressure-glow");
+    this.setStatus("idle");
+  }
+ 
+  stop(): void { this.stopAudio(); }
+ 
+  destroy(): void {
+    this.isDestroyed = true;
+    this.stopAudio();
+    if (this.blinkTimeoutId) clearTimeout(this.blinkTimeoutId);
+    if (this.source) this.source.disconnect();
+    if (this.audioCtx && this.audioCtx.state !== "closed") this.audioCtx.close();
+    if (this.container) this.container.innerHTML = "";
+    this.mouthElement = null;
+    this.avatarWrapper = null;
+  }
+}

--- a/src/shared/lib/avatar/PrettyAvatarProvider.ts
+++ b/src/shared/lib/avatar/PrettyAvatarProvider.ts
@@ -52,7 +52,7 @@ export class PrettyAvatarProvider implements IAvatarProvider {
     const bodyWrapper = document.createElement("div");
     bodyWrapper.id = "avatar-body-wrapper";
     bodyWrapper.className = "avatar-container relative w-56 h-56 shrink-0";
-    bodyWrapper.innerHTML = this.buildHairHTML() + this.buildFaceHTML() + this.buildBodyHTML();
+    bodyWrapper.appendChild(this.parseStaticHTML(this.buildHairHTML() + this.buildFaceHTML() + this.buildBodyHTML()));
 
     const status = document.createElement("div");
     status.id = "avatar-status";
@@ -165,6 +165,16 @@ export class PrettyAvatarProvider implements IAvatarProvider {
         </svg>
       </div>
     `;
+  }
+
+  private parseStaticHTML(html: string): DocumentFragment {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+    const fragment = document.createDocumentFragment();
+    Array.from(doc.body.childNodes).forEach((node) =>
+      fragment.appendChild(document.adoptNode(node))
+    );
+    return fragment;
   }
 
   private startBlinking() {

--- a/src/shared/lib/avatar/PrettyAvatarProvider.ts
+++ b/src/shared/lib/avatar/PrettyAvatarProvider.ts
@@ -14,7 +14,15 @@ export class PrettyAvatarProvider implements IAvatarProvider {
 
   async initialize(container: HTMLElement): Promise<void> {
     this.container = container;
+    this.injectStyles();
+    const wrapper = this.buildHTML();
+    container.appendChild(wrapper);
+    this.avatarWrapper = wrapper.querySelector("#avatar-body-wrapper");
+    this.mouthElement = wrapper.querySelector("#pretty-mouth");
+    this.startBlinking();
+  }
 
+  private injectStyles(): void {
     const styleId = "pretty-avatar-style";
     if (!document.getElementById(styleId)) {
       const styleEl = document.createElement("style");
@@ -34,7 +42,9 @@ export class PrettyAvatarProvider implements IAvatarProvider {
       `;
       document.head.appendChild(styleEl);
     }
+  }
 
+  private buildHTML(): HTMLElement {
     const wrapper = document.createElement("div");
     wrapper.className = "w-full h-full flex flex-col items-center justify-center relative overflow-hidden text-center";
     wrapper.style.background = "#080f1a";
@@ -171,10 +181,7 @@ export class PrettyAvatarProvider implements IAvatarProvider {
       </div>
     `;
 
-    container.appendChild(wrapper);
-    this.avatarWrapper = wrapper.querySelector("#avatar-body-wrapper");
-    this.mouthElement = wrapper.querySelector("#pretty-mouth");
-    this.startBlinking();
+    return wrapper;
   }
 
   private startBlinking() {
@@ -185,7 +192,10 @@ export class PrettyAvatarProvider implements IAvatarProvider {
       setTimeout(() => {
         if (!this.isDestroyed) eyes.forEach((e) => (e.style.transform = "scaleY(1)"));
       }, 150);
-      this.blinkTimeoutId = window.setTimeout(blink, Math.random() * 4000 + 2000);
+      const buf = new Uint32Array(1);
+      crypto.getRandomValues(buf);
+      const delay = (buf[0] / 0xFFFFFFFF) * 4000 + 2000;
+      this.blinkTimeoutId = window.setTimeout(blink, delay);
     };
     blink();
   }

--- a/src/shared/lib/avatar/PrettyAvatarProvider.ts
+++ b/src/shared/lib/avatar/PrettyAvatarProvider.ts
@@ -29,7 +29,6 @@ export class PrettyAvatarProvider implements IAvatarProvider {
           box-shadow: inset -10px -10px 20px rgba(200,100,50,0.2), 0 20px 40px rgba(0,0,0,0.4);
         }
         .pretty-eye { transition: transform 0.15s cubic-bezier(0.4,0,0.2,1); transform-origin: center; }
-        .pretty-hair { background: linear-gradient(180deg, #2d3748 0%, #1a202c 100%); }
         .avatar-container { animation: floatHead 6s ease-in-out infinite; }
         .speaking-glow { box-shadow: inset -10px -10px 20px rgba(200,100,50,0.2), 0 0 60px rgba(96,165,250,0.3) !important; }
       `;
@@ -38,14 +37,43 @@ export class PrettyAvatarProvider implements IAvatarProvider {
 
     const wrapper = document.createElement("div");
     wrapper.className = "w-full h-full flex flex-col items-center justify-center relative overflow-hidden text-center";
-    wrapper.style.background = "radial-gradient(circle at center, #1e293b 0%, #0f172a 100%)";
+    wrapper.style.background = "#080f1a";
     wrapper.innerHTML = `
       <div id="avatar-body-wrapper" class="avatar-container relative w-56 h-56 shrink-0">
-        <div class="pretty-hair absolute -top-8 -left-4 w-64 h-36 rounded-t-[100px] rounded-b-3xl -z-10"></div>
-        <div id="pretty-face" class="pretty-face w-full h-full rounded-[45%] flex flex-col items-center relative overflow-hidden border-4 border-white/5 transition-all duration-300">
+
+        <!-- 뒤 머리카락: 타원형 -->
+        <div class="absolute -z-10"
+          style="width:260px; height:200px; top:-36px; left:-18px; background:linear-gradient(180deg,#2d3748 0%,#1a202c 100%); border-radius:50%;"></div>
+
+        <!-- 귀 왼쪽 -->
+        <div class="absolute -z-10"
+          style="width:18px; height:26px; background:linear-gradient(160deg,#ffcba4,#e8a87c); border-radius:50%; top:38%; left:-6px; box-shadow:inset 3px 0 6px rgba(200,100,50,0.3);">
+          <div style="position:absolute; top:25%; left:20%; width:8px; height:14px; background:rgba(200,100,50,0.2); border-radius:50%;"></div>
+        </div>
+        <!-- 귀 오른쪽 -->
+        <div class="absolute -z-10"
+          style="width:18px; height:26px; background:linear-gradient(160deg,#ffcba4,#e8a87c); border-radius:50%; top:38%; right:-6px; box-shadow:inset -3px 0 6px rgba(200,100,50,0.3);">
+          <div style="position:absolute; top:25%; right:20%; width:8px; height:14px; background:rgba(200,100,50,0.2); border-radius:50%;"></div>
+        </div>
+
+        <!-- 얼굴 -->
+        <div id="pretty-face" class="pretty-face w-full h-full rounded-[45%] flex flex-col items-center relative overflow-hidden transition-all duration-300">
+          <!-- 볼터치 -->
           <div class="absolute top-[35%] left-[15%] w-10 h-6 bg-rose-400/30 rounded-full blur-md"></div>
           <div class="absolute top-[35%] right-[15%] w-10 h-6 bg-rose-400/30 rounded-full blur-md"></div>
-          <div class="absolute top-[32%] w-full flex justify-between px-12">
+
+          <!-- 눈썹: 자연스러운 아치형, 머리카락과 같은 색 -->
+          <div class="absolute top-[26%] w-full flex justify-between px-11">
+            <svg width="28" height="10" viewBox="0 0 28 10">
+              <path d="M 2 8 Q 8 1 26 4" stroke="#2d3748" stroke-width="3" fill="none" stroke-linecap="round"/>
+            </svg>
+            <svg width="28" height="10" viewBox="0 0 28 10">
+              <path d="M 26 8 Q 20 1 2 4" stroke="#2d3748" stroke-width="3" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+
+          <!-- 눈 -->
+          <div class="absolute top-[33%] w-full flex justify-between px-12">
             <div class="pretty-eye w-7 h-9 bg-white rounded-[50%] relative overflow-hidden shadow-inner">
               <div class="absolute bottom-1 right-1 w-4 h-5 bg-slate-800 rounded-full">
                 <div class="absolute top-1 left-1 w-1.5 h-1.5 bg-white rounded-full"></div>
@@ -57,25 +85,87 @@ export class PrettyAvatarProvider implements IAvatarProvider {
               </div>
             </div>
           </div>
-          <div class="absolute top-[29%] w-full flex justify-between px-8 pointer-events-none opacity-70">
+
+          <!-- 안경 -->
+          <div class="absolute top-[30%] w-full flex justify-between px-8 pointer-events-none opacity-70">
             <div class="w-14 h-14 border-[3px] border-amber-600/60 rounded-[40%]"></div>
             <div class="absolute w-5 h-1 bg-amber-600/60 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"></div>
             <div class="w-14 h-14 border-[3px] border-amber-600/60 rounded-[40%]"></div>
           </div>
+
+          <!-- 코 -->
+          <div class="absolute top-[50%] left-1/2 -translate-x-1/2"
+            style="width:14px; height:10px; border-radius:50%; background:rgba(200,120,70,0.2); box-shadow:inset 0 2px 4px rgba(180,90,40,0.3);">
+            <div class="absolute" style="width:4px; height:4px; border-radius:50%; background:rgba(160,80,30,0.35); bottom:1px; left:1px;"></div>
+            <div class="absolute" style="width:4px; height:4px; border-radius:50%; background:rgba(160,80,30,0.35); bottom:1px; right:1px;"></div>
+          </div>
+
+          <!-- 입 -->
           <div class="absolute top-[62%] w-full flex justify-center">
             <div id="pretty-mouth" class="w-8 h-2 bg-[#881337] rounded-full transition-all duration-75 relative overflow-hidden">
               <div class="absolute top-0 w-full h-[30%] bg-white/90"></div>
               <div class="absolute bottom-0 w-full h-[40%] bg-rose-400/80 rounded-full transform translate-y-1/2"></div>
             </div>
           </div>
+
+          <!-- 얼굴 위 머리카락 마스크 (7:3 가르마) -->
           <svg class="absolute top-0 left-0 w-full h-20" viewBox="0 0 100 40" preserveAspectRatio="none">
-            <path d="M 0 0 L 100 0 L 100 15 Q 75 35 50 20 Q 25 35 0 15 Z" fill="#1e293b"/>
+            <path d="M 0 0 L 100 0 L 100 12 C 85 10 75 6 70 14 C 60 4 30 10 0 12 Z" fill="#1a202c"/>
           </svg>
         </div>
-        <div class="absolute -bottom-14 left-1/2 -translate-x-1/2 w-14 h-16 bg-[#e6bca0] -z-10 rounded-b-xl"></div>
-        <div class="absolute -bottom-20 left-1/2 -translate-x-1/2 w-40 h-20 bg-indigo-600 -z-20 rounded-t-[40px]"></div>
+
+        <!-- 앞머리 SVG -->
+        <div class="absolute pointer-events-none" style="top:-36px; left:-18px; width:260px; height:200px; z-index:1;">
+          <svg width="260" height="200" viewBox="0 0 260 200" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <linearGradient id="fg-hair-grad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stop-color="#2d3748"/>
+                <stop offset="100%" stop-color="#1e2a3a"/>
+              </linearGradient>
+              <clipPath id="hair-oval-clip">
+                <ellipse cx="130" cy="100" rx="130" ry="100"/>
+              </clipPath>
+            </defs>
+            <g clip-path="url(#hair-oval-clip)">
+              <path d="
+                M 0 0 L 260 0 L 260 115
+                C 230 108 210 96 182 65
+                C 155 95 120 112 80 118
+                C 50 122 25 118 0 115
+                Z
+              " fill="url(#fg-hair-grad)"/>
+            </g>
+          </svg>
+        </div>
+
+        <!-- 목 + 셔츠 SVG 통합 -->
+        <div class="absolute pointer-events-none" style="bottom:-90px; left:50%; transform:translateX(-50%); width:240px; height:100px; z-index:-1;">
+          <svg width="240" height="100" viewBox="0 0 240 100" xmlns="http://www.w3.org/2000/svg">
+            <!-- 셔츠 몸통 -->
+            <path d="M 0 40 Q 0 25 20 22 L 80 18 L 120 28 L 160 18 L 220 22 Q 240 25 240 40 L 240 100 L 0 100 Z" fill="#f1f5f9"/>
+            <!-- 셔츠 음영 -->
+            <path d="M 0 40 Q 0 25 20 22 L 80 18 L 120 28 L 160 18 L 220 22 Q 240 25 240 40 L 240 50 Q 200 42 120 44 Q 40 42 0 50 Z" fill="#e2e8f0"/>
+            <!-- 목 -->
+            <rect x="100" y="0" width="40" height="35" rx="6" fill="#e6bca0"/>
+            <!-- 카라 왼쪽 날개 -->
+            <path d="M 120 28 L 80 18 L 72 32 L 112 38 Z" fill="#f8fafc"/>
+            <path d="M 120 28 L 80 18 L 72 32 L 112 38 Z" fill="none" stroke="#e2e8f0" stroke-width="1"/>
+            <!-- 카라 오른쪽 날개 -->
+            <path d="M 120 28 L 160 18 L 168 32 L 128 38 Z" fill="#f8fafc"/>
+            <path d="M 120 28 L 160 18 L 168 32 L 128 38 Z" fill="none" stroke="#e2e8f0" stroke-width="1"/>
+            <!-- 카라 중앙 V -->
+            <path d="M 112 38 L 120 50 L 128 38 Z" fill="#8f8f8fff"/>
+            <!-- 단추 -->
+            <circle cx="120" cy="56" r="3" fill="#cbd5e1"/>
+            <circle cx="120" cy="70" r="3" fill="#cbd5e1"/>
+            <circle cx="120" cy="84" r="3" fill="#cbd5e1"/>
+            <!-- 셔츠 중앙선 -->
+            <line x1="120" y1="50" x2="120" y2="100" stroke="#e2e8f0" stroke-width="1"/>
+          </svg>
+        </div>
       </div>
-      <div id="avatar-status" class="mt-20 px-5 py-2 rounded-full bg-slate-800/80 border border-white/5 text-sm text-slate-300 font-medium flex items-center gap-2.5">
+
+      <div id="avatar-status" class="mt-28 px-5 py-2 rounded-full bg-slate-800/80 border border-white/5 text-sm text-slate-300 font-medium flex items-center gap-2.5">
         <span class="w-2 h-2 rounded-full bg-slate-500"></span>
         <span class="status-text">AI 면접관 대기 중</span>
       </div>
@@ -103,7 +193,6 @@ export class PrettyAvatarProvider implements IAvatarProvider {
   async speak(audioUrlOrBase64: string, text: string): Promise<void> {
     this.stopAudio();
     this.setStatus("speaking");
-
     if (this.avatarWrapper) {
       this.avatarWrapper.style.transform = text.includes("?") ? "rotate(-3deg) scale(1.02)" : "";
     }
@@ -113,7 +202,6 @@ export class PrettyAvatarProvider implements IAvatarProvider {
     return new Promise((resolve) => {
       this.audio = new Audio(audioUrlOrBase64);
       this.audio.crossOrigin = "anonymous";
-
       const AudioCtxClass = window.AudioContext || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext!;
       if (!this.audioCtx) {
         this.audioCtx = new AudioCtxClass();
@@ -125,7 +213,6 @@ export class PrettyAvatarProvider implements IAvatarProvider {
       this.source = this.audioCtx.createMediaElementSource(this.audio);
       this.source.connect(this.analyser!);
       this.analyser!.connect(this.audioCtx.destination);
-
       const dataArray = new Uint8Array(this.analyser!.frequencyBinCount);
       const renderFrame = () => {
         if (!this.analyser || !this.mouthElement || !this.audio || this.audio.paused) return;
@@ -138,12 +225,9 @@ export class PrettyAvatarProvider implements IAvatarProvider {
           this.mouthElement.style.height = `${h}px`;
           this.mouthElement.style.width = `${w}px`;
           this.mouthElement.style.borderRadius = `${r}px`;
-        } else {
-          this.resetMouth();
-        }
+        } else { this.resetMouth(); }
         this.animationFrameId = requestAnimationFrame(renderFrame);
       };
-
       this.audio.onplay = renderFrame;
       this.audio.onended = () => { this.stopAudio(); resolve(); };
       this.audio.onerror = () => { this.stopAudio(); resolve(); };

--- a/src/shared/lib/avatar/PrettyAvatarProvider.ts
+++ b/src/shared/lib/avatar/PrettyAvatarProvider.ts
@@ -50,138 +50,112 @@ export class PrettyAvatarProvider implements IAvatarProvider {
     wrapper.style.background = "#080f1a";
     wrapper.innerHTML = `
       <div id="avatar-body-wrapper" class="avatar-container relative w-56 h-56 shrink-0">
-
-        <!-- 뒤 머리카락: 타원형 -->
-        <div class="absolute -z-10"
-          style="width:260px; height:200px; top:-36px; left:-18px; background:linear-gradient(180deg,#2d3748 0%,#1a202c 100%); border-radius:50%;"></div>
-
-        <!-- 귀 왼쪽 -->
-        <div class="absolute -z-10"
-          style="width:18px; height:26px; background:linear-gradient(160deg,#ffcba4,#e8a87c); border-radius:50%; top:38%; left:-6px; box-shadow:inset 3px 0 6px rgba(200,100,50,0.3);">
-          <div style="position:absolute; top:25%; left:20%; width:8px; height:14px; background:rgba(200,100,50,0.2); border-radius:50%;"></div>
-        </div>
-        <!-- 귀 오른쪽 -->
-        <div class="absolute -z-10"
-          style="width:18px; height:26px; background:linear-gradient(160deg,#ffcba4,#e8a87c); border-radius:50%; top:38%; right:-6px; box-shadow:inset -3px 0 6px rgba(200,100,50,0.3);">
-          <div style="position:absolute; top:25%; right:20%; width:8px; height:14px; background:rgba(200,100,50,0.2); border-radius:50%;"></div>
-        </div>
-
-        <!-- 얼굴 -->
-        <div id="pretty-face" class="pretty-face w-full h-full rounded-[45%] flex flex-col items-center relative overflow-hidden transition-all duration-300">
-          <!-- 볼터치 -->
-          <div class="absolute top-[35%] left-[15%] w-10 h-6 bg-rose-400/30 rounded-full blur-md"></div>
-          <div class="absolute top-[35%] right-[15%] w-10 h-6 bg-rose-400/30 rounded-full blur-md"></div>
-
-          <!-- 눈썹: 자연스러운 아치형, 머리카락과 같은 색 -->
-          <div class="absolute top-[26%] w-full flex justify-between px-11">
-            <svg width="28" height="10" viewBox="0 0 28 10">
-              <path d="M 2 8 Q 8 1 26 4" stroke="#2d3748" stroke-width="3" fill="none" stroke-linecap="round"/>
-            </svg>
-            <svg width="28" height="10" viewBox="0 0 28 10">
-              <path d="M 26 8 Q 20 1 2 4" stroke="#2d3748" stroke-width="3" fill="none" stroke-linecap="round"/>
-            </svg>
-          </div>
-
-          <!-- 눈 -->
-          <div class="absolute top-[33%] w-full flex justify-between px-12">
-            <div class="pretty-eye w-7 h-9 bg-white rounded-[50%] relative overflow-hidden shadow-inner">
-              <div class="absolute bottom-1 right-1 w-4 h-5 bg-slate-800 rounded-full">
-                <div class="absolute top-1 left-1 w-1.5 h-1.5 bg-white rounded-full"></div>
-              </div>
-            </div>
-            <div class="pretty-eye w-7 h-9 bg-white rounded-[50%] relative overflow-hidden shadow-inner">
-              <div class="absolute bottom-1 left-1 w-4 h-5 bg-slate-800 rounded-full">
-                <div class="absolute top-1 left-1 w-1.5 h-1.5 bg-white rounded-full"></div>
-              </div>
-            </div>
-          </div>
-
-          <!-- 안경 -->
-          <div class="absolute top-[30%] w-full flex justify-between px-8 pointer-events-none opacity-70">
-            <div class="w-14 h-14 border-[3px] border-amber-600/60 rounded-[40%]"></div>
-            <div class="absolute w-5 h-1 bg-amber-600/60 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"></div>
-            <div class="w-14 h-14 border-[3px] border-amber-600/60 rounded-[40%]"></div>
-          </div>
-
-          <!-- 코 -->
-          <div class="absolute top-[50%] left-1/2 -translate-x-1/2"
-            style="width:14px; height:10px; border-radius:50%; background:rgba(200,120,70,0.2); box-shadow:inset 0 2px 4px rgba(180,90,40,0.3);">
-            <div class="absolute" style="width:4px; height:4px; border-radius:50%; background:rgba(160,80,30,0.35); bottom:1px; left:1px;"></div>
-            <div class="absolute" style="width:4px; height:4px; border-radius:50%; background:rgba(160,80,30,0.35); bottom:1px; right:1px;"></div>
-          </div>
-
-          <!-- 입 -->
-          <div class="absolute top-[62%] w-full flex justify-center">
-            <div id="pretty-mouth" class="w-8 h-2 bg-[#881337] rounded-full transition-all duration-75 relative overflow-hidden">
-              <div class="absolute top-0 w-full h-[30%] bg-white/90"></div>
-              <div class="absolute bottom-0 w-full h-[40%] bg-rose-400/80 rounded-full transform translate-y-1/2"></div>
-            </div>
-          </div>
-
-          <!-- 얼굴 위 머리카락 마스크 (7:3 가르마) -->
-          <svg class="absolute top-0 left-0 w-full h-20" viewBox="0 0 100 40" preserveAspectRatio="none">
-            <path d="M 0 0 L 100 0 L 100 12 C 85 10 75 6 70 14 C 60 4 30 10 0 12 Z" fill="#1a202c"/>
-          </svg>
-        </div>
-
-        <!-- 앞머리 SVG -->
-        <div class="absolute pointer-events-none" style="top:-36px; left:-18px; width:260px; height:200px; z-index:1;">
-          <svg width="260" height="200" viewBox="0 0 260 200" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-              <linearGradient id="fg-hair-grad" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stop-color="#2d3748"/>
-                <stop offset="100%" stop-color="#1e2a3a"/>
-              </linearGradient>
-              <clipPath id="hair-oval-clip">
-                <ellipse cx="130" cy="100" rx="130" ry="100"/>
-              </clipPath>
-            </defs>
-            <g clip-path="url(#hair-oval-clip)">
-              <path d="
-                M 0 0 L 260 0 L 260 115
-                C 230 108 210 96 182 65
-                C 155 95 120 112 80 118
-                C 50 122 25 118 0 115
-                Z
-              " fill="url(#fg-hair-grad)"/>
-            </g>
-          </svg>
-        </div>
-
-        <!-- 목 + 셔츠 SVG 통합 -->
-        <div class="absolute pointer-events-none" style="bottom:-90px; left:50%; transform:translateX(-50%); width:240px; height:100px; z-index:-1;">
-          <svg width="240" height="100" viewBox="0 0 240 100" xmlns="http://www.w3.org/2000/svg">
-            <!-- 셔츠 몸통 -->
-            <path d="M 0 40 Q 0 25 20 22 L 80 18 L 120 28 L 160 18 L 220 22 Q 240 25 240 40 L 240 100 L 0 100 Z" fill="#f1f5f9"/>
-            <!-- 셔츠 음영 -->
-            <path d="M 0 40 Q 0 25 20 22 L 80 18 L 120 28 L 160 18 L 220 22 Q 240 25 240 40 L 240 50 Q 200 42 120 44 Q 40 42 0 50 Z" fill="#e2e8f0"/>
-            <!-- 목 -->
-            <rect x="100" y="0" width="40" height="35" rx="6" fill="#e6bca0"/>
-            <!-- 카라 왼쪽 날개 -->
-            <path d="M 120 28 L 80 18 L 72 32 L 112 38 Z" fill="#f8fafc"/>
-            <path d="M 120 28 L 80 18 L 72 32 L 112 38 Z" fill="none" stroke="#e2e8f0" stroke-width="1"/>
-            <!-- 카라 오른쪽 날개 -->
-            <path d="M 120 28 L 160 18 L 168 32 L 128 38 Z" fill="#f8fafc"/>
-            <path d="M 120 28 L 160 18 L 168 32 L 128 38 Z" fill="none" stroke="#e2e8f0" stroke-width="1"/>
-            <!-- 카라 중앙 V -->
-            <path d="M 112 38 L 120 50 L 128 38 Z" fill="#8f8f8fff"/>
-            <!-- 단추 -->
-            <circle cx="120" cy="56" r="3" fill="#cbd5e1"/>
-            <circle cx="120" cy="70" r="3" fill="#cbd5e1"/>
-            <circle cx="120" cy="84" r="3" fill="#cbd5e1"/>
-            <!-- 셔츠 중앙선 -->
-            <line x1="120" y1="50" x2="120" y2="100" stroke="#e2e8f0" stroke-width="1"/>
-          </svg>
-        </div>
+        ${this.buildHairHTML()}
+        ${this.buildFaceHTML()}
+        ${this.buildBodyHTML()}
       </div>
-
       <div id="avatar-status" class="mt-28 px-5 py-2 rounded-full bg-slate-800/80 border border-white/5 text-sm text-slate-300 font-medium flex items-center gap-2.5">
         <span class="w-2 h-2 rounded-full bg-slate-500"></span>
         <span class="status-text">AI 면접관 대기 중</span>
       </div>
     `;
-
     return wrapper;
+  }
+
+  private buildHairHTML(): string {
+    return `
+      <div class="absolute -z-10"
+        style="width:260px; height:200px; top:-36px; left:-18px; background:linear-gradient(180deg,#2d3748 0%,#1a202c 100%); border-radius:50%;"></div>
+      <div class="absolute -z-10"
+        style="width:18px; height:26px; background:linear-gradient(160deg,#ffcba4,#e8a87c); border-radius:50%; top:38%; left:-6px; box-shadow:inset 3px 0 6px rgba(200,100,50,0.3);">
+        <div style="position:absolute; top:25%; left:20%; width:8px; height:14px; background:rgba(200,100,50,0.2); border-radius:50%;"></div>
+      </div>
+      <div class="absolute -z-10"
+        style="width:18px; height:26px; background:linear-gradient(160deg,#ffcba4,#e8a87c); border-radius:50%; top:38%; right:-6px; box-shadow:inset -3px 0 6px rgba(200,100,50,0.3);">
+        <div style="position:absolute; top:25%; right:20%; width:8px; height:14px; background:rgba(200,100,50,0.2); border-radius:50%;"></div>
+      </div>
+      <div class="absolute pointer-events-none" style="top:-36px; left:-18px; width:260px; height:200px; z-index:1;">
+        <svg width="260" height="200" viewBox="0 0 260 200" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="fg-hair-grad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#2d3748"/>
+              <stop offset="100%" stop-color="#1e2a3a"/>
+            </linearGradient>
+            <clipPath id="hair-oval-clip">
+              <ellipse cx="130" cy="100" rx="130" ry="100"/>
+            </clipPath>
+          </defs>
+          <g clip-path="url(#hair-oval-clip)">
+            <path d="M 0 0 L 260 0 L 260 115 C 230 108 210 96 182 65 C 155 95 120 112 80 118 C 50 122 25 118 0 115 Z" fill="url(#fg-hair-grad)"/>
+          </g>
+        </svg>
+      </div>
+    `;
+  }
+
+  private buildFaceHTML(): string {
+    return `
+      <div id="pretty-face" class="pretty-face w-full h-full rounded-[45%] flex flex-col items-center relative overflow-hidden transition-all duration-300">
+        <div class="absolute top-[35%] left-[15%] w-10 h-6 bg-rose-400/30 rounded-full blur-md"></div>
+        <div class="absolute top-[35%] right-[15%] w-10 h-6 bg-rose-400/30 rounded-full blur-md"></div>
+        <div class="absolute top-[26%] w-full flex justify-between px-11">
+          <svg width="28" height="10" viewBox="0 0 28 10"><path d="M 2 8 Q 8 1 26 4" stroke="#2d3748" stroke-width="3" fill="none" stroke-linecap="round"/></svg>
+          <svg width="28" height="10" viewBox="0 0 28 10"><path d="M 26 8 Q 20 1 2 4" stroke="#2d3748" stroke-width="3" fill="none" stroke-linecap="round"/></svg>
+        </div>
+        <div class="absolute top-[33%] w-full flex justify-between px-12">
+          <div class="pretty-eye w-7 h-9 bg-white rounded-[50%] relative overflow-hidden shadow-inner">
+            <div class="absolute bottom-1 right-1 w-4 h-5 bg-slate-800 rounded-full">
+              <div class="absolute top-1 left-1 w-1.5 h-1.5 bg-white rounded-full"></div>
+            </div>
+          </div>
+          <div class="pretty-eye w-7 h-9 bg-white rounded-[50%] relative overflow-hidden shadow-inner">
+            <div class="absolute bottom-1 left-1 w-4 h-5 bg-slate-800 rounded-full">
+              <div class="absolute top-1 left-1 w-1.5 h-1.5 bg-white rounded-full"></div>
+            </div>
+          </div>
+        </div>
+        <div class="absolute top-[30%] w-full flex justify-between px-8 pointer-events-none opacity-70">
+          <div class="w-14 h-14 border-[3px] border-amber-600/60 rounded-[40%]"></div>
+          <div class="absolute w-5 h-1 bg-amber-600/60 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"></div>
+          <div class="w-14 h-14 border-[3px] border-amber-600/60 rounded-[40%]"></div>
+        </div>
+        <div class="absolute top-[50%] left-1/2 -translate-x-1/2"
+          style="width:14px; height:10px; border-radius:50%; background:rgba(200,120,70,0.2); box-shadow:inset 0 2px 4px rgba(180,90,40,0.3);">
+          <div class="absolute" style="width:4px; height:4px; border-radius:50%; background:rgba(160,80,30,0.35); bottom:1px; left:1px;"></div>
+          <div class="absolute" style="width:4px; height:4px; border-radius:50%; background:rgba(160,80,30,0.35); bottom:1px; right:1px;"></div>
+        </div>
+        <div class="absolute top-[62%] w-full flex justify-center">
+          <div id="pretty-mouth" class="w-8 h-2 bg-[#881337] rounded-full transition-all duration-75 relative overflow-hidden">
+            <div class="absolute top-0 w-full h-[30%] bg-white/90"></div>
+            <div class="absolute bottom-0 w-full h-[40%] bg-rose-400/80 rounded-full transform translate-y-1/2"></div>
+          </div>
+        </div>
+        <svg class="absolute top-0 left-0 w-full h-20" viewBox="0 0 100 40" preserveAspectRatio="none">
+          <path d="M 0 0 L 100 0 L 100 12 C 85 10 75 6 70 14 C 60 4 30 10 0 12 Z" fill="#1a202c"/>
+        </svg>
+      </div>
+    `;
+  }
+
+  private buildBodyHTML(): string {
+    return `
+      <div class="absolute pointer-events-none" style="bottom:-90px; left:50%; transform:translateX(-50%); width:240px; height:100px; z-index:-1;">
+        <svg width="240" height="100" viewBox="0 0 240 100" xmlns="http://www.w3.org/2000/svg">
+          <path d="M 0 40 Q 0 25 20 22 L 80 18 L 120 28 L 160 18 L 220 22 Q 240 25 240 40 L 240 100 L 0 100 Z" fill="#f1f5f9"/>
+          <path d="M 0 40 Q 0 25 20 22 L 80 18 L 120 28 L 160 18 L 220 22 Q 240 25 240 40 L 240 50 Q 200 42 120 44 Q 40 42 0 50 Z" fill="#e2e8f0"/>
+          <rect x="100" y="0" width="40" height="35" rx="6" fill="#e6bca0"/>
+          <path d="M 120 28 L 80 18 L 72 32 L 112 38 Z" fill="#f8fafc"/>
+          <path d="M 120 28 L 80 18 L 72 32 L 112 38 Z" fill="none" stroke="#e2e8f0" stroke-width="1"/>
+          <path d="M 120 28 L 160 18 L 168 32 L 128 38 Z" fill="#f8fafc"/>
+          <path d="M 120 28 L 160 18 L 168 32 L 128 38 Z" fill="none" stroke="#e2e8f0" stroke-width="1"/>
+          <path d="M 112 38 L 120 50 L 128 38 Z" fill="#8f8f8fff"/>
+          <circle cx="120" cy="56" r="3" fill="#cbd5e1"/>
+          <circle cx="120" cy="70" r="3" fill="#cbd5e1"/>
+          <circle cx="120" cy="84" r="3" fill="#cbd5e1"/>
+          <line x1="120" y1="50" x2="120" y2="100" stroke="#e2e8f0" stroke-width="1"/>
+        </svg>
+      </div>
+    `;
   }
 
   private startBlinking() {

--- a/src/shared/lib/avatar/PrettyAvatarProvider.ts
+++ b/src/shared/lib/avatar/PrettyAvatarProvider.ts
@@ -48,17 +48,26 @@ export class PrettyAvatarProvider implements IAvatarProvider {
     const wrapper = document.createElement("div");
     wrapper.className = "w-full h-full flex flex-col items-center justify-center relative overflow-hidden text-center";
     wrapper.style.background = "#080f1a";
-    wrapper.innerHTML = `
-      <div id="avatar-body-wrapper" class="avatar-container relative w-56 h-56 shrink-0">
-        ${this.buildHairHTML()}
-        ${this.buildFaceHTML()}
-        ${this.buildBodyHTML()}
-      </div>
-      <div id="avatar-status" class="mt-28 px-5 py-2 rounded-full bg-slate-800/80 border border-white/5 text-sm text-slate-300 font-medium flex items-center gap-2.5">
-        <span class="w-2 h-2 rounded-full bg-slate-500"></span>
-        <span class="status-text">AI 면접관 대기 중</span>
-      </div>
-    `;
+
+    const bodyWrapper = document.createElement("div");
+    bodyWrapper.id = "avatar-body-wrapper";
+    bodyWrapper.className = "avatar-container relative w-56 h-56 shrink-0";
+    bodyWrapper.innerHTML = this.buildHairHTML() + this.buildFaceHTML() + this.buildBodyHTML();
+
+    const status = document.createElement("div");
+    status.id = "avatar-status";
+    status.className = "mt-28 px-5 py-2 rounded-full bg-slate-800/80 border border-white/5 text-sm text-slate-300 font-medium flex items-center gap-2.5";
+
+    const dot = document.createElement("span");
+    dot.className = "w-2 h-2 rounded-full bg-slate-500";
+
+    const statusText = document.createElement("span");
+    statusText.className = "status-text";
+    statusText.textContent = "AI 면접관 대기 중";
+
+    status.append(dot, statusText);
+    wrapper.append(bodyWrapper, status);
+
     return wrapper;
   }
 

--- a/src/shared/ui/StepIndicator.tsx
+++ b/src/shared/ui/StepIndicator.tsx
@@ -1,4 +1,5 @@
 /** done/active/pending 상태의 단계를 연결선과 함께 수평으로 표시하는 스텝퍼. */
+import { Check } from "lucide-react";
 interface Step {
   label: string;
   state: "done" | "active" | "pending";
@@ -17,8 +18,8 @@ export function StepIndicator({ steps, onStepClick, dark = false, className = ""
     : "bg-mefit-gray-50 border-mefit-gray-200";
 
   const getCircleCls = (state: Step["state"]) => {
-    if (state === "done")   return "bg-mefit-primary text-white";
-    if (state === "active") return dark ? "bg-indigo-600 text-white" : "bg-mefit-black text-white";
+    if (state === "done")   return dark ? "bg-emerald-400 text-white" : "bg-mefit-success text-white";
+    if (state === "active") return dark ? "bg-[#06B6D4] text-white" : "bg-mefit-black text-white";
     return dark ? "bg-slate-700 text-slate-500" : "bg-mefit-gray-200 text-mefit-gray-400";
   };
 
@@ -29,7 +30,7 @@ export function StepIndicator({ steps, onStepClick, dark = false, className = ""
   };
 
   const getLineCls = (done: boolean) =>
-    done ? "bg-mefit-primary" : dark ? "bg-slate-700" : "bg-mefit-gray-200";
+    done ? (dark ? "bg-emerald-400" : "bg-mefit-success") : dark ? "bg-slate-700" : "bg-mefit-gray-200";
 
   return (
     <div className={`flex items-center border rounded-lg p-[14px_22px] shadow-widget ${baseCls} ${className}`}>
@@ -44,7 +45,7 @@ export function StepIndicator({ steps, onStepClick, dark = false, className = ""
             className="flex items-center gap-[7px] shrink-0 bg-transparent border-none p-0 cursor-pointer disabled:cursor-default"
           >
             <div className={`w-[26px] h-[26px] rounded-full flex items-center justify-center text-2xs font-extrabold shrink-0 transition-all ${getCircleCls(s.state)}`}>
-              {s.state === "done" ? "✓" : i + 1}
+              {s.state === "done" ? <Check size={13} strokeWidth={3} /> : i + 1}
             </div>
             <span className={`text-xs whitespace-nowrap ${getLabelCls(s.state)}`}>{s.label}</span>
           </button>


### PR DESCRIPTION
## 관련 이슈
Closes #143

## 변경 사항

- **면접 난이도별 아바타 캐릭터 추가**
  - `friendly` (친근한 면접관): 갈색 머리, 따뜻한 피부톤, 파란 셔츠, 노란 글로우
  - `normal` (일반 면접관): 검은 머리, 안경, 인디고 셔츠, 파란 글로우
  - `pressure` (압박 면접관): 검은 머리, 각진 안경, 어두운 티셔츠, 빨간 글로우
  - 세션 로드 전 이전 세션 캐릭터가 먼저 노출되는 문제 수정
- **면접 설정 페이지**: 빈 placeholder에 추가 페이지 바로가기 링크 추가
- **설정 사이드바**: 홈으로 이동 버튼 추가
- **면접 난이도 태그 색상 통일**
  - 친근한 면접관: 초록, 일반 면접관: 파랑, 압박 면접관: 빨강
  - `SessionCard`, `InterviewOverview`, `RecentSessions` 전체 적용
- **홈 최근 면접 기록**
  - 리포트 생성 완료(`reportStatus === "completed"`)된 세션만 표시
  - 아이콘 스타일 개선 (배경 사각형 추가)

## 변경 유형

- [x] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)

## 테스트 방법

- [x] 수동 테스트 (Manual testing)

### 테스트 환경

- [x] Chrome

테스트 시나리오:
1. 친근한/일반/압박 면접관 선택 후 면접 세션 진입 시 각각 다른 아바타 캐릭터가 표시되는지 확인
2. 면접 결과 목록 및 리포트 페이지에서 난이도 태그 색상이 올바르게 표시되는지 확인
3. 홈 최근 면접 기록에 리포트 완료된 세션만 표시되는지 확인
4. 설정 페이지 사이드바에서 홈으로 이동 버튼 동작 확인

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다

## 스크린샷

### Before
<!-- 변경 전: 단일 아바타, 색상 없는 난이도 태그 -->

### After
<!-- 변경 후: 난이도별 아바타 3종, 색상 구분 난이도 태그 -->

## 추가 정보

- 아바타는 외부 라이브러리 없이 순수 HTML/CSS/JS로 구현되어 있으며, 음성에 맞춰 입 모양이 실시간으로 변화하는 립싱크 기능 포함
- 난이도 레이블 텍스트를 `labels.ts`에서 중앙 관리하도록 통일
