### PR TITLE
[163] 이력서 템플릿 모달 아이콘 변경

### DIFF
--- a/src/app/ProtectedRoute.tsx
+++ b/src/app/ProtectedRoute.tsx
@@ -7,9 +7,17 @@ import { AppLayout } from "./AppLayout";
 export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, authReady } = useAuthStore();
   const toastFired = useRef(false);
+  // 마운트 시점에 user가 있었는지 기록 — 있었다가 null이 된 경우(세션 만료)에만 토스트
+  const hadUser = useRef(false);
 
   useEffect(() => {
-    if (authReady && !user && !toastFired.current) {
+    if (user) {
+      hadUser.current = true;
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (authReady && !user && hadUser.current && !toastFired.current) {
       toastFired.current = true;
       toast.error("로그인해주세요.", { duration: 3000 });
     }

--- a/src/pages/resume-new/ui/mode-tabs/text-upload/TemplatePickerList.tsx
+++ b/src/pages/resume-new/ui/mode-tabs/text-upload/TemplatePickerList.tsx
@@ -2,7 +2,8 @@
 
 import { Loader2 } from "lucide-react";
 import { Alert, Button, Spinner } from "@/shared/ui";
-import { CompanyIcon } from "@/shared/ui/CompanyIcon";
+import { CATEGORY_STYLE } from "@/shared/ui/categoryIconStyle";
+import { inferCategoryId } from "@/shared/ui/inferCategoryId";
 import type { ResumeTemplateListItem } from "@/features/resume";
 
 interface TemplatePickerListProps {
@@ -67,6 +68,8 @@ export function TemplatePickerList(props: TemplatePickerListProps) {
           <div className="grid grid-cols-2 gap-2 max-sm:grid-cols-1">
             {items.map((t) => {
               const isLoading = pickerLoadingUuid === t.uuid;
+              const categoryId = inferCategoryId(t.job.category ?? t.job.name, t.title);
+              const { Icon, color, bgColor } = CATEGORY_STYLE[categoryId] ?? CATEGORY_STYLE[0];
               return (
                 <button
                   key={t.uuid}
@@ -75,8 +78,8 @@ export function TemplatePickerList(props: TemplatePickerListProps) {
                   disabled={pickerLoadingUuid !== null}
                   className="flex items-start gap-3 p-3 rounded-lg border border-[#E5E7EB] bg-white text-left transition-all hover:border-[#0991B2] hover:bg-[#F0FDFE] disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  <div className="w-8 h-8 rounded-lg shrink-0 overflow-hidden">
-                    <CompanyIcon seed={t.uuid} size={16} />
+                  <div className={`w-8 h-8 rounded-lg shrink-0 flex items-center justify-center ${bgColor}`}>
+                    <Icon size={16} className={color} />
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="text-[13px] font-bold text-[#0A0A0A] truncate">{t.title}</div>


### PR DESCRIPTION
## 관련 이슈
Closes #163 

## 변경 사항
이 PR에서 변경된 내용을 요약해주세요.

- TemplatePickerList: CompanyIcon(seed 기반) → CATEGORY_STYLE + inferCategoryId로 교체
- ProtectedRoute: 로그아웃 후 랜딩 진입 시 불필요한 토스트 노출 버그 수정

## 변경 유형

해당하는 항목에 체크해주세요.

- [ ] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [x] UI/UX 개선 (UI/UX improvement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가 (Test addition)
- [ ] 접근성 개선 (Accessibility improvement)
- [x] 기타 (Other) — 로그아웃 후 불필요한 토스트 노출 버그 수정

## 테스트 방법

변경 사항을 테스트한 방법을 설명해주세요.

- [ ] 단위 테스트 (Unit tests)
- [ ] 통합 테스트 (Integration tests)
- [ ] E2E 테스트 (E2E tests)
- [x] 수동 테스트 (Manual testing)

### 테스트 환경

- [x] Chrome
- [ ] Safari
- [ ] Firefox

테스트 시나리오:

1. 이력서 템플릿 모달을 열어 직군별 템플릿 목록에 카테고리 아이콘이 이력서 카드와 동일하게 표시되는지 확인
2. 로그인 상태에서 로그아웃 후 랜딩 페이지로 이동 시 "로그인해주세요" 토스트가 뜨지 않는지 확인
3. 비로그인 상태에서 보호 라우트(`/resume` 등) 직접 접근 시 토스트 없이 랜딩으로 리다이렉트되는지 확인

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 코드에 적절한 주석을 추가했습니다
- [ ] 관련 문서를 업데이트했습니다
- [x] 변경 사항이 새로운 경고를 발생시키지 않습니다
- [x] 테스트를 추가했으며 모든 테스트가 통과합니다 (112 passed)
- [ ] 반응형 디자인을 확인했습니다
- [ ] 브라우저 호환성을 확인했습니다
- [ ] 접근성 가이드라인을 준수했습니다

## 스크린샷

UI 변경이 있다면 Before/After 스크린샷을 추가해주세요.

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->

## 추가 정보

**[TemplatePickerList] 이력서 템플릿 모달 아이콘 통일**

기존에는 템플릿 모달의 각 항목에 `CompanyIcon`(uuid seed 기반 랜덤 아이콘)이 사용되어 이력서 카드와 시각적으로 일관성이 없었습니다. 이력서 카드와 동일하게 `inferCategoryId` + `CATEGORY_STYLE`을 사용해 직군 카테고리에 맞는 아이콘과 색상을 표시하도록 변경했습니다.

**[ProtectedRoute] 로그아웃 후 토스트 오발화 버그 수정**

`hadUser` ref를 추가해 마운트 이후 `user`가 한 번이라도 존재했다가 사라진 경우(세션 만료)에만 "로그인해주세요" 토스트를 발화하도록 수정했습니다. 정상 로그아웃이나 비로그인 상태의 보호 라우트 직접 접근 시에는 토스트가 뜨지 않습니다.
